### PR TITLE
[flex_counter]: Fix FC removal criteria

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -66,7 +66,7 @@ void FlexCounter::setPortCounterList(
         SWSS_LOG_ERROR("Port %s does not has supported counters", sai_serialize_object_id(portId).c_str());
 
         // Remove flex counter if counter IDs map is empty
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+        if (fc.isEmpty())
         {
             removeInstance(pollInterval);
         }
@@ -115,7 +115,7 @@ void FlexCounter::setQueueCounterList(
         SWSS_LOG_ERROR("Queue %s does not has supported counters", sai_serialize_object_id(queueId).c_str());
 
         // Remove flex counter if counter IDs map is empty
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+        if (fc.isEmpty())
         {
             removeInstance(pollInterval);
         }
@@ -136,7 +136,7 @@ void FlexCounter::setQueueCounterList(
         SWSS_LOG_ERROR("Queue %s can't provide the statistic",  sai_serialize_object_id(queueId).c_str());
 
         // Remove flex counter if counter IDs map is empty
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+        if (fc.isEmpty())
         {
             removeInstance(pollInterval);
         }
@@ -196,7 +196,7 @@ void FlexCounter::removePort(
     {
         SWSS_LOG_ERROR("Trying to remove nonexisting port counter Ids 0x%lx", portVid);
         // Remove flex counter if counter IDs map is empty
-        if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+        if (fc.isEmpty())
         {
             removeInstance(pollInterval);
         }
@@ -206,7 +206,7 @@ void FlexCounter::removePort(
     fc.m_portCounterIdsMap.erase(it);
 
     // Remove flex counter if counter IDs map is empty
-    if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+    if (fc.isEmpty())
     {
         removeInstance(pollInterval);
     }
@@ -242,7 +242,7 @@ void FlexCounter::removeQueue(
     }
 
     // Remove flex counter if counter IDs map is empty
-    if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty())
+    if (fc.isEmpty())
     {
         removeInstance(pollInterval);
     }
@@ -296,8 +296,7 @@ void FlexCounter::removeCounterPlugin(
     fc.m_portPlugins.erase(sha);
 
     // Remove flex counter if counter IDs maps are empty
-    if (fc.m_queueCounterIdsMap.empty() && fc.m_portCounterIdsMap.empty() && fc.m_queueAttrIdsMap.empty() &&
-        fc.m_queuePlugins.empty() && fc.m_portPlugins.empty())
+    if (fc.isEmpty())
     {
         removeInstance(pollInterval);
     }

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -97,6 +97,15 @@ class FlexCounter
         bool isPortCounterSupported(sai_port_stat_t counter) const;
         bool isQueueCounterSupported(sai_queue_stat_t counter) const;
 
+        bool isEmpty(void) const
+        {
+            return m_queueCounterIdsMap.empty() &&
+                m_portCounterIdsMap.empty() &&
+                m_queueAttrIdsMap.empty() &&
+                m_queuePlugins.empty() &&
+                m_portPlugins.empty();
+        }
+
         // Key is a Virtual ID
         std::map<sai_object_id_t, std::shared_ptr<PortCounterIds>> m_portCounterIdsMap;
         std::map<sai_object_id_t, std::shared_ptr<QueueCounterIds>> m_queueCounterIdsMap;


### PR DESCRIPTION
Check if all counter ID/plugin lists are empty before removing flex
counter entry

Signed-off-by: marian-pritsak <marianp@mellanox.com>