### PR TITLE
Per buffer pool watermark polling mode

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2902,6 +2902,7 @@ void processFlexCounterGroupEvent(
         {
             if (field == POLL_INTERVAL_FIELD)
             {
+                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::setPollInterval(stoi(value), groupName);
             }
             else if (field == QUEUE_PLUGIN_FIELD)
@@ -2930,6 +2931,7 @@ void processFlexCounterGroupEvent(
             }
             else if (field == BUFFER_POOL_PLUGIN_FIELD)
             {
+                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 auto shaStrings = swss::tokenize(value, ',');
                 for (const auto &sha : shaStrings)
                 {
@@ -2938,10 +2940,12 @@ void processFlexCounterGroupEvent(
             }
             else if (field == FLEX_COUNTER_STATUS_FIELD)
             {
+                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::updateFlexCounterStatus(value, groupName);
             }
             else if (field == STATS_MODE_FIELD)
             {
+                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::updateFlexCounterStatsMode(value, groupName);
             }
             else

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3024,6 +3024,8 @@ void processFlexCounterEvent(
     }
 
     const auto values = kfvFieldsValues(kco);
+    vector<string> counterIds;
+    string statsMode;
     for (const auto& valuePair : values)
     {
         const auto field = fvField(valuePair);
@@ -3031,7 +3033,7 @@ void processFlexCounterEvent(
 
         if (op == SET_COMMAND)
         {
-            auto idStrings  = swss::tokenize(value, ',');
+            auto idStrings = swss::tokenize(value, ',');
 
             if (objectType == SAI_OBJECT_TYPE_PORT && field == PORT_COUNTER_ID_LIST)
             {
@@ -3107,21 +3109,30 @@ void processFlexCounterEvent(
             }
             else if (objectType == SAI_OBJECT_TYPE_BUFFER_POOL && field == BUFFER_POOL_COUNTER_ID_LIST)
             {
-                std::vector<sai_buffer_pool_stat_t> bufferPoolCounterIds;
-                for (const auto &str : idStrings)
-                {
-                    sai_buffer_pool_stat_t stat;
-                    sai_deserialize_buffer_pool_stat(str.c_str(), &stat);
-                    bufferPoolCounterIds.push_back(stat);
-                }
-
-                FlexCounter::setBufferPoolCounterList(vid, rid, groupName, bufferPoolCounterIds);
+                counterIds = idStrings;
+            }
+            else if (objectType == SAI_OBJECT_TYPE_BUFFER_POOL && field == STATS_MODE_FIELD)
+            {
+                statsMode = value;
             }
             else
             {
                 SWSS_LOG_ERROR("Object type and field combination is not supported, object type %s, field %s", objectTypeStr.c_str(), field.c_str());
             }
         }
+    }
+
+    if (objectType == SAI_OBJECT_TYPE_BUFFER_POOL && counterIds.size())
+    {
+        std::vector<sai_buffer_pool_stat_t> bufferPoolCounterIds;
+        for (const auto &str : counterIds)
+        {
+            sai_buffer_pool_stat_t stat;
+            sai_deserialize_buffer_pool_stat(str.c_str(), &stat);
+            bufferPoolCounterIds.push_back(stat);
+        }
+
+        FlexCounter::setBufferPoolCounterList(vid, rid, groupName, bufferPoolCounterIds, statsMode);
     }
 }
 

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2902,7 +2902,6 @@ void processFlexCounterGroupEvent(
         {
             if (field == POLL_INTERVAL_FIELD)
             {
-                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::setPollInterval(stoi(value), groupName);
             }
             else if (field == QUEUE_PLUGIN_FIELD)
@@ -2931,7 +2930,6 @@ void processFlexCounterGroupEvent(
             }
             else if (field == BUFFER_POOL_PLUGIN_FIELD)
             {
-                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 auto shaStrings = swss::tokenize(value, ',');
                 for (const auto &sha : shaStrings)
                 {
@@ -2940,12 +2938,10 @@ void processFlexCounterGroupEvent(
             }
             else if (field == FLEX_COUNTER_STATUS_FIELD)
             {
-                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::updateFlexCounterStatus(value, groupName);
             }
             else if (field == STATS_MODE_FIELD)
             {
-                SWSS_LOG_ERROR("groupName: %s, field: %s, value: %s", groupName.c_str(), field.c_str(), value.c_str());
                 FlexCounter::updateFlexCounterStatsMode(value, groupName);
             }
             else

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3024,8 +3024,8 @@ void processFlexCounterEvent(
     }
 
     const auto values = kfvFieldsValues(kco);
-    vector<string> counterIds;
-    string statsMode;
+    std::vector<std::string> counterIds;
+    std::string statsMode;
     for (const auto& valuePair : values)
     {
         const auto field = fvField(valuePair);

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -61,8 +61,9 @@ FlexCounter::RifCounterIds::RifCounterIds(
 
 FlexCounter::BufferPoolCounterIds::BufferPoolCounterIds(
         _In_ sai_object_id_t bufferPool,
-        _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds):
-    bufferPoolId(bufferPool), bufferPoolCounterIds(bufferPoolIds), bufferPoolStatsMode(statsMode)
+        _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds,
+        _In_ sai_stats_mode_t statsMode):
+    bufferPoolId(bufferPool), bufferPoolStatsMode(statsMode), bufferPoolCounterIds(bufferPoolIds)
 {
     SWSS_LOG_ENTER();
 }
@@ -472,21 +473,21 @@ void FlexCounter::setBufferPoolCounterList(
     FlexCounter &fc = getInstance(instanceId);
 
     sai_stats_mode_t bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
-    switch (statsMode)
+    if (statsMode == STATS_MODE_READ_AND_CLEAR)
     {
-        case STATS_MODE_READ_AND_CLEAR:
-            bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
-            SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
-                mode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
-            break;
-        case STATS_MODE_READ:
-            bufferPoolStatsMode = SAI_STATS_MODE_READ;
-            SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
-                mode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
-            break;
-        default:
-            SWSS_LOG_WARN("Stats mode %s not supported for flex counter. Using STATS_MODE_READ_AND_CLEAR", statsMode.c_str());
-            break;
+        bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
+        SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
+            statsMode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
+    }
+    else if (statsMode == STATS_MODE_READ)
+    {
+        bufferPoolStatsMode = SAI_STATS_MODE_READ;
+        SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
+            statsMode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
+    }
+    else
+    {
+        SWSS_LOG_WARN("Stats mode %s not supported for flex counter. Using STATS_MODE_READ_AND_CLEAR", statsMode.c_str());
     }
 
     fc.saiUpdateSupportedBufferPoolCounters(bufferPoolId, counterIds, bufferPoolStatsMode);
@@ -1213,7 +1214,7 @@ void FlexCounter::collectCounters(
         const auto &bufferPoolVid = it.first;
         const auto &bufferPoolId = it.second->bufferPoolId;
         const auto &bufferPoolCounterIds = it.second->bufferPoolCounterIds;
-        const auto &bufferPoolStatsMode = it.second>bufferPoolStatsMode;
+        const auto &bufferPoolStatsMode = it.second->bufferPoolStatsMode;
 
         std::vector<uint64_t> bufferPoolStats(bufferPoolCounterIds.size());
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -476,14 +476,10 @@ void FlexCounter::setBufferPoolCounterList(
     if (statsMode == STATS_MODE_READ_AND_CLEAR)
     {
         bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
-        SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
-            statsMode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
     }
     else if (statsMode == STATS_MODE_READ)
     {
         bufferPoolStatsMode = SAI_STATS_MODE_READ;
-        SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
-            statsMode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
     }
     else
     {

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -62,7 +62,7 @@ FlexCounter::RifCounterIds::RifCounterIds(
 FlexCounter::BufferPoolCounterIds::BufferPoolCounterIds(
         _In_ sai_object_id_t bufferPool,
         _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds):
-    bufferPoolId(bufferPool), bufferPoolCounterIds(bufferPoolIds)
+    bufferPoolId(bufferPool), bufferPoolCounterIds(bufferPoolIds), bufferPoolStatsMode(statsMode)
 {
     SWSS_LOG_ENTER();
 }
@@ -463,14 +463,33 @@ void FlexCounter::setRifCounterList(
 void FlexCounter::setBufferPoolCounterList(
         _In_ sai_object_id_t bufferPoolVid,
         _In_ sai_object_id_t bufferPoolId,
-        _In_ std::string instanceId,
-        _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds)
+        _In_ const std::string &instanceId,
+        _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds,
+        _In_ const std::string &statsMode)
 {
     SWSS_LOG_ENTER();
 
     FlexCounter &fc = getInstance(instanceId);
 
-    fc.saiUpdateSupportedBufferPoolCounters(bufferPoolId, counterIds);
+    sai_stats_mode_t bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
+    switch (statsMode)
+    {
+        case STATS_MODE_READ_AND_CLEAR:
+            bufferPoolStatsMode = SAI_STATS_MODE_READ_AND_CLEAR;
+            SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
+                mode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
+            break;
+        case STATS_MODE_READ:
+            bufferPoolStatsMode = SAI_STATS_MODE_READ;
+            SWSS_LOG_ERROR("Set stats mode %s for FC %s buffer pool %s",
+                mode.c_str(), instanceId.c_str(), sai_serialize_object_id(bufferPoolId).c_str());
+            break;
+        default:
+            SWSS_LOG_WARN("Stats mode %s not supported for flex counter. Using STATS_MODE_READ_AND_CLEAR", statsMode.c_str());
+            break;
+    }
+
+    fc.saiUpdateSupportedBufferPoolCounters(bufferPoolId, counterIds, bufferPoolStatsMode);
 
     // Filter unsupported counters
     std::vector<sai_buffer_pool_stat_t> supportedIds;
@@ -504,7 +523,7 @@ void FlexCounter::setBufferPoolCounterList(
         return;
     }
 
-    auto bufferPoolCounterIds = std::make_shared<BufferPoolCounterIds>(bufferPoolId, supportedIds);
+    auto bufferPoolCounterIds = std::make_shared<BufferPoolCounterIds>(bufferPoolId, supportedIds, bufferPoolStatsMode);
     fc.m_bufferPoolCounterIdsMap.emplace(bufferPoolVid, bufferPoolCounterIds);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
@@ -1194,6 +1213,7 @@ void FlexCounter::collectCounters(
         const auto &bufferPoolVid = it.first;
         const auto &bufferPoolId = it.second->bufferPoolId;
         const auto &bufferPoolCounterIds = it.second->bufferPoolCounterIds;
+        const auto &bufferPoolStatsMode = it.second>bufferPoolStatsMode;
 
         std::vector<uint64_t> bufferPoolStats(bufferPoolCounterIds.size());
 
@@ -1215,22 +1235,22 @@ void FlexCounter::collectCounters(
                     sai_serialize_status(status).c_str());
             continue;
         }
-        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR)
+        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR || bufferPoolStatsMode == SAI_STATS_MODE_READ_AND_CLEAR)
         {
             status = sai_metadata_sai_buffer_api->clear_buffer_pool_stats(
                             bufferPoolId,
                             static_cast<uint32_t>(bufferPoolCounterIds.size()),
                             reinterpret_cast<const sai_stat_id_t *>(bufferPoolCounterIds.data()));
-        }
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            // Because of stat pre-qualification in setting the buffer pool counter list,
-            // it is less likely that we will get a failure return here in clearing the stats
-            SWSS_LOG_ERROR("%s: failed to clear stats of buffer pool %s, rv: %s",
-                    m_instanceId.c_str(),
-                    sai_serialize_object_id(bufferPoolId).c_str(),
-                    sai_serialize_status(status).c_str());
-            continue;
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                // Because of stat pre-qualification in setting the buffer pool counter list,
+                // it is less likely that we will get a failure return here in clearing the stats
+                SWSS_LOG_ERROR("%s: failed to clear stats of buffer pool %s, rv: %s",
+                        m_instanceId.c_str(),
+                        sai_serialize_object_id(bufferPoolId).c_str(),
+                        sai_serialize_status(status).c_str());
+                continue;
+            }
         }
 
         // Write counter values to DB table
@@ -1529,7 +1549,8 @@ void FlexCounter::saiUpdateSupportedRifCounters(sai_object_id_t rifId)
 
 void FlexCounter::saiUpdateSupportedBufferPoolCounters(
         _In_ sai_object_id_t bufferPoolId,
-        _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds)
+        _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds,
+        _In_ sai_stats_mode_t statsMode)
 {
     SWSS_LOG_ENTER();
 
@@ -1550,7 +1571,7 @@ void FlexCounter::saiUpdateSupportedBufferPoolCounters(
             continue;
         }
 
-        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR)
+        if (m_statsMode == SAI_STATS_MODE_READ_AND_CLEAR || statsMode == SAI_STATS_MODE_READ_AND_CLEAR)
         {
             status = sai_metadata_sai_buffer_api->clear_buffer_pool_stats(bufferPoolId, 1, (const sai_stat_id_t *)&counterId);
             if (status != SAI_STATUS_SUCCESS)

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -41,7 +41,7 @@ class FlexCounter
                 _In_ sai_object_id_t bufferPoolVid,
                 _In_ sai_object_id_t bufferPoolId,
                 _In_ const std::string &instanceId,
-                _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds
+                _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds,
                 _In_ const std::string &statsMode = "");
         static void setQueueAttrList(
                 _In_ sai_object_id_t queueVid,
@@ -144,8 +144,8 @@ class FlexCounter
         {
             BufferPoolCounterIds(
                 _In_ sai_object_id_t bufferPool,
-                _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds
-                _IN_ statsMode);
+                _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds,
+                _In_ sai_stats_mode_t statsMode);
 
             sai_object_id_t bufferPoolId;
             sai_stats_mode_t bufferPoolStatsMode;

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -146,6 +146,7 @@ class FlexCounter
                 _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds);
 
             sai_object_id_t bufferPoolId;
+            sai_stats_mode_t statsMode;
             std::vector<sai_buffer_pool_stat_t> bufferPoolCounterIds;
         };
 

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -40,8 +40,9 @@ class FlexCounter
         static void setBufferPoolCounterList(
                 _In_ sai_object_id_t bufferPoolVid,
                 _In_ sai_object_id_t bufferPoolId,
-                _In_ std::string instanceId,
-                _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds);
+                _In_ const std::string &instanceId,
+                _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds
+                _In_ const std::string &statsMode = "");
         static void setQueueAttrList(
                 _In_ sai_object_id_t queueVid,
                 _In_ sai_object_id_t queueId,
@@ -143,10 +144,11 @@ class FlexCounter
         {
             BufferPoolCounterIds(
                 _In_ sai_object_id_t bufferPool,
-                _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds);
+                _In_ const std::vector<sai_buffer_pool_stat_t> &bufferPoolIds
+                _IN_ statsMode);
 
             sai_object_id_t bufferPoolId;
-            sai_stats_mode_t statsMode;
+            sai_stats_mode_t bufferPoolStatsMode;
             std::vector<sai_buffer_pool_stat_t> bufferPoolCounterIds;
         };
 
@@ -184,7 +186,9 @@ class FlexCounter
         void saiUpdateSupportedQueueCounters(sai_object_id_t queueId, const std::vector<sai_queue_stat_t> &counterIds);
         void saiUpdateSupportedPriorityGroupCounters(sai_object_id_t priorityGroupId, const std::vector<sai_ingress_priority_group_stat_t> &counterIds);
         void saiUpdateSupportedRifCounters(sai_object_id_t rifId);
-        void saiUpdateSupportedBufferPoolCounters(sai_object_id_t bufferPoolId, const std::vector<sai_buffer_pool_stat_t> &counterIds);
+        void saiUpdateSupportedBufferPoolCounters(sai_object_id_t bufferPoolId,
+                                                  const std::vector<sai_buffer_pool_stat_t> &counterIds,
+                                                  sai_stats_mode_t statsMode = SAI_STATS_MODE_READ_AND_CLEAR);
         bool isPortCounterSupported(sai_port_stat_t counter) const;
         bool isQueueCounterSupported(sai_queue_stat_t counter) const;
         bool isPriorityGroupCounterSupported(sai_ingress_priority_group_stat_t counter) const;


### PR DESCRIPTION
Add STATS_MODE field parsing when oid in FLEX_COUTER_TABLE key is SAI_OBJECT_TYPE_BUFFER_POOL.

Use READ_AND_CLEAR mode when either global stats polling mode or the particular buffer pool stats polling mode is READ_AND_CLEAR.

In the opposite, use READ mode (no stats clear) only when both global and per buffer pool stats polling mode are READ.