### PR TITLE
[vslib] add missing port attributes for virtual switch

### DIFF
--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -107,6 +107,7 @@ mlnx
 mpls
 mutex
 mutexes
+MTU
 namespace
 namespaces
 NHG

--- a/vslib/src/sai_vs_switch_BCM56850.cpp
+++ b/vslib/src/sai_vs_switch_BCM56850.cpp
@@ -169,6 +169,16 @@ static sai_status_t create_ports()
 
         sai_attribute_t attr;
 
+        attr.id = SAI_PORT_ATTR_ADMIN_STATE;
+        attr.value.booldata = false;     /* default admin state is down as defined in SAI */
+
+        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+        attr.id = SAI_PORT_ATTR_MTU;
+        attr.value.u32 = 1514;     /* default MTU is 1514 as defined in SAI */
+
+        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
         attr.id = SAI_PORT_ATTR_SPEED;
         attr.value.u32 = 10 * 1000;
 

--- a/vslib/src/sai_vs_switch_MLNX2700.cpp
+++ b/vslib/src/sai_vs_switch_MLNX2700.cpp
@@ -166,6 +166,16 @@ static sai_status_t create_ports()
 
         sai_attribute_t attr;
 
+        attr.id = SAI_PORT_ATTR_ADMIN_STATE;
+        attr.value.booldata = false;     /* default admin state is down as defined in SAI */
+
+        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+        attr.id = SAI_PORT_ATTR_MTU;
+        attr.value.u32 = 1514;     /* default MTU is 1514 as defined in SAI */
+
+        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
         attr.id = SAI_PORT_ATTR_SPEED;
         attr.value.u32 = 40 * 1000;     /* TODO from config */
 


### PR DESCRIPTION
 - add default port attributes - admin state and mtu

Get SAI_PORT_ATTR_ADMIN_STATUS before it was set returned not implemented:
```
Feb 10 00:57:46.380006 adcde36a1608 ERR #orchagent: :- meta_sai_get_oid: get status: SAI_STATUS_NOT_IMPLEMENTED
Feb 10 00:57:46.380018 adcde36a1608 ERR #orchagent: :- getPortAdminStatus: Failed to get admin status for port pid:1000000000008

```
Also, added MTU set as default (1514 as defined by SAI)

<b>NOTE:</b> To 201811 as well

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>