### PR TITLE
[notifications]: Add support for native PFC storm notify

### DIFF
--- a/meta/saiserialize.h
+++ b/meta/saiserialize.h
@@ -109,6 +109,10 @@ std::string sai_serialize_port_oper_status_ntf(
         _In_ uint32_t count,
         _In_ const sai_port_oper_status_notification_t* port_oper_status);
 
+std::string sai_serialize_queue_deadlock_ntf(
+        _In_ uint32_t count,
+        _In_ const sai_queue_deadlock_notification_data_t* deadlock_data);
+
 // deserialize
 
 void sai_deserialize_number(
@@ -183,6 +187,11 @@ void sai_deserialize_port_oper_status_ntf(
         _Out_ uint32_t &count,
         _Out_ sai_port_oper_status_notification_t** portoperstatus);
 
+void sai_deserialize_queue_deadlock_ntf(
+        _In_ const std::string& s,
+        _Out_ uint32_t &count,
+        _Out_ sai_queue_deadlock_notification_data_t** deadlock_data);
+
 // free methods
 
 void sai_deserialize_free_attribute_value(
@@ -198,6 +207,10 @@ void sai_deserialize_free_fdb_event_ntf(
 void sai_deserialize_free_port_oper_status_ntf(
         _In_ uint32_t count,
         _In_ sai_port_oper_status_notification_t* portoperstatus);
+
+void sai_deserialize_free_queue_deadlock_ntf(
+        _In_ uint32_t count,
+        _In_ sai_queue_deadlock_notification_data_t* deadlock_data);
 
 void sai_deserialize_port_stat(
         _In_ const std::string& s,


### PR DESCRIPTION
Implement notification path and serializattion/deserialization
for event SAI_SWITCH_ATTRIBUTE_QUEUE_PFC_DEADLOCK_NOTIFY

Signed-off-by: marian-pritsak <marianp@mellanox.com>