### PR TITLE
Modify sai_create_port to breakout a port for virtual switch

### DIFF
--- a/vslib/inc/sai_vs_switch_BCM56850.h
+++ b/vslib/inc/sai_vs_switch_BCM56850.h
@@ -21,7 +21,4 @@ sai_status_t vs_create_port_BCM56850(
         _In_ sai_object_id_t port_id,
         _In_ sai_object_id_t switch_id);
 
-sai_status_t vs_remove_port_BCM56850(
-        _In_ sai_object_id_t port_id);
-
 #endif // __SAI_VS_SWITCH_BCM56850__

--- a/vslib/inc/sai_vs_switch_BCM56850.h
+++ b/vslib/inc/sai_vs_switch_BCM56850.h
@@ -17,4 +17,11 @@ sai_status_t refresh_read_only_BCM56850(
         _In_ sai_object_id_t object_id,
         _In_ sai_object_id_t switch_id);
 
+sai_status_t vs_create_port_BCM56850(
+        _In_ sai_object_id_t port_id,
+        _In_ sai_object_id_t switch_id);
+
+sai_status_t vs_remove_port_BCM56850(
+        _In_ sai_object_id_t port_id);
+
 #endif // __SAI_VS_SWITCH_BCM56850__

--- a/vslib/inc/sai_vs_switch_MLNX2700.h
+++ b/vslib/inc/sai_vs_switch_MLNX2700.h
@@ -17,4 +17,8 @@ sai_status_t refresh_read_only_MLNX2700(
         _In_ sai_object_id_t object_id,
         _In_ sai_object_id_t switch_id);
 
+sai_status_t vs_create_port_MLNX2700(
+        _In_ sai_object_id_t port_id,
+        _In_ sai_object_id_t switch_id);
+
 #endif // __SAI_VS_SWITCH_MLNX2700__

--- a/vslib/src/sai_vs_port.cpp
+++ b/vslib/src/sai_vs_port.cpp
@@ -34,21 +34,7 @@ sai_status_t vs_create_port(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t vs_remove_port(
-            _In_ sai_object_id_t port_id)
-{
-    MUTEX();
-    SWSS_LOG_ENTER();
-
-    if (g_vs_switch_type == SAI_VS_SWITCH_TYPE_BCM56850)
-    {
-	vs_remove_port_BCM56850(port_id);
-    }
-
-    return meta_sai_remove_oid((sai_object_type_t)SAI_OBJECT_TYPE_PORT,
-                port_id,&vs_generic_remove);
-}
-
+VS_REMOVE(PORT,port);
 VS_SET(PORT,port);
 VS_GET(PORT,port);
 VS_GENERIC_QUAD(PORT_POOL,port_pool);

--- a/vslib/src/sai_vs_port.cpp
+++ b/vslib/src/sai_vs_port.cpp
@@ -1,5 +1,7 @@
 #include "sai_vs.h"
 #include "sai_vs_internal.h"
+#include "sai_vs_state.h"
+#include "sai_vs_switch_BCM56850.h"
 
 sai_status_t vs_clear_port_all_stats(
         _In_ sai_object_id_t port_id)
@@ -11,7 +13,44 @@ sai_status_t vs_clear_port_all_stats(
     return SAI_STATUS_NOT_IMPLEMENTED;
 }
 
-VS_GENERIC_QUAD(PORT,port);
+sai_status_t vs_create_port(
+            _Out_ sai_object_id_t *port_id,
+            _In_ sai_object_id_t switch_id,
+            _In_ uint32_t attr_count,
+            _In_ const sai_attribute_t *attr_list)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+
+    /* create port */
+    CHECK_STATUS(meta_sai_create_oid((sai_object_type_t)SAI_OBJECT_TYPE_PORT,
+                port_id,switch_id,attr_count,attr_list,&vs_generic_create));
+
+    if (g_vs_switch_type == SAI_VS_SWITCH_TYPE_BCM56850)
+    {
+        vs_create_port_BCM56850(*port_id, switch_id);
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t vs_remove_port(
+            _In_ sai_object_id_t port_id)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+
+    if (g_vs_switch_type == SAI_VS_SWITCH_TYPE_BCM56850)
+    {
+	vs_remove_port_BCM56850(port_id);
+    }
+
+    return meta_sai_remove_oid((sai_object_type_t)SAI_OBJECT_TYPE_PORT,
+                port_id,&vs_generic_remove);
+}
+
+VS_SET(PORT,port);
+VS_GET(PORT,port);
 VS_GENERIC_QUAD(PORT_POOL,port_pool);
 VS_GENERIC_STATS(PORT,port);
 VS_GENERIC_STATS(PORT_POOL,port_pool);

--- a/vslib/src/sai_vs_port.cpp
+++ b/vslib/src/sai_vs_port.cpp
@@ -2,6 +2,7 @@
 #include "sai_vs_internal.h"
 #include "sai_vs_state.h"
 #include "sai_vs_switch_BCM56850.h"
+#include "sai_vs_switch_MLNX2700.h"
 
 sai_status_t vs_clear_port_all_stats(
         _In_ sai_object_id_t port_id)
@@ -29,6 +30,10 @@ sai_status_t vs_create_port(
     if (g_vs_switch_type == SAI_VS_SWITCH_TYPE_BCM56850)
     {
         vs_create_port_BCM56850(*port_id, switch_id);
+    }
+    else if (g_vs_switch_type == SAI_VS_SWITCH_TYPE_MLNX2700)
+    {
+        vs_create_port_MLNX2700(*port_id, switch_id);
     }
 
     return SAI_STATUS_SUCCESS;

--- a/vslib/src/sai_vs_switch_BCM56850.cpp
+++ b/vslib/src/sai_vs_switch_BCM56850.cpp
@@ -418,7 +418,9 @@ static sai_status_t create_default_trap_group()
     return vs_generic_set(SAI_OBJECT_TYPE_SWITCH, switch_object_id, &attr);
 }
 
-static sai_status_t create_qos_queues_per_port(sai_object_id_t switch_object_id, sai_object_id_t port_id)
+static sai_status_t create_qos_queues_per_port(
+        _In_ sai_object_id_t switch_object_id,
+        _In_ sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 
@@ -470,7 +472,9 @@ static sai_status_t create_qos_queues()
     return SAI_STATUS_SUCCESS;
 }
 
-static sai_status_t create_ingress_priority_groups_per_port(sai_object_id_t switch_object_id, sai_object_id_t port_id)
+static sai_status_t create_ingress_priority_groups_per_port(
+        _In_ sai_object_id_t switch_object_id,
+        _In_ sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/sai_vs_switch_BCM56850.cpp
+++ b/vslib/src/sai_vs_switch_BCM56850.cpp
@@ -418,6 +418,40 @@ static sai_status_t create_default_trap_group()
     return vs_generic_set(SAI_OBJECT_TYPE_SWITCH, switch_object_id, &attr);
 }
 
+static sai_status_t create_qos_queues_per_port(sai_object_id_t switch_object_id, sai_object_id_t port_id)
+{
+    SWSS_LOG_ENTER();
+
+    // 10 in and 10 out queues per port
+    const uint32_t port_qos_queues_count = 20;
+
+    std::vector<sai_object_id_t> queues;
+
+    for (uint32_t i = 0; i < port_qos_queues_count; ++i)
+    {
+        sai_object_id_t queue_id;
+
+        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_QUEUE, &queue_id, switch_object_id, 0, NULL));
+
+        queues.push_back(queue_id);
+    }
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
+    attr.value.u32 = port_qos_queues_count;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
+    attr.value.objlist.count = port_qos_queues_count;
+    attr.value.objlist.list = queues.data();
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    return SAI_STATUS_SUCCESS;
+}
+
 static sai_status_t create_qos_queues()
 {
     SWSS_LOG_ENTER();
@@ -428,35 +462,43 @@ static sai_status_t create_qos_queues()
 
     sai_object_id_t switch_object_id = ss->getSwitchId();
 
-    // 10 in and 10 out queues per port
-    const uint32_t port_qos_queues_count = 20;
-
     for (auto &port_id : port_list)
     {
-        std::vector<sai_object_id_t> queues;
-
-        for (uint32_t i = 0; i < port_qos_queues_count; ++i)
-        {
-            sai_object_id_t queue_id;
-
-            CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_QUEUE, &queue_id, switch_object_id, 0, NULL));
-
-            queues.push_back(queue_id);
-        }
-
-        sai_attribute_t attr;
-
-        attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
-        attr.value.u32 = port_qos_queues_count;
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-        attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
-        attr.value.objlist.count = port_qos_queues_count;
-        attr.value.objlist.list = queues.data();
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+        create_qos_queues_per_port(switch_object_id, port_id);
     }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+static sai_status_t create_ingress_priority_groups_per_port(sai_object_id_t switch_object_id, sai_object_id_t port_id)
+{
+    SWSS_LOG_ENTER();
+
+    const uint32_t port_pgs_count = 8;
+
+    std::vector<sai_object_id_t> pgs;
+
+    for (uint32_t i = 0; i < port_pgs_count; ++i)
+    {
+        sai_object_id_t pg_id;
+
+        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, &pg_id, switch_object_id, 0, NULL));
+
+        pgs.push_back(pg_id);
+    }
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
+    attr.value.u32 = port_pgs_count;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
+    attr.value.objlist.count = port_pgs_count;
+    attr.value.objlist.list = pgs.data();
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
     return SAI_STATUS_SUCCESS;
 }
@@ -472,33 +514,9 @@ static sai_status_t create_ingress_priority_groups()
     sai_object_id_t switch_object_id = ss->getSwitchId();
 
     //
-    const uint32_t port_pgs_count = 8;
-
     for (auto &port_id : port_list)
     {
-        std::vector<sai_object_id_t> pgs;
-
-        for (uint32_t i = 0; i < port_pgs_count; ++i)
-        {
-            sai_object_id_t pg_id;
-
-            CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, &pg_id, switch_object_id, 0, NULL));
-
-            pgs.push_back(pg_id);
-        }
-
-        sai_attribute_t attr;
-
-        attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
-        attr.value.u32 = port_pgs_count;
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-        attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
-        attr.value.objlist.count = port_pgs_count;
-        attr.value.objlist.list = pgs.data();
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+        create_ingress_priority_groups_per_port(switch_object_id, port_id);
     }
 
     return SAI_STATUS_SUCCESS;
@@ -1216,7 +1234,7 @@ sai_status_t vs_create_port_BCM56850(
         _In_ sai_object_id_t switch_id)
 {
     SWSS_LOG_ENTER();
- 
+
     sai_attribute_t attr;
 
     attr.id = SAI_PORT_ATTR_ADMIN_STATE;
@@ -1225,104 +1243,12 @@ sai_status_t vs_create_port_BCM56850(
     CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
     /* create priority groups */
-    const uint32_t port_pgs_count = 8;
-
-    std::vector<sai_object_id_t> pgs;
-
-    for (uint32_t i = 0; i < port_pgs_count; ++i)
-    {
-        sai_object_id_t pg_id;
-
-        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, &pg_id, switch_id, 0, NULL));
-
-        pgs.push_back(pg_id);
-    }
-
-    attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
-    attr.value.u32 = port_pgs_count;
-
-    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-    attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
-    attr.value.objlist.count = port_pgs_count;
-    attr.value.objlist.list = pgs.data();
-
-    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+    create_ingress_priority_groups_per_port(switch_id, port_id);
 
     /* create qos queues */
-    const uint32_t port_qos_queues_count = 20;
-
-    std::vector<sai_object_id_t> queues;
-
-    for (uint32_t i = 0; i < port_qos_queues_count; ++i)
-    {
-        sai_object_id_t queue_id;
-
-        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_QUEUE, &queue_id, switch_id, 0, NULL));
-
-        queues.push_back(queue_id);
-    }
-
-    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
-    attr.value.u32 = port_qos_queues_count;
-
-    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-    attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
-    attr.value.objlist.count = port_qos_queues_count;
-    attr.value.objlist.list = queues.data();
-
-    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+    create_qos_queues_per_port(switch_id, port_id);
 
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t vs_remove_port_BCM56850(
-        _In_ sai_object_id_t port_id)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-
-    /* remove priority groups */
-    uint32_t port_pgs_count;
-    std::vector<sai_object_id_t> pgs;
-
-    attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
-    CHECK_STATUS(vs_generic_get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
-    port_pgs_count = attr.value.u32;
-    pgs.resize(port_pgs_count);
-
-    attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
-    attr.value.objlist.count = port_pgs_count;
-    attr.value.objlist.list = pgs.data();
-    CHECK_STATUS(vs_generic_get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
-
-    for (uint32_t i = 0; i < pgs.size(); ++i)
-    {
-        CHECK_STATUS(vs_generic_remove(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, pgs[i]));
-    }
-
-
-    /* remove qos queues */
-    uint32_t port_qos_queues_count;
-    std::vector<sai_object_id_t> queues;
-
-    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
-    CHECK_STATUS(vs_generic_get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
-    port_qos_queues_count = attr.value.u32;
-    queues.resize(port_qos_queues_count);
-
-    attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
-    attr.value.objlist.count = port_qos_queues_count;
-    attr.value.objlist.list = queues.data();
-    CHECK_STATUS(vs_generic_get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
-
-    for (uint32_t i = 0; i < queues.size(); ++i)
-    {
-        CHECK_STATUS(vs_generic_remove(SAI_OBJECT_TYPE_QUEUE, queues[i]));
-    }
-
-    return SAI_STATUS_SUCCESS;
-}
 

--- a/vslib/src/sai_vs_switch_MLNX2700.cpp
+++ b/vslib/src/sai_vs_switch_MLNX2700.cpp
@@ -352,6 +352,8 @@ static sai_status_t create_default_trap_group()
 
 static sai_status_t create_qos_queues_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
 {
+    SWSS_LOG_ENTER();
+
     // 8 in and 8 out queues per port
     const uint32_t port_qos_queues_count = 16;
     std::vector<sai_object_id_t> queues;
@@ -410,6 +412,8 @@ static sai_status_t create_qos_queues()
 
 static sai_status_t create_ingress_priority_groups_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
 {
+    SWSS_LOG_ENTER();
+
     const uint32_t port_pgs_count = 8;
     std::vector<sai_object_id_t> pgs;
 

--- a/vslib/src/sai_vs_switch_MLNX2700.cpp
+++ b/vslib/src/sai_vs_switch_MLNX2700.cpp
@@ -350,7 +350,9 @@ static sai_status_t create_default_trap_group()
     return vs_generic_set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 }
 
-static sai_status_t create_qos_queues_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
+static sai_status_t create_qos_queues_per_port(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 
@@ -410,7 +412,9 @@ static sai_status_t create_qos_queues()
     return SAI_STATUS_SUCCESS;
 }
 
-static sai_status_t create_ingress_priority_groups_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
+static sai_status_t create_ingress_priority_groups_per_port(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/sai_vs_switch_MLNX2700.cpp
+++ b/vslib/src/sai_vs_switch_MLNX2700.cpp
@@ -350,6 +350,44 @@ static sai_status_t create_default_trap_group()
     return vs_generic_set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 }
 
+static sai_status_t create_qos_queues_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
+{
+    // 8 in and 8 out queues per port
+    const uint32_t port_qos_queues_count = 16;
+    std::vector<sai_object_id_t> queues;
+
+    for (uint32_t i = 0; i < port_qos_queues_count; ++i)
+    {
+        sai_object_id_t queue_id;
+
+        sai_attribute_t attr[2];
+
+        attr[0].id = SAI_QUEUE_ATTR_INDEX;
+        attr[0].value.u8 = (uint8_t)i;
+        attr[1].id = SAI_QUEUE_ATTR_PORT;
+        attr[1].value.oid = port_id;
+
+        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_QUEUE, &queue_id, switch_id, 2, attr));
+
+        queues.push_back(queue_id);
+    }
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
+    attr.value.u32 = port_qos_queues_count;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
+    attr.value.objlist.count = port_qos_queues_count;
+    attr.value.objlist.list = queues.data();
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    return SAI_STATUS_SUCCESS;
+}
+
 static sai_status_t create_qos_queues()
 {
     SWSS_LOG_ENTER();
@@ -358,47 +396,60 @@ static sai_status_t create_qos_queues()
 
     sai_object_id_t switch_id = ss->getSwitchId();
 
-    // 8 in and 8 out queues per port
-    const uint32_t port_qos_queues_count = 16;
-
     std::vector<sai_object_id_t> copy = port_list;
 
     copy.push_back(cpu_port_id);
 
     for (auto &port_id : copy)
     {
-        std::vector<sai_object_id_t> queues;
-
-        for (uint32_t i = 0; i < port_qos_queues_count; ++i)
-        {
-            sai_object_id_t queue_id;
-
-            sai_attribute_t attr[2];
-
-            attr[0].id = SAI_QUEUE_ATTR_INDEX;
-            attr[0].value.u8 = (uint8_t)i;
-
-            attr[1].id = SAI_QUEUE_ATTR_PORT;
-            attr[1].value.oid = port_id;
-
-            CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_QUEUE, &queue_id, switch_id, 2, attr));
-
-            queues.push_back(queue_id);
-        }
-
-        sai_attribute_t attr;
-
-        attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
-        attr.value.u32 = port_qos_queues_count;
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-        attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
-        attr.value.objlist.count = port_qos_queues_count;
-        attr.value.objlist.list = queues.data();
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+        create_qos_queues_per_port(switch_id, port_id);
     }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+static sai_status_t create_ingress_priority_groups_per_port(sai_object_id_t switch_id, sai_object_id_t port_id)
+{
+    const uint32_t port_pgs_count = 8;
+    std::vector<sai_object_id_t> pgs;
+
+    for (uint32_t i = 0; i < port_pgs_count; ++i)
+    {
+        sai_object_id_t pg_id;
+
+        sai_attribute_t attr[3];
+
+        attr[0].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
+        attr[0].value.oid = SAI_NULL_OBJECT_ID;
+
+        /*
+         * not in headers yet
+         *
+         * attr[1].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_PORT;
+         * attr[1].value.oid = port_id;
+
+         * attr[2].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_INDEX;
+         * attr[2].value.oid = i;
+
+         * fix number of attributes
+         */
+
+        CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, &pg_id, switch_id, 1, attr));
+        pgs.push_back(pg_id);
+    }
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
+    attr.value.u32 = port_pgs_count;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
+    attr.value.objlist.count = port_pgs_count;
+    attr.value.objlist.list = pgs.data();
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
     return SAI_STATUS_SUCCESS;
 }
@@ -411,50 +462,9 @@ static sai_status_t create_ingress_priority_groups()
 
     sai_object_id_t switch_id = ss->getSwitchId();
 
-    const uint32_t port_pgs_count = 8;
-
     for (auto &port_id : port_list)
     {
-        std::vector<sai_object_id_t> pgs;
-
-        for (uint32_t i = 0; i < port_pgs_count; ++i)
-        {
-            sai_object_id_t pg_id;
-
-            sai_attribute_t attr[3];
-
-            attr[0].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-            attr[0].value.oid = SAI_NULL_OBJECT_ID;
-
-            /*
-             * not in headers yet
-             *
-             * attr[1].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_PORT;
-             * attr[1].value.oid = port_id;
-
-             * attr[2].id = SAI_INGRESS_PRIORITY_GROUP_ATTR_INDEX;
-             * attr[2].value.oid = i;
-
-             * fix number of attributes
-             */
-
-            CHECK_STATUS(vs_generic_create(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, &pg_id, switch_id, 1, attr));
-
-            pgs.push_back(pg_id);
-        }
-
-        sai_attribute_t attr;
-
-        attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
-        attr.value.u32 = port_pgs_count;
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-        attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
-        attr.value.objlist.count = port_pgs_count;
-        attr.value.objlist.list = pgs.data();
-
-        CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+        create_ingress_priority_groups_per_port(switch_id, port_id);
     }
 
     return SAI_STATUS_SUCCESS;
@@ -1194,3 +1204,26 @@ sai_status_t refresh_read_only_MLNX2700(
 
     return SAI_STATUS_NOT_IMPLEMENTED;
 }
+
+sai_status_t vs_create_port_MLNX2700(
+        _In_ sai_object_id_t port_id,
+        _In_ sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_ADMIN_STATE;
+    attr.value.booldata = false;     /* default admin state is down as defined in SAI */
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    /* create priority groups */
+    create_ingress_priority_groups_per_port(switch_id, port_id);
+
+    /* create qos queues */
+    create_qos_queues_per_port(switch_id, port_id);
+
+    return SAI_STATUS_SUCCESS;
+}
+


### PR DESCRIPTION
For breakout a port, it needs to support create port and remove port.
When create a port, it needs to init some attributes.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>