### PR TITLE
Move sai_dbg_generate_dump to saisdkdump

### DIFF
--- a/saisdkdump/saisdkdump.cpp
+++ b/saisdkdump/saisdkdump.cpp
@@ -25,6 +25,14 @@ void print_usage()
     std::cerr << "--help  -h       usage" << std::endl;
 }
 
+sai_status_t sai_dbg_generate_dump(
+        _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_SUCCESS;
+}
+
 __attribute__((__noreturn__)) void exit_with_sai_failure(const char *msg, sai_status_t status)
 {
     SWSS_LOG_ENTER();

--- a/vslib/src/sai_vs.cpp
+++ b/vslib/src/sai_vs.cpp
@@ -1,10 +1,3 @@
 #include "sai_vs.h"
 #include "sai_vs_internal.h"
 
-sai_status_t sai_dbg_generate_dump(
-        _In_ const char *dump_file_name) 
-{
-    SWSS_LOG_ENTER();
-
-    return SAI_STATUS_SUCCESS;
-}


### PR DESCRIPTION
Move sai_dbg_generate_dump to saisdkdump as it causes linkage error if saisdkdump
is not linked with vslib:
https://github.com/Azure/sonic-sairedis/blob/201803/saisdkdump/Makefile.am#L11

Logs:
saisdkdump-saisdkdump.o: In function `main':
/sonic/src/sonic-sairedis/saisdkdump/saisdkdump.cpp:145: undefined reference to `sai_dbg_generate_dump'
collect2: error: ld returned 1 exit status

Signed-off-by: Nadiya Stetskovych <Nadiya.Stetskovych@cavium.com>