### PR TITLE
Fix a bug in parsing kernel argument of fast-reboot

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -30,7 +30,7 @@ case "$(cat /proc/cmdline)" in
         FASTFAST_REBOOT='yes'
     fi
     ;;
-  *SONIC_BOOT_TYPE=fast*|fast-reboot*)
+  *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
      FAST_REBOOT='yes'
     ;;
   *)


### PR DESCRIPTION
It will handle the kernel argument on 201803 image correctly.
The bug was introduced by https://github.com/Azure/sonic-sairedis/pull/480
