### PR TITLE
[everflow]: Remove SAI_MIRROR_SESSION_ATTR_VLAN_ID from VLAN validation.

### DIFF
--- a/meta/sai_meta.h
+++ b/meta/sai_meta.h
@@ -623,11 +623,8 @@ typedef struct _sai_attr_metadata_t {
             return true;
         }
 
-        if (objecttype == SAI_OBJECT_TYPE_MIRROR &&
-                attrid == SAI_MIRROR_SESSION_ATTR_VLAN_ID)
-        {
-            return true;
-        }
+        // Requires special handling ("0" is valid value).
+        // SAI_MIRROR_SESSION_ATTR_VLAN_ID
 
         // has different serialization than u16
         // SAI_ACL_ENTRY_ATTR_FIELD_OUTER_VLAN_ID


### PR DESCRIPTION
0 is valid value for SAI_MIRROR_SESSION_ATTR_VLAN_ID attribute. Means that
outer packet should be untagged. On attempt to create session with VLAN 0
error was returned.