### PR TITLE
Full sleep wait flex counter polling thread when POLL_COUNTER_STATUS is disable

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2783,7 +2783,10 @@ void processFlexCounterGroupEvent(
     SWSS_LOG_ENTER();
 
     swss::KeyOpFieldsValuesTuple kco;
-    consumer.pop(kco);
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        consumer.pop(kco);
+    }
 
     const auto &groupName = kfvKey(kco);
     const auto &op = kfvOp(kco);
@@ -2860,7 +2863,10 @@ void processFlexCounterEvent(
     SWSS_LOG_ENTER();
 
     swss::KeyOpFieldsValuesTuple kco;
-    consumer.pop(kco);
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        consumer.pop(kco);
+    }
 
     const auto &key = kfvKey(kco);
     const auto &op = kfvOp(kco);

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2782,7 +2782,6 @@ void processFlexCounterGroupEvent(
 {
     SWSS_LOG_ENTER();
 
-    std::lock_guard<std::mutex> lock(g_mutex);
     swss::KeyOpFieldsValuesTuple kco;
     consumer.pop(kco);
 
@@ -2851,8 +2850,6 @@ void processFlexCounterEvent(
         _In_ swss::ConsumerTable &consumer)
 {
     SWSS_LOG_ENTER();
-
-    std::lock_guard<std::mutex> lock(g_mutex);
 
     swss::KeyOpFieldsValuesTuple kco;
     consumer.pop(kco);

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1345,7 +1345,7 @@ void FlexCounter::startFlexCounterThread(void)
 
     m_runFlexCounterThread = true;
 
-    m_flexCounterThread = std::unique_ptr<std::thread>(new std::thread(&FlexCounter::flexCounterThread, this));
+    m_flexCounterThread = std::make_shared<std::thread>(&FlexCounter::flexCounterThread, this);
 
     SWSS_LOG_INFO("Flex Counter thread started");
 }
@@ -1368,7 +1368,7 @@ void FlexCounter::endFlexCounterThread(void)
 
     if (m_flexCounterThread != nullptr)
     {
-        std::unique_ptr<std::thread> fcThread = std::move(m_flexCounterThread);
+        std::shared_ptr<std::thread> fcThread = std::move(m_flexCounterThread);
         lkMgr.unlock();
         SWSS_LOG_INFO("Wait for Flex Counter thread to end");
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1310,7 +1310,6 @@ void FlexCounter::flexCounterThread(void)
         }
         while (!m_enable || isEmpty() || (m_pollInterval == 0))
         {
-            SWSS_LOG_ERROR("Flex counter thread FC %s, condition wait", m_instanceId.c_str());
             if (!m_runFlexCounterThread)
             {
                 return;
@@ -1328,7 +1327,6 @@ void FlexCounter::flexCounterThread(void)
 
         lkMgr.unlock();
 
-        SWSS_LOG_ERROR("End of flex counter thread FC %s, took %d ms", m_instanceId.c_str(), delay);
         SWSS_LOG_DEBUG("End of flex counter thread FC %s, took %d ms", m_instanceId.c_str(), delay);
         std::unique_lock<std::mutex> lk(m_mtxSleep);
         m_cvSleep.wait_for(lk, std::chrono::milliseconds(m_pollInterval - correction));

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1017,7 +1017,7 @@ void FlexCounter::collectCounters(
     }
 
     // Collect stats for every registered router interface
-    for (const auto &kv: rifCounterIdsMap)
+    for (const auto &kv: m_rifCounterIdsMap)
     {
         const auto &rifVid = kv.first;
         const auto &rifId = kv.second->rifId;

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -207,7 +207,7 @@ class FlexCounter
         std::set<std::string> m_bufferPoolPlugins;
 
         bool m_runFlexCounterThread = false;
-        std::unique_ptr<std::thread> m_flexCounterThread = nullptr;
+        std::shared_ptr<std::thread> m_flexCounterThread = nullptr;
         std::mutex m_mtxSleep;
         std::condition_variable m_cvSleep;
 

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -181,11 +181,13 @@ class FlexCounter
         std::set<std::string> m_portPlugins;
         std::set<std::string> m_priorityGroupPlugins;
 
-        std::atomic_bool m_runFlexCounterThread = { false };
-        std::shared_ptr<std::thread> m_flexCounterThread = nullptr;
+        bool m_runFlexCounterThread = false;
+        std::unique_ptr<std::thread> m_flexCounterThread = nullptr;
         std::mutex m_mtxSleep;
         std::condition_variable m_cvSleep;
 
+        std::mutex m_mtx;
+        std::condition_variable m_pollCond;
         uint32_t m_pollInterval = 0;
         std::string m_instanceId;
         sai_stats_mode_t m_statsMode;


### PR DESCRIPTION
In the current implementation, when  FLEX_COUNTER_STATUS is set to disable, which can be issued by counterpoll disable cli, a flex counter thread will still wake up every polling interval, though skipping the actual collectCounters() and runPlugins() operations. 

The main drive of the PR is to put the polling thread to a complete sleep in the above situation to save CPU cycles, and hence to improve the scalability of flex counter polling architecture in general.

To that end, the following changes are made to pave the way and for further optimization purpose:

1\) Introduce a per-thread lock, together with a condition variable, to enable the full sleep behavior when FLEX_COUNTER_STATUS is set to disable, the status of which is maintained by data member m_enable per flex counter object. 

2\) Remove acquiring the global lock g_mutex to configure a flex counter object in the syncd main thread context. This is because each flex counter object maintains its own configuration setting, counter/attribute id list, plugin list, etc. to be accessed only in either the syncd main thread context or its own flex counter polling thread context.

With the introduction of per-thread lock, the scope of the data access serialization can be reduced from the unnecessarily global wise, among all flex counter polling threads and the syncd main thread, to per flex counter object wise, between only the syncd main thread and the corresponding flex counter polling thread.

3\) Remove acquiring the global lock g_mutex and remove copying the plugin list and/or the counter/attribute id list in the flex counter polling thread context as the acquisition of the per-thread lock before and during calling collectCounters() and runPlugins() ensures the correct synchronization to data member access.

4\) Change the memory management entity of the thread object from shared_ptr to unique_ptr in the flex counter object to avoid its join() function to be called more than once in the destruction phase. Because each thread can only be joined once, it does not make sense to use shared_ptr to manage the thread object memory, but merely creates the opportunity to have join() function being called multiple times if the thread object happens to be referenced by multiple shared_ptr objects.

5\) Change m_runFlexCounterThread from atomic_bool to a regular bool type.





Validation:

counterpoll watermark enable

May 26 23:38:04.968123 str-dx010-acs-1 ERR swss#orchagent: :- generateBufferPoolWatermarkCounterIdList: generateBufferPoolCounterIdList: Buffer pool COUNTER_ID_LIST already generated
...
May 26 23:38:07.129572 str-dx010-acs-1 ERR syncd#syncd: brcm_sai_get_buffer_pool_stats:718 Ingress buffer pool 0x1800000001: bst value: 416
May 26 23:38:07.134184 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC BUFFER_POOL_WATERMARK_STAT_COUNTER, took 47 ms
May 26 23:38:07.641090 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC QUEUE_WATERMARK_STAT_COUNTER, took 702 ms
...
May 26 23:38:08.452268 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PG_WATERMARK_STAT_COUNTER, took 1512 ms
...
May 26 23:38:17.094576 str-dx010-acs-1 ERR syncd#syncd: brcm_sai_get_buffer_pool_stats:718 Ingress buffer pool 0x1800000001: bst value: 208
May 26 23:38:17.097077 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC BUFFER_POOL_WATERMARK_STAT_COUNTER, took 9 ms
...
May 26 23:38:17.765136 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC QUEUE_WATERMARK_STAT_COUNTER, took 825 ms
May 26 23:38:18.413790 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PG_WATERMARK_STAT_COUNTER, took 1473 ms
...

counterpoll watermark disable
May 26 23:38:26.940287 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: Flex counter thread FC QUEUE_WATERMARK_STAT_COUNTER, condition wait
May 26 23:38:26.940802 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: Flex counter thread FC PG_WATERMARK_STAT_COUNTER, condition wait
May 26 23:38:27.088245 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: Flex counter thread FC BUFFER_POOL_WATERMARK_STAT_COUNTER, condition wait
...

counterpoll watermark enable
May 26 23:43:07.336258 str-dx010-acs-1 ERR swss#orchagent: :- generateBufferPoolWatermarkCounterIdList: generateBufferPoolCounterIdList: Buffer pool COUNTER_ID_LIST already generated
May 26 23:43:07.564374 str-dx010-acs-1 ERR syncd#syncd: brcm_sai_get_buffer_pool_stats:718 Ingress buffer pool 0x1800000001: bst value: 416
May 26 23:43:07.567735 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC BUFFER_POOL_WATERMARK_STAT_COUNTER, took 280479 ms
...
May 26 23:43:07.960222 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC QUEUE_WATERMARK_STAT_COUNTER, took 281019 ms
May 26 23:43:08.776857 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PG_WATERMARK_STAT_COUNTER, took 281836 ms
...
May 26 23:43:17.157729 str-dx010-acs-1 ERR syncd#syncd: brcm_sai_get_buffer_pool_stats:718 Ingress buffer pool 0x1800000001: bst value: 208
May 26 23:43:17.163423 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC BUFFER_POOL_WATERMARK_STAT_COUNTER, took 74 ms
May 26 23:43:17.732528 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC QUEUE_WATERMARK_STAT_COUNTER, took 791 ms
...
May 26 23:43:18.381651 str-dx010-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PG_WATERMARK_STAT_COUNTER, took 1440 ms