### PR TITLE
Fixed conditional operator

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -59,9 +59,9 @@ function set_start_type()
 {
     if [ x"$WARM_BOOT" == x"true" ]; then
         CMD_ARGS+=" -t warm"
-    elif [ $FAST_REBOOT == "yes" ]; then
+    elif [ x"$FAST_REBOOT" == x"yes" ]; then
         CMD_ARGS+=" -t fast"
-    elif [ $FASTFAST_REBOOT == "yes" ]; then
+    elif [ x"$FASTFAST_REBOOT" == x"yes" ]; then
         CMD_ARGS+=" -t fastfast"
     fi
 }


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

Fixed:
Jul 17 15:29:42.645392 sonic INFO syncd#supervisord: syncd /usr/bin/syncd_init_common.sh: line 62: [: ==: unary operator expected