### PR TITLE
[syncd_flex_counter.cpp]: Move lock_guard to narrow scope

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -378,10 +378,11 @@ void FlexCounter::flexCounterThread(void)
 
     while (m_runFlexCounterThread)
     {
-
-        std::lock_guard<std::mutex> lock(g_mutex);
-        collectCounters(countersTable);
-        runPlugins(db);
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            collectCounters(countersTable);
+            runPlugins(db);
+        }
 
         std::unique_lock<std::mutex> lk(m_mtxSleep);
         m_cvSleep.wait_for(lk, std::chrono::milliseconds(FLEX_COUNTER_POLL_MSECS));


### PR DESCRIPTION
lock_guard holds mutex during sleep, which does not allow other threads
to acquire it for most of time. It is moved to a scope that actually
needs this mutex.

Signed-off-by: marian-pritsak <marianp@mellanox.com>