### PR TITLE
Enable syncd-rpc target compilation.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ binary-syncd:
 	dh binary -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 
 binary-syncd-rpc: | binary-syncd
-	$(shell echo '--enable-rpcserver=no' > /tmp/syncd-build)
+	$(shell echo '--enable-rpcserver=yes' > /tmp/syncd-build)
 	dh clean  --with autotools-dev
 	dh build  -N syncd -N syncd-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 	dh binary -N syncd -N syncd-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -65,6 +65,13 @@ std::set<sai_object_id_t> initViewRemovedVidSet;
  */
 volatile bool g_asicInitViewMode = false;
 
+#ifdef SAITHRIFT
+/*
+ * SAI switch global needed for RPC server
+ */
+sai_object_id_t gSwitchId;
+#endif
+
 struct cmdOptions
 {
     int countersThreadIntervalInSeconds;
@@ -1754,6 +1761,10 @@ void on_switch_create_in_init_view(
             SWSS_LOG_THROW("failed to create switch in init view mode: %s",
                     sai_serialize_status(status).c_str());
         }
+
+#ifdef SAITHRIFT
+        gSwitchId = switch_rid;
+#endif
 
         /*
          * Object was created so new object id was generated we


### PR DESCRIPTION
The rebased copy of #260

Export switch ID variable required by SAI thrift.