### PR TITLE
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -126,6 +126,15 @@ config_syncd_marvell()
 
 config_syncd_barefoot()
 {
+    PROFILE_FILE="$HWSKU_DIR/sai.profile"
+    if [ ! -f $PROFILE_FILE ]; then
+        # default profile file
+        PROFILE_FILE="/tmp/sai.profile"
+        echo "SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin" > $PROFILE_FILE
+        echo "SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin" >> $PROFILE_FILE
+    fi
+    CMD_ARGS+=" -p $PROFILE_FILE"
+
     # Check and load SDE profile
     P4_PROFILE=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["p4_profile"]')
     if [[ -n "$P4_PROFILE" ]]; then


### PR DESCRIPTION
**- What I did**
added WARM_BOOT options for Barefoot based platforms including
* append sai.profile to the syncd arguments

**- How to verify it**
run sudo warm-reboot on the hardware box

**- Description for the changelog**
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

**- Should be merged together with**
https://github.com/Azure/sonic-buildimage/pull/2687
https://github.com/Azure/sonic-utilities/pull/485

@akokhan, @mkbalani FYI
