### PR TITLE
[syncd]: Only query queue counters that are needed by the application

### DIFF
--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -93,7 +93,7 @@ class FlexCounter
         void endFlexCounterThread(void);
 
         void saiUpdateSupportedPortCounters(sai_object_id_t portId);
-        void saiUpdateSupportedQueueCounters(sai_object_id_t queueId);
+        void saiUpdateSupportedQueueCounters(sai_object_id_t queueId, const std::vector<sai_queue_stat_t> &counterIds);
         bool isPortCounterSupported(sai_port_stat_t counter) const;
         bool isQueueCounterSupported(sai_queue_stat_t counter) const;
 


### PR DESCRIPTION
The previous hardcoded for loop to iterate items defined in the SAI
header file was not ideal. Update the logic here so that only needed
attributes are checked for the support.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>