### PR TITLE
Change WARNING in sai_api_query to NOTICE and ERROR in sai_log_set to NOTICE

### DIFF
--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -179,7 +179,7 @@ sai_status_t sai_log_set(
 
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("not implemented");
+    SWSS_LOG_NOTICE("not implemented");
 
     return SAI_STATUS_NOT_IMPLEMENTED;
 }

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3294,7 +3294,7 @@ int syncd_main(int argc, char **argv)
 
     if (failed > 0)
     {
-        SWSS_LOG_WARN("sai_api_query failed for %d apis", failed);
+        SWSS_LOG_NOTICE("sai_api_query failed for %d apis", failed);
     }
 
     /*


### PR DESCRIPTION
Not an actionable syslog and sai_api_queries failures have been changed to NOTICE.

Also changing to NOTICE the error in sai_log_set which generates multiple ERR syslogs:

syslog:Feb 12 17:44:11.277382 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277382 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277382 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277382 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277431 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277431 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277431 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277541 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277571 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277571 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277586 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277663 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277663 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277663 sonic ERR orchagent: :- sai_log_set: not implemented
syslog:Feb 12 17:44:11.277663 sonic ERR orchagent: :- sai_log_set: not implemented

Thanks,

Nikos.-