### PR TITLE
Fix record line for notifications

### DIFF
--- a/lib/src/sai_redis_record.cpp
+++ b/lib/src/sai_redis_record.cpp
@@ -21,9 +21,12 @@ std::string getTimestamp()
 volatile bool g_record = true;
 
 std::ofstream recording;
+std::mutex g_recordMutex;
 
 void recordLine(std::string s)
 {
+    std::lock_guard<std::mutex> lock(g_recordMutex);
+
     SWSS_LOG_ENTER();
 
     if (recording.is_open())


### PR DESCRIPTION
Because race condition of main thread and notifications thread it could happen that some lines in recording log were duplicated, using mutex will fix that problem