### PR TITLE
[flex_counter]:change log level from error to notice

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -204,7 +204,7 @@ void FlexCounter::removePort(
     auto it = fc.m_portCounterIdsMap.find(portVid);
     if (it == fc.m_portCounterIdsMap.end())
     {
-        SWSS_LOG_ERROR("Trying to remove nonexisting port counter Ids 0x%lx", portVid);
+        SWSS_LOG_NOTICE("Trying to remove nonexisting port counter Ids 0x%lx", portVid);
         // Remove flex counter if counter IDs map is empty
         if (fc.isCounterMapsEmpty())
         {
@@ -247,7 +247,7 @@ void FlexCounter::removeQueue(
 
     if (!found)
     {
-        SWSS_LOG_ERROR("Trying to remove nonexisting queue from flex counter 0x%lx", queueVid);
+        SWSS_LOG_NOTICE("Trying to remove nonexisting queue from flex counter 0x%lx", queueVid);
         return;
     }
 


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

Remove non-existing queue/port id doesn't mean to be error. Reduce severity to notice. 