### PR TITLE
Move warm_restart enable/disable config to stateDB WARM_RESTART_ENABL…

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -46,8 +46,8 @@ function check_warm_boot()
 {
     # FIXME: if we want to continue start option approach, then we need to add
     #        code here to support redis database query.
-    # SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
-    # SERVICE_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|${SERVICE}" enable`
+    # SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    # SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     # if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
     #     WARM_BOOT="true"


### PR DESCRIPTION
…E_TABLE

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

For warm_restart enable/disable configuration, putting them into configDB caused confusion in configuration save and restore. They are not supposed to be persistent across cold boot. Moving them to stateDB which will be saved and restored during warm reboot.

https://github.com/Azure/sonic-swss-common/pull/260

https://github.com/Azure/sonic-swss/pull/786

https://github.com/Azure/sonic-sairedis/pull/418

https://github.com/Azure/sonic-utilities/pull/458

https://github.com/Azure/sonic-buildimage/pull/2538