### PR TITLE
Add OA switch_shutdown_request notification on syncd exit

### DIFF
--- a/syncd/syncd.h
+++ b/syncd/syncd.h
@@ -59,6 +59,8 @@ extern "C" {
 #define SWITCH_SAI_THRIFT_RPC_SERVER_PORT 9092
 #endif // SAITHRIFT
 
+extern void exit_and_notify(int status) __attribute__ ((__noreturn__));
+
 extern std::mutex g_mutex;
 
 void onSyncdStart(bool warmStart);

--- a/syncd/syncd_hard_reinit.cpp
+++ b/syncd/syncd_hard_reinit.cpp
@@ -44,7 +44,7 @@ sai_object_type_t getObjectTypeFromVid(sai_object_id_t sai_object_id)
     {
         SWSS_LOG_ERROR("invalid object type: %x on object id: %llx", objectType, sai_object_id);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     return objectType;
@@ -89,7 +89,7 @@ sai_object_type_t getObjectTypeFromAsicKey(const std::string &key)
     {
         SWSS_LOG_ERROR("invalid object type: %x on asic key: %s", objectType, key.c_str());
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     return objectType;
@@ -134,7 +134,7 @@ void checkAllIds()
         {
             SWSS_LOG_ERROR("failed to find vid %llx in previous map", kv.first);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         g_vidToRidMap.erase(it);
@@ -151,7 +151,7 @@ void checkAllIds()
             SWSS_LOG_ERROR("vid not translated: %llx, object type: %llx", kv.first, objectType);
         }
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     redisSetVidAndRidMap(g_translated);
@@ -257,7 +257,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
         {
             SWSS_LOG_ERROR("failed to find VID %llx in VIDTORID map", vid);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         sai_object_id_t virtualRouterRid = it->second;
@@ -288,7 +288,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
         {
             SWSS_LOG_ERROR("failed to find VID %llx in VIDTORID map", vid);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         rid = it->second;
@@ -304,7 +304,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
     {
         SWSS_LOG_ERROR("failed to find VID %s in OIDs map", strVid.c_str());
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     std::string asicKey = oit->second;;
@@ -325,7 +325,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
         {
             SWSS_LOG_ERROR("create function is not defined for object type %llx", objectType);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         sai_status_t status = create(&rid, attrCount, attrList);
@@ -334,7 +334,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
         {
             SWSS_LOG_ERROR("failed to create object %llx: %d", objectType, status);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         SWSS_LOG_DEBUG("created object of type %x, processed VID %llx to RID %llx", objectType, vid, rid);
@@ -355,7 +355,7 @@ sai_object_id_t processSingleVid(sai_object_id_t vid)
             {
                 SWSS_LOG_ERROR("failed to set attribute for object type %llx attr id %llx: %d", objectType, attr->id, status);
 
-                exit(EXIT_FAILURE);
+                exit_and_notify(EXIT_FAILURE);
             }
         }
     }
@@ -376,7 +376,7 @@ sai_attr_serialization_type_t getSerializationType(sai_object_type_t objectType,
     {
         SWSS_LOG_ERROR("unable to find serialization type on object type %x and attr id %x", objectType, attrId);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     return serializationType;
@@ -505,7 +505,7 @@ void processSwitch()
             {
                 SWSS_LOG_ERROR("failed to set_switch_attribute %llx: %d", attr->id, status);
 
-                exit(EXIT_FAILURE);
+                exit_and_notify(EXIT_FAILURE);
             }
         }
     }
@@ -542,7 +542,7 @@ void processVlans()
             {
                 SWSS_LOG_ERROR("failed to create_vlan %d: %d", vlanId, status);
 
-                exit(EXIT_FAILURE);
+                exit_and_notify(EXIT_FAILURE);
             }
         }
 
@@ -564,7 +564,7 @@ void processVlans()
             {
                 SWSS_LOG_ERROR("failed to set_vlan_attribute %llx: %d", attr->id, status);
 
-                exit(EXIT_FAILURE);
+                exit_and_notify(EXIT_FAILURE);
             }
         }
     }
@@ -606,7 +606,7 @@ void processFdbs()
         {
             SWSS_LOG_ERROR("failed to create_fdb_entry: %d", status);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
     }
 }
@@ -649,7 +649,7 @@ void processNeighbors()
         {
             SWSS_LOG_ERROR("failed to create_neighbor_entry: %d", status);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
     }
 }
@@ -692,7 +692,7 @@ void processRoutes()
         {
             SWSS_LOG_ERROR("failed to create_route_entry: %d", status);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
     }
 }
@@ -740,7 +740,7 @@ void processTraps()
             {
                 SWSS_LOG_ERROR("failed to set_trap_attribute %d: %d", trapId, status);
 
-                exit(EXIT_FAILURE);
+                exit_and_notify(EXIT_FAILURE);
             }
         }
     }

--- a/syncd/syncd_reinit.cpp
+++ b/syncd/syncd_reinit.cpp
@@ -18,7 +18,7 @@ sai_uint32_t saiGetPortCount()
     {
         SWSS_LOG_ERROR("failed to get port number: %d", status);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     SWSS_LOG_DEBUG("port count is %u", attr.value.u32);
@@ -40,7 +40,7 @@ sai_object_id_t saiGetCpuId()
     {
         SWSS_LOG_ERROR("failed to get cpu port: %d", status);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     SWSS_LOG_DEBUG("cpu port RID %llx", attr.value.oid);
@@ -70,7 +70,7 @@ std::vector<sai_object_id_t> saiGetPortList()
     {
         SWSS_LOG_ERROR("failed to get port list: %d", status);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     return portList;
@@ -104,7 +104,7 @@ std::unordered_map<sai_uint32_t, sai_object_id_t> saiGetHardwareLaneMap()
         {
             SWSS_LOG_ERROR("failed to get hardware lane list pid: %lx: %d", portList[i], status);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         sai_int32_t laneCount = attr.value.u32list.count;
@@ -132,7 +132,7 @@ sai_object_id_t saiGetDefaultVirtualRouter()
     {
          SWSS_LOG_ERROR("failed to get switch virtual router id %d", status);
 
-         exit(EXIT_FAILURE);
+         exit_and_notify(EXIT_FAILURE);
     }
 
     return attr.value.oid;
@@ -286,7 +286,7 @@ void helperCheckLaneMap()
     {
         SWSS_LOG_ERROR("lanes map size differ: %lu vs %lu", laneMap.size(), redisLaneMap.size());
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     for (auto kv: laneMap)
@@ -298,7 +298,7 @@ void helperCheckLaneMap()
         {
             SWSS_LOG_ERROR("lane %u not found in redis", lane);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         if (redisLaneMap[lane] != portId)
@@ -306,7 +306,7 @@ void helperCheckLaneMap()
             // if this happens, we need to remap VIDTORID and RIDTOVID
             SWSS_LOG_ERROR("FIXME: lane port id differs: %llx vs %llx, port ids must be remapped", portId, redisLaneMap[lane]);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
     }
 }
@@ -383,7 +383,7 @@ void redisSetDummyAsicStateForRealObjectId(sai_object_id_t rid)
     {
         SWSS_LOG_ERROR("sai_object_type_query returned NULL type for RID %llx", rid);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 
     std::string strObjectType;
@@ -427,7 +427,7 @@ void helperCheckVirtualRouterId()
         // if this happens, we need to remap VIDTORID and RIDTOVID
         SWSS_LOG_ERROR("FIXME: default virtual router id differs: %llx vs %llx, ids must be remapped", vrId, redisVrId);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 }
 
@@ -466,7 +466,7 @@ void helperCheckCpuId()
         // if this happens, we need to remap VIDTORID and RIDTOVID
         SWSS_LOG_ERROR("FIXME: cpu id differs: %llx vs %llx, ids must be remapped", cpuId, redisCpuId);
 
-        exit(EXIT_FAILURE);
+        exit_and_notify(EXIT_FAILURE);
     }
 }
 
@@ -491,7 +491,7 @@ void helperCheckPortIds()
         {
             SWSS_LOG_ERROR("sai_object_type_query returned NULL type for RID %llx", portId);
 
-            exit(EXIT_FAILURE);
+            exit_and_notify(EXIT_FAILURE);
         }
 
         std::string strObjectType;


### PR DESCRIPTION
When syncd will exit unexpectedly because of db failure or any SAI api failure it will send notification to OA so it can know and respond and take action. This notification is not guaranteed to be send on unexpected exit or crash.