### PR TITLE
[debian/rules] Change build order in target binary

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ clean:
 build:
 	echo build stage is skipped. Please use binary to generate debian packages
 
-binary: binary-syncd binary-syncd-rpc
+binary: binary-syncd-rpc binary-syncd
 
 binary-syncd:
 	$(shell echo > /tmp/syncd-build)


### PR DESCRIPTION
Make binary-syncd the last target, so the non-rpc requisites will be available after the first build
It will allow doing incremental builds later on for the main binary type