### PR TITLE
[syncd_init_common.sh] fix fast reboot backwards compatibility

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -24,16 +24,14 @@ fi
 # Use temporary view between init and apply
 CMD_ARGS+=" -u"
 
-BOOT_TYPE="$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)"
-
-case "$BOOT_TYPE" in
-  fast-reboot)
-     FAST_REBOOT='yes'
-    ;;
-  fastfast)
+case "$(cat /proc/cmdline)" in
+  *fastfast*)
     if [ -e /var/warmboot/warm-starting ]; then
         FASTFAST_REBOOT='yes'
     fi
+    ;;
+  *fast*)
+     FAST_REBOOT='yes'
     ;;
   *)
      FAST_REBOOT='no'

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -25,12 +25,12 @@ fi
 CMD_ARGS+=" -u"
 
 case "$(cat /proc/cmdline)" in
-  *fastfast*)
+  *SONIC_BOOT_TYPE=fastfast*)
     if [ -e /var/warmboot/warm-starting ]; then
         FASTFAST_REBOOT='yes'
     fi
     ;;
-  *fast*)
+  *SONIC_BOOT_TYPE=fast*|fast-reboot*)
      FAST_REBOOT='yes'
     ;;
   *)


### PR DESCRIPTION
We should handle both cases for backward-compatible with 201803:
 - fast-reboot
 - SONIC_BOOT_TYPE=fast-reboot

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>