### PR TITLE
[flex_counter]: Fix cleanup flow

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2514,28 +2514,29 @@ void processFlexCounterEvent(
     sai_object_id_t rid = translate_vid_to_rid(vid);
     sai_object_type_t objectType = sai_object_type_query(rid);
 
+    if (op == DEL_COMMAND)
+    {
+        if (objectType == SAI_OBJECT_TYPE_PORT)
+        {
+            FlexCounter::removePort(vid, pollInterval);
+        }
+        else if (objectType == SAI_OBJECT_TYPE_QUEUE)
+        {
+            FlexCounter::removeQueue(vid, pollInterval);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Object type for removal not supported");
+        }
+    }
+
     const auto values = kfvFieldsValues(kco);
     for (const auto& valuePair : values)
     {
         const auto field = fvField(valuePair);
         const auto value = fvValue(valuePair);
 
-        if (op == DEL_COMMAND)
-        {
-            if (objectType == SAI_OBJECT_TYPE_PORT)
-            {
-                FlexCounter::removePort(vid, pollInterval);
-            }
-            else if (objectType == SAI_OBJECT_TYPE_QUEUE)
-            {
-                FlexCounter::removeQueue(vid, pollInterval);
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Object type for removal not supported");
-            }
-        }
-        else if (op == SET_COMMAND)
+        if (op == SET_COMMAND)
         {
             auto idStrings  = swss::tokenize(value, ',');
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -215,33 +215,28 @@ void FlexCounter::removeQueue(
 {
     SWSS_LOG_ENTER();
 
+    bool found = false;
     FlexCounter &fc = getInstance(pollInterval);
 
     auto counterIter = fc.m_queueCounterIdsMap.find(queueVid);
-    if (counterIter == fc.m_queueCounterIdsMap.end())
+    if (counterIter != fc.m_queueCounterIdsMap.end())
     {
-        SWSS_LOG_ERROR("Trying to remove nonexisting queue counter Ids 0x%lx", queueVid);
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
-        {
-            removeInstance(pollInterval);
-        }
-        return;
+        fc.m_queueCounterIdsMap.erase(counterIter);
+        found = true;
     }
-
-    fc.m_queueCounterIdsMap.erase(counterIter);
 
     auto attrIter = fc.m_queueAttrIdsMap.find(queueVid);
-    if (attrIter == fc.m_queueAttrIdsMap.end())
+    if (attrIter != fc.m_queueAttrIdsMap.end())
     {
-        SWSS_LOG_ERROR("Trying to remove nonexisting queue attr Ids 0x%lx", queueVid);
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
-        {
-            removeInstance(pollInterval);
-        }
-        return;
+        fc.m_queueAttrIdsMap.erase(attrIter);
+        found = true;
     }
 
-    fc.m_queueAttrIdsMap.erase(attrIter);
+    if (!found)
+    {
+        SWSS_LOG_ERROR("Trying to remove nonexisting queue from flex counter 0x%lx", queueVid);
+        return;
+    }
 
     // Remove flex counter if counter IDs map is empty
     if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())


### PR DESCRIPTION
Remove objects from flex counter bu key, not when iterating over values
because on DEL op there are no values, only key.
Fix logic in removeQueue.

Signed-off-by: marian-pritsak <marianp@mellanox.com>