### PR TITLE
[Syncd] make sure syncd can exit gracefully

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3449,6 +3449,8 @@ int syncd_main(int argc, char **argv)
 
 #endif
 
+    FlexCounter::removeAllCounters();
+
     // Stop notification thread before removing switch
     stopNotificationsProcessingThread();
 

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3449,6 +3449,9 @@ int syncd_main(int argc, char **argv)
 
 #endif
 
+    // Stop notification thread before removing switch
+    stopNotificationsProcessingThread();
+
     status = sai_switch_api->remove_switch(gSwitchId);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -3464,8 +3467,6 @@ int syncd_main(int argc, char **argv)
     {
         SWSS_LOG_ERROR("failed to uninitialize api: %s", sai_serialize_status(status).c_str());
     }
-
-    stopNotificationsProcessingThread();
 
     SWSS_LOG_NOTICE("uninitialize finished");
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -333,6 +333,8 @@ void FlexCounter::removeCounterPlugin(
 
 void FlexCounter::removeAllCounters()
 {
+    SWSS_LOG_ENTER();
+
     g_flex_counters_map.clear();
 }
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -331,6 +331,11 @@ void FlexCounter::removeCounterPlugin(
     }
 }
 
+void FlexCounter::removeAllCounters()
+{
+    g_flex_counters_map.clear();
+}
+
 
 FlexCounter::~FlexCounter(void)
 {

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -51,6 +51,7 @@ class FlexCounter
                 _In_ std::string instanceId);
         static void removeCounterPlugin(
                 _In_ std::string instanceId);
+        static void removeAllCounters();
 
         FlexCounter(
                 _In_ const FlexCounter&) = delete;

--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -535,7 +535,6 @@ void ntf_process_function()
     while (runThread)
     {
         cv.wait(ulock);
-        if (! runThread) break;
 
         // this is notifications processing thread context, which is different
         // from SAI notifications context, we can safe use g_mutex here,

--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -535,6 +535,7 @@ void ntf_process_function()
     while (runThread)
     {
         cv.wait(ulock);
+        if (! runThread) break;
 
         // this is notifications processing thread context, which is different
         // from SAI notifications context, we can safe use g_mutex here,
@@ -559,8 +560,6 @@ void startNotificationsProcessingThread()
     runThread = true;
 
     ntf_process_thread = std::make_shared<std::thread>(ntf_process_function);
-
-    ntf_process_thread->detach();
 }
 
 void stopNotificationsProcessingThread()


### PR DESCRIPTION
- Stop notification thread before removing switch
- Stop flex counter queries before removing switch