### PR TITLE
[flex counter] use get_stats_ext SAI calls for queue and PG counters

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -700,26 +700,12 @@ void FlexCounter::collectCounters(
         std::vector<uint64_t> queueStats(queueCounterIds.size());
 
         // Get queue stats
-        sai_status_t status = -1;
-//        TODO: replace if with get_queue_stats_ext() call when it's fully supported
-//        Example:
-//        sai_status_t status = sai_metadata_sai_queue_api->get_queue_stats_ext(
-//                queueId,
-//                static_cast<uint32_t>(queueCounterIds.size()),
-//                queueCounterIds.data(),
-//                m_statsMode,
-//                queueStats.data());
-        status = sai_metadata_sai_queue_api->get_queue_stats(
+        sai_status_t status = sai_metadata_sai_queue_api->get_queue_stats_ext(
                 queueId,
                 static_cast<uint32_t>(queueCounterIds.size()),
                 queueCounterIds.data(),
+                m_statsMode,
                 queueStats.data());
-        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR){
-            status = sai_metadata_sai_queue_api->clear_queue_stats(
-                    queueId,
-                    static_cast<uint32_t>(queueCounterIds.size()),
-                    queueCounterIds.data());
-        }
 
         if (status != SAI_STATUS_SUCCESS)
         {
@@ -794,19 +780,12 @@ void FlexCounter::collectCounters(
         std::vector<uint64_t> priorityGroupStats(priorityGroupCounterIds.size());
 
         // Get PG stats
-        sai_status_t status = -1;
-//        TODO: replace if with get_ingress_priority_group_stats_ext() call when it's fully supported
-        status = sai_metadata_sai_buffer_api->get_ingress_priority_group_stats(
+        sai_status_t status = sai_metadata_sai_buffer_api->get_ingress_priority_group_stats_ext(
                         priorityGroupId,
                         static_cast<uint32_t>(priorityGroupCounterIds.size()),
                         priorityGroupCounterIds.data(),
+                        m_statsMode,
                         priorityGroupStats.data());
-        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR){
-            status = sai_metadata_sai_buffer_api->clear_ingress_priority_group_stats(
-                            priorityGroupId,
-                            static_cast<uint32_t>(priorityGroupCounterIds.size()),
-                            priorityGroupCounterIds.data());
-        }
 
         if (status != SAI_STATUS_SUCCESS)
         {


### PR DESCRIPTION
closes a TODO.

Use a get_stats_ext instead of separate get and clear calls.
Should boost performance.

This is related to watermark read and clear behavior.

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>