### PR TITLE
[syncd]: The cause of 10 minutes long reboot for SONiC project removed.

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -88,8 +88,6 @@ config_syncd_cavium()
     until [ $(redis-cli ping | grep -c PONG) -gt 0 ]; do
         sleep 1
     done
-
-    redis-cli FLUSHALL
 }
 
 config_syncd_marvell()


### PR DESCRIPTION
This line causes to deletion of the database content AFTER configuration set.

Signed-off-by: Denis Maslov denis.maslov@cavium.com