### PR TITLE
[bfn|syncd] Ged rid of ld_preload. Link against libsai only

### DIFF
--- a/saidiscovery/Makefile.am
+++ b/saidiscovery/Makefile.am
@@ -12,7 +12,8 @@ if SAIVS
 SAILIB=-L$(top_srcdir)/vslib/src/.libs -lsaivs
 else
 if sonic_asic_platform_barefoot
-SAILIB=-L/opt/bfn/install/lib -lswitchsai -lswitchapi -lbf_switchd_lib -ltofinopdfixed_thrift -ldriver -lbfutils -lbfsys -lbfutils -L/opt/bfn/install/lib/tofinopd/switch -lpd -lpdcli -lpdthrift
+AM_CPPFLAGS += -I/opt/bfn/install/include
+SAILIB=-L/opt/bfn/install/lib -lswitchsai
 else
 SAILIB=-lsai
 endif

--- a/saisdkdump/Makefile.am
+++ b/saisdkdump/Makefile.am
@@ -13,7 +13,6 @@ if SAIVS
 SAILIB=-L$(top_srcdir)/vslib/src/.libs -lsaivs
 else
 if sonic_asic_platform_barefoot
-AM_LDFLAGS = -Wl,-unresolved-symbols=ignore-in-shared-libs
 SAILIB=-L/opt/bfn/install/lib -lswitchsai
 else
 SAILIB=-lsai

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -13,7 +13,6 @@ SAILIB=-L$(top_srcdir)/vslib/src/.libs -lsaivs
 else
 if sonic_asic_platform_barefoot
 AM_CPPFLAGS += -I/opt/bfn/install/include
-AM_LDFLAGS = -Wl,-unresolved-symbols=ignore-in-shared-libs
 SAILIB=-L/opt/bfn/install/lib -lswitchsai
 else
 SAILIB=-lsai

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -139,7 +139,6 @@ config_syncd_barefoot()
     export ONIE_PLATFORM=`grep onie_platform /etc/machine.conf | awk 'BEGIN { FS = "=" } ; { print $2 }'`
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/bfn/install/lib/platform/$ONIE_PLATFORM:/opt/bfn/install/lib:/opt/bfn/install/lib/tofinopd/switch
     ./opt/bfn/install/bin/dma_setup.sh
-    export LD_PRELOAD=libswitchapi.so:libswitchsai.so:libpd.so:libpdcli.so:libdriver.so:libbfsys.so:libbfutils.so:libbf_switchd_lib.so:libtofinopdfixed_thrift.so:libpdthrift.so
 }
 
 config_syncd_nephos()


### PR DESCRIPTION
- Remove hard coded libs in saidiscovery for bfn platform
- Remove ignoring unresolved-symbols
- Get rid of LD_PRELOAD in syncd

Signed-off-by: Nadiya.Stetskovych <nstetskovych@barefootnetworks.com>