### PR TITLE
[syncd] fix a fdb-clear bug that introduced by SAI 1.2 modification

### DIFF
--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -88,8 +88,9 @@ void redisPutFdbEntryToAsicView(
 
     std::string key = ASIC_STATE_TABLE + (":" + strObjectType + ":" + strFdbEntry);
 
-    if (fdb->fdb_entry.switch_id == SAI_NULL_OBJECT_ID ||
-        fdb->fdb_entry.bv_id == SAI_NULL_OBJECT_ID)
+    if ((fdb->fdb_entry.switch_id == SAI_NULL_OBJECT_ID ||
+         fdb->fdb_entry.bv_id == SAI_NULL_OBJECT_ID) && 
+        (fdb->event_type != SAI_FDB_EVENT_FLUSHED))
     {
         SWSS_LOG_WARN("skipped to put int db: %s", strFdbEntry.c_str());
         return;


### PR DESCRIPTION
consolidated fdb flush event will carry a fdb_entry which include a bvid equal to SAI_NULL_OBJECT_ID, in fdb flush case it shall not be considered as an invalid fdb_entry.

This fix has been verified on MLNX platform.

