### PR TITLE
change the log level to error for conditional attribute check

### DIFF
--- a/meta/sai_meta.cpp
+++ b/meta/sai_meta.cpp
@@ -1531,7 +1531,7 @@ sai_status_t meta_generic_validation_create(
             // maybe we can let it go here?
             if (attrs.find(md.attrid) != attrs.end())
             {
-                META_LOG_DEBUG(md, "conditional, but condition was not met, this attribute is not required, but passed");
+                META_LOG_ERROR(md, "conditional, but condition was not met, this attribute is not required, but passed");
 
                 return SAI_STATUS_INVALID_PARAMETER;
             }


### PR DESCRIPTION
the log level should match the return value, since the return value is error,
the log level should be error too.