### PR TITLE
Add switch ASIC vendor for Nephos

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -99,6 +99,15 @@ config_syncd_marvell()
     [ -e /dev/net/tun ] || ( mkdir -p /dev/net && mknod /dev/net/tun c 10 200 )
 }
 
+config_syncd_nephos()
+{
+    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+
+    if [ $FAST_REBOOT == "yes" ]; then
+        CMD_ARGS+=" -t fast"
+    fi
+}
+
 config_syncd()
 {
     if [ "$SONIC_ASIC_TYPE" == "broadcom" ]; then
@@ -111,6 +120,8 @@ config_syncd()
         config_syncd_centec
     elif [ "$SONIC_ASIC_TYPE" == "marvell" ]; then
         config_syncd_marvell
+    elif [ "$SONIC_ASIC_TYPE" == "nephos" ]; then
+        config_syncd_nephos
     else
         echo "Unknown ASIC type $SONIC_ASIC_TYPE"
         exit 1


### PR DESCRIPTION
**-What I did**
    Add switch ASIC vendor: Nephos

**- How I did it**
    Add switch configuration file for Nephos

**- How to verify it**
    Check switch ports has been created and worked as well

**- Description for the changelog**
    Add switch ASIC vendor for Nephos

Signed-off-by: Sam Yang <yang.kaiyu@gmail.com>