### PR TITLE
ASIC temperature sensors support

### DIFF
--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -138,6 +138,9 @@ std::string sai_serialize_ipmc_entry_type(
 std::string sai_serialize_qos_map_item(
         _In_ const sai_qos_map_t& qosmap);
 
+std::string sai_serialize_switch_attr(
+        _In_ const sai_switch_attr_t switch_attr);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -286,5 +289,9 @@ void sai_deserialize_ingress_priority_group_attr(
 void sai_deserialize_queue_attr(
         _In_ const std::string& s,
         _Out_ sai_queue_attr_t& attr);
+
+void sai_deserialize_switch_attr(
+        _In_ const std::string& s,
+        _Out_ sai_switch_attr_t& attr);
 
 #endif // __SAI_SERIALIZE__

--- a/meta/saiserialize.cpp
+++ b/meta/saiserialize.cpp
@@ -1636,6 +1636,14 @@ std::string sai_serialize_object_meta_key(
     return key;
 }
 
+std::string sai_serialize_switch_attr(
+        _In_ const sai_switch_attr_t switch_attr)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_enum(switch_attr, &sai_metadata_enum_sai_switch_attr_t);
+}
+
 // deserialize
 
 void sai_deserialize_bool(
@@ -2975,4 +2983,13 @@ void sai_deserialize_queue_attr(
     SWSS_LOG_ENTER();
 
     sai_deserialize_enum(s, &sai_metadata_enum_sai_queue_attr_t, (int32_t&)attr);
+}
+
+void sai_deserialize_switch_attr(
+        _In_ const std::string& s,
+        _Out_ sai_switch_attr_t& attr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_enum(s, &sai_metadata_enum_sai_switch_attr_t, (int32_t&)attr);
 }

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2907,6 +2907,17 @@ void processFlexCounterEvent(
 
                 FlexCounter::setPriorityGroupAttrList(vid, rid, groupName, pgAttrIds);
             }
+            else if (objectType == SAI_OBJECT_TYPE_SWITCH && field == SWITCH_SENSOR_ID_LIST)
+            {
+                std::vector<sai_switch_attr_t> SwitchSensorIds;
+                for (const auto &str : idStrings)
+                {
+                    sai_switch_attr_t attr;
+                    sai_deserialize_switch_attr(str, attr);
+                    SwitchSensorIds.push_back(attr);
+                }
+                FlexCounter::setSwitchSensorsList(vid, rid, groupName, SwitchSensorIds);
+            }
             else
             {
                 SWSS_LOG_ERROR("Object type and field combination is not supported, object type %s, field %s", objectTypeStr.c_str(), field.c_str());

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -42,6 +42,11 @@ class FlexCounter
                 _In_ sai_object_id_t priorityGroupId,
                 _In_ std::string instanceId,
                 _In_ const std::vector<sai_ingress_priority_group_attr_t> &attrIds);
+        static void setSwitchSensorsList(
+                _In_ sai_object_id_t switchVid,
+                _In_ sai_object_id_t switchId,
+                _In_ std::string instanceId,
+                _In_ const std::vector<sai_switch_attr_t> &SwitchSensorIds);
         static void updateFlexCounterStatus(
                 _In_ std::string status,
                 _In_ std::string instanceId);
@@ -57,6 +62,9 @@ class FlexCounter
                 _In_ std::string instanceId);
         static void removePriorityGroup(
                 _In_ sai_object_id_t priorityGroupVid,
+                _In_ std::string instanceId);
+        static void removeSwitch(
+                _In_ sai_object_id_t SwitchVid,
                 _In_ std::string instanceId);
 
         static void addPortCounterPlugin(
@@ -130,6 +138,16 @@ class FlexCounter
             std::vector<sai_port_stat_t> portCounterIds;
         };
 
+        struct SwitchSensorIds
+        {
+            SwitchSensorIds(
+                    _In_ sai_object_id_t switchId,
+                    _In_ const std::vector<sai_switch_attr_t> &SensorIds);
+
+            sai_object_id_t switchId;
+            std::vector<sai_switch_attr_t> switchSensorIds;
+        };
+
         FlexCounter(std::string instanceId);
         static FlexCounter& getInstance(std::string instanceId);
         static void removeInstance(std::string instanceId);
@@ -143,9 +161,11 @@ class FlexCounter
         void saiUpdateSupportedPortCounters(sai_object_id_t portId);
         void saiUpdateSupportedQueueCounters(sai_object_id_t queueId, const std::vector<sai_queue_stat_t> &counterIds);
         void saiUpdateSupportedPriorityGroupCounters(sai_object_id_t priorityGroupId, const std::vector<sai_ingress_priority_group_stat_t> &counterIds);
+        void saiUpdateSupportedSwitchSensors(_In_ sai_object_id_t switchId, _In_ const std::vector<sai_switch_attr_t> &SwitchSensorIds);
         bool isPortCounterSupported(sai_port_stat_t counter) const;
         bool isQueueCounterSupported(sai_queue_stat_t counter) const;
         bool isPriorityGroupCounterSupported(sai_ingress_priority_group_stat_t counter) const;
+        bool isSwitchSensorSupported(sai_switch_attr_t sensor) const;
         bool isEmpty();
 
         // Key is a Virtual ID
@@ -154,6 +174,10 @@ class FlexCounter
         std::map<sai_object_id_t, std::shared_ptr<QueueAttrIds>> m_queueAttrIdsMap;
         std::map<sai_object_id_t, std::shared_ptr<IngressPriorityGroupCounterIds>> m_priorityGroupCounterIdsMap;
         std::map<sai_object_id_t, std::shared_ptr<IngressPriorityGroupAttrIds>> m_priorityGroupAttrIdsMap;
+        std::map<sai_object_id_t, std::shared_ptr<SwitchSensorIds>> m_switchSensorIdsMap;
+
+        // Max number of temperature sensors
+        uint8_t max_temp_sensors;
 
         // Plugins
         std::set<std::string> m_queuePlugins;


### PR DESCRIPTION
**Please do not merge yet.**

Recently (https://github.com/opencomputeproject/SAI/pull/880), new switch attributes were added to retrieve the temperature readings from the ASIC's internal sensors. 

This is a preliminary commit (pending SAI support from vendors) for temperature monitoring. The max, average and the entire list of temperatures are now added to the flex counters DB so that platform sensors scripts may query and use these values in thermal control algorithms.