### PR TITLE
[src/sonic-sairedis] Change sai.profile directory

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -32,7 +32,11 @@ esac
 
 config_syncd_bcm()
 {
-    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    if [ -f "/etc/sai.d/sai.profile" ]; then
+        CMD_ARGS+=" -p /etc/sai.d/sai.profile"
+    else
+        CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    fi
 
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0
     [ -e /dev/linux-user-bde ] || mknod /dev/linux-user-bde c 126 0


### PR DESCRIPTION
This commit changes the directory of sai.profile to point to the new
directory location for sai.profile /etc/sai.d/sai.profile file.
This is the location of sai.profile dynamic generation or for
copying the file from the hwsku directory.

Unit tested the code on S6100 for dynamic generation of sai.profile file for
both T0 and T1 and the file was created in /etc/sai.d/sai.profile
Similarly tested the sonic binary on S6000 to make sure that the sai.profile is
copied from the /usr/share/sonic/hwsku/sai.profile to /etc/sai.d/sai.profile.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>