### PR TITLE
Full sleep wait change for PFC watchdog

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -836,16 +836,29 @@ bool FlexCounter::isEmpty()
 {
     SWSS_LOG_ENTER();
 
+    return isIdsEmpty() && isPluginsEmpty();
+}
+
+bool FlexCounter::isIdsEmpty()
+{
+    SWSS_LOG_ENTER();
+
     return m_priorityGroupCounterIdsMap.empty() &&
            m_priorityGroupAttrIdsMap.empty() &&
-           m_priorityGroupPlugins.empty() &&
            m_queueCounterIdsMap.empty() &&
+           m_queueAttrIdsMap.empty() &&
            m_portCounterIdsMap.empty() &&
            m_rifCounterIdsMap.empty() &&
-           m_queueAttrIdsMap.empty() &&
+           m_bufferPoolCounterIdsMap.empty();
+}
+
+bool FlexCounter::isPluginsEmpty()
+{
+    SWSS_LOG_ENTER();
+
+    return m_priorityGroupPlugins.empty() &&
            m_queuePlugins.empty() &&
            m_portPlugins.empty() &&
-           m_bufferPoolCounterIdsMap.empty() &&
            m_bufferPoolPlugins.empty();
 }
 
@@ -1308,7 +1321,7 @@ void FlexCounter::flexCounterThread(void)
         {
             return;
         }
-        while (!m_enable || isEmpty() || (m_pollInterval == 0))
+        while (!m_enable || isIdsEmpty() || (m_pollInterval == 0))
         {
             if (!m_runFlexCounterThread)
             {
@@ -1347,6 +1360,7 @@ void FlexCounter::startFlexCounterThread(void)
 
     m_flexCounterThread = std::make_shared<std::thread>(&FlexCounter::flexCounterThread, this);
 
+    SWSS_LOG_ERROR("Flex Counter thread started");
     SWSS_LOG_INFO("Flex Counter thread started");
 }
 
@@ -1370,11 +1384,13 @@ void FlexCounter::endFlexCounterThread(void)
     {
         std::shared_ptr<std::thread> fcThread = std::move(m_flexCounterThread);
         lkMgr.unlock();
+        SWSS_LOG_ERROR("Wait for Flex Counter thread to end");
         SWSS_LOG_INFO("Wait for Flex Counter thread to end");
 
         fcThread->join();
     }
 
+    SWSS_LOG_ERROR("Flex Counter thread ended");
     SWSS_LOG_INFO("Flex Counter thread ended");
 }
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -836,10 +836,10 @@ bool FlexCounter::isEmpty()
 {
     SWSS_LOG_ENTER();
 
-    return isIdsEmpty() && isPluginsEmpty();
+    return allIdsEmpty() && allPluginsEmpty();
 }
 
-bool FlexCounter::isIdsEmpty()
+bool FlexCounter::allIdsEmpty()
 {
     SWSS_LOG_ENTER();
 
@@ -852,7 +852,7 @@ bool FlexCounter::isIdsEmpty()
            m_bufferPoolCounterIdsMap.empty();
 }
 
-bool FlexCounter::isPluginsEmpty()
+bool FlexCounter::allPluginsEmpty()
 {
     SWSS_LOG_ENTER();
 
@@ -1321,7 +1321,7 @@ void FlexCounter::flexCounterThread(void)
         {
             return;
         }
-        while (!m_enable || isIdsEmpty() || (m_pollInterval == 0))
+        while (!m_enable || allIdsEmpty() || (m_pollInterval == 0))
         {
             if (!m_runFlexCounterThread)
             {

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1360,7 +1360,6 @@ void FlexCounter::startFlexCounterThread(void)
 
     m_flexCounterThread = std::make_shared<std::thread>(&FlexCounter::flexCounterThread, this);
 
-    SWSS_LOG_ERROR("Flex Counter thread started");
     SWSS_LOG_INFO("Flex Counter thread started");
 }
 
@@ -1384,13 +1383,11 @@ void FlexCounter::endFlexCounterThread(void)
     {
         std::shared_ptr<std::thread> fcThread = std::move(m_flexCounterThread);
         lkMgr.unlock();
-        SWSS_LOG_ERROR("Wait for Flex Counter thread to end");
         SWSS_LOG_INFO("Wait for Flex Counter thread to end");
 
         fcThread->join();
     }
 
-    SWSS_LOG_ERROR("Flex Counter thread ended");
     SWSS_LOG_INFO("Flex Counter thread ended");
 }
 

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -190,8 +190,8 @@ class FlexCounter
         bool isRifCounterSupported(sai_router_interface_stat_t counter) const;
         bool isBufferPoolCounterSupported(sai_buffer_pool_stat_t counter) const;
         bool isEmpty();
-        bool isIdsEmpty();
-        bool isPluginsEmpty();
+        bool allIdsEmpty();
+        bool allPluginsEmpty();
 
         // Key is a Virtual ID
         std::map<sai_object_id_t, std::shared_ptr<PortCounterIds>> m_portCounterIdsMap;

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -190,6 +190,8 @@ class FlexCounter
         bool isRifCounterSupported(sai_router_interface_stat_t counter) const;
         bool isBufferPoolCounterSupported(sai_buffer_pool_stat_t counter) const;
         bool isEmpty();
+        bool isIdsEmpty();
+        bool isPluginsEmpty();
 
         // Key is a Virtual ID
         std::map<sai_object_id_t, std::shared_ptr<PortCounterIds>> m_portCounterIdsMap;


### PR DESCRIPTION
When issuing 'pfcwd stop' cli to stop PFC watchdog, it only clears the counter id list for physical ports under the hood, leaving lua script plugins still installed and ieEmpty() returns false.

So even when PFC watchdog is stopped, the flex counter thread would wake up every 200 ms.

Jun  4 17:58:51.273413 str-a7050-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PFC_WD, took 33 ms
Jun  4 17:58:51.471288 str-a7050-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PFC_WD, took 30 ms
Jun  4 17:58:51.672930 str-a7050-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PFC_WD, took 31 ms
Jun  4 17:58:51.882972 str-a7050-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PFC_WD, took 40 ms
Jun  4 17:58:52.074862 str-a7050-acs-1 ERR syncd#syncd: :- flexCounterThread: End of flex counter thread FC PFC_WD, took 31 ms


This PR is to address the above observation:

Fine granularize the isEmpty() to two functions---isIdsEmpty() and isPluginsEmpty(), and use the emptiness check of the counter id list, isIdsEmpty(), as the criteria for full sleep wait. This approach is generally valid because current flex counter use cases would have the presence of non-empty counter id list to be meaningful, followed by an optional execution of the Lua script plugins if they are installed.



Validated on brcm dut

Signed-off-by: Wenda Ni <wenni@microsoft.com>