### PR TITLE
install SAI extension header files into /usr/include/sai

### DIFF
--- a/debian/libsaivs-dev.install
+++ b/debian/libsaivs-dev.install
@@ -1,1 +1,2 @@
 SAI/inc/*.h usr/include/sai/
+SAI/experimental/*.h usr/include/sai/


### PR DESCRIPTION
fix swss build issue

https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-swss-build/54/console