### PR TITLE
[flex couter] add RIF counter check to isEmpty

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -677,6 +677,7 @@ bool FlexCounter::isEmpty()
            m_priorityGroupPlugins.empty() &&
            m_queueCounterIdsMap.empty() &&
            m_portCounterIdsMap.empty() &&
+           m_rifCounterIdsMap.empty() &&
            m_queueAttrIdsMap.empty() &&
            m_queuePlugins.empty() &&
            m_portPlugins.empty();


### PR DESCRIPTION
Fix logic to remove the Flex counter instance if it does not have registered Counter Ids or plugins.

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>