### PR TITLE
Suppress FDB events if notifier queue exceeds limit 

### DIFF
--- a/syncd/syncd.h
+++ b/syncd/syncd.h
@@ -89,6 +89,7 @@ sai_object_id_t redis_sai_switch_id_query(
 sai_object_id_t translate_rid_to_vid(
         _In_ sai_object_id_t rid,
         _In_ sai_object_id_t switch_vid);
+
 void translate_rid_to_vid_list(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t switch_vid,

--- a/syncd/syncd.h
+++ b/syncd/syncd.h
@@ -89,7 +89,6 @@ sai_object_id_t redis_sai_switch_id_query(
 sai_object_id_t translate_rid_to_vid(
         _In_ sai_object_id_t rid,
         _In_ sai_object_id_t switch_vid);
-
 void translate_rid_to_vid_list(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t switch_vid,

--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -504,6 +504,8 @@ bool ntf_queue_t::tryDequeue(
 bool ntf_queue_t::enqueue(
         _In_ swss::KeyOpFieldsValuesTuple item)
 {
+    SWSS_LOG_ENTER();
+
     std::string notification = kfvKey(item);
 
     /*

--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -531,12 +531,13 @@ bool ntf_queue_t::enqueue(
 
     static uint32_t log_count = 0;
 
-    if (!log_count)
+    if (!(log_count % 1000))
     {
-        SWSS_LOG_NOTICE("Too many messages in queue (%ld), dropping FDB events!", queueStats());
+        SWSS_LOG_NOTICE("Too many messages in queue (%ld), dropped %ld FDB events!",
+                         queueStats(), (log_count+1));
     }
 
-    log_count = (log_count + 1) % 1000;
+    ++log_count;
 
     return false;
 }


### PR DESCRIPTION
In the event of continuous mac-move, it is observed that the notifier-queue keeps growing consuming high memory. 
Current solution is to drop FDB events beyond a limit (set to `300k`, considering 256k MAC entries in a typical L2 deployment + some extra buffer for other events). A permanent approach would be to have the event stateful and notify only the latest event. 

Tested and observed that with this cap, the syncd memory usage is `~3.8%` and does not exceed beyond this. 