### PR TITLE
Fix for the correct export gSwitchId for SAI thrift

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -1234,6 +1234,10 @@ sai_status_t handle_generic(
                     if (object_type == SAI_OBJECT_TYPE_SWITCH)
                     {
                         on_switch_create(switch_id);
+#ifdef SAITHRIFT
+                        gSwitchId = real_object_id;
+                        SWSS_LOG_NOTICE("Initialize gSwitchId with ID = 0x%lx", gSwitchId);
+#endif
                     }
                 }
 
@@ -1762,6 +1766,7 @@ void on_switch_create_in_init_view(
 
 #ifdef SAITHRIFT
         gSwitchId = switch_rid;
+        SWSS_LOG_NOTICE("Initialize gSwitchId with ID = 0x%lx", gSwitchId);
 #endif
 
         /*

--- a/syncd/syncd_hard_reinit.cpp
+++ b/syncd/syncd_hard_reinit.cpp
@@ -47,6 +47,13 @@ static sai_object_id_t g_switch_vid = SAI_NULL_OBJECT_ID;
 
 static std::shared_ptr<SaiSwitch> g_sw;
 
+#ifdef SAITHRIFT
+/*
+ * SAI switch global needed for RPC server
+ */
+extern sai_object_id_t gSwitchId;
+#endif
+
 void processAttributesForOids(
         _In_ sai_object_type_t objectType,
         _In_ uint32_t attr_count,
@@ -417,6 +424,11 @@ void processSwitches()
                 sai_serialize_object_id(switch_vid).c_str());
 
         sai_status_t status = sai_metadata_sai_switch_api->create_switch(&switch_rid, attr_count, attr_list);
+
+#ifdef SAITHRIFT
+        gSwitchId = switch_rid;
+        SWSS_LOG_NOTICE("Initialize gSwitchId with ID = 0x%lx", gSwitchId);
+#endif
 
         if (status != SAI_STATUS_SUCCESS)
         {


### PR DESCRIPTION
The fix for below issue with incorrect global "gSwitchId" variable which is used by SAI thrift
Azure/sonic-buildimage#1405