### PR TITLE
Dynamic transceiver tuning support

### DIFF
--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <streambuf>
 #include <iomanip>
 #include <map>
+#include <vector>
 #include <tuple>
 #include <string.h>
 #include "swss/logger.h"
@@ -280,5 +281,9 @@ void sai_deserialize_ingress_priority_group_attr(
 void sai_deserialize_queue_attr(
         _In_ const std::string& s,
         _Out_ sai_queue_attr_t& attr);
+
+void sai_deserialize_port_serdes_attr(
+        _In_ const std::string& s,
+        _Out_ std::vector<uint32_t> &lane_values);
 
 #endif // __SAI_SERIALIZE__

--- a/meta/saiserialize.cpp
+++ b/meta/saiserialize.cpp
@@ -2976,3 +2976,21 @@ void sai_deserialize_queue_attr(
 
     sai_deserialize_enum(s, &sai_metadata_enum_sai_queue_attr_t, (int32_t&)attr);
 }
+
+void sai_deserialize_port_serdes_attr(
+        _In_ const std::string& s,
+        _Out_ std::vector<uint32_t> &lane_values)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+    std::string lane_str = "lane";
+    uint32_t count = (uint32_t)j.size();
+
+    for (uint32_t i = 0; i < count; i++)
+    {
+        std::string lane_idx_str = lane_str + std::to_string(i);
+        std::string value_str = j[lane_idx_str];
+        lane_values.push_back((uint32_t)std::stoul(value_str, NULL, 16));
+    }
+}


### PR DESCRIPTION
**- What I did**
Dynamic transceiver tuning support
**- How I did it**
Dynamically program pre-emphasis and other settings based on media detected in xcvrd. The various supported media are defined in media_settings.json

**- How to verify it**
Perform OIR of different media types. Dump the pre-emphasis values from hardware and verify that they got reflected

**- Description for the changelog**

Support for dynamically programming pre-emphasis


**- A picture of a cute animal (not mandatory but encouraged)**
