### PR TITLE
[/etc/init.d/sync.d]: Infer right HWSKU pathname

### DIFF
--- a/debian/syncd.init
+++ b/debian/syncd.init
@@ -88,6 +88,10 @@ case "$1" in
 start)
     eval $(parse_yaml /etc/sonic/sonic_version.yml "sonic_")
 
+    [ -r /etc/machine.conf ] && . /etc/machine.conf
+
+    [ -r $HWSKU_DIR/$onie_platform/minigraph.xml ] && HWSKU_DIR=$HWSKU_DIR/$onie_platform/$(cat $HWSKU_DIR/$onie_platform/minigraph.xml | grep HwSku | sed -e 's/<[^>]*>//g;s/^ *//;s/$//' | uniq)
+
     if [ $sonic_asic_type == "broadcom" ]; then
         start_bcm
         DAEMON_ARGS+=" -p $HWSKU_DIR/sai.profile "


### PR DESCRIPTION
Otherwise syncd will not start because HWSKU point to wrong directory. This bug was introduced in https://github.com/Azure/sonic-sairedis/pull/166
