### PR TITLE
Use pointer to member function to reduce the footprint of collectCounters()

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -132,9 +132,9 @@ void FlexCounter::updateFlexCounterStatsMode(
     }
  }
 
-void FlexCounter::addCollectCountersHandler(const std::string &key, collect_counters_handler_t)
+void FlexCounter::addCollectCountersHandler(const std::string &key, const collect_counters_handler_t &handler)
 {
-    m_collectCountersHandlers.emplace(key, collect_counters_handler_t);
+    m_collectCountersHandlers.emplace(key, handler);
 }
 
 void FlexCounter::removeCollectCountersHandler(const std::string &key)

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -134,11 +134,15 @@ void FlexCounter::updateFlexCounterStatsMode(
 
 void FlexCounter::addCollectCountersHandler(const std::string &key, const collect_counters_handler_t &handler)
 {
+    SWSS_LOG_ENTER();
+
     m_collectCountersHandlers.emplace(key, handler);
 }
 
 void FlexCounter::removeCollectCountersHandler(const std::string &key)
 {
+    SWSS_LOG_ENTER();
+
     m_collectCountersHandlers.erase(key);
 }
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -997,6 +997,8 @@ void FlexCounter::collectCounters(
 
 void FlexCounter::collectPortCounters(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect stats for every registered port
     for (const auto &kv: m_portCounterIdsMap)
     {
@@ -1036,6 +1038,8 @@ void FlexCounter::collectPortCounters(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectQueueCounters(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect stats for every registered queue
     for (const auto &kv: m_queueCounterIdsMap)
     {
@@ -1095,6 +1099,8 @@ void FlexCounter::collectQueueCounters(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectQueueAttrs(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect attrs for every registered queue
     for (const auto &kv: m_queueAttrIdsMap)
     {
@@ -1140,6 +1146,8 @@ void FlexCounter::collectQueueAttrs(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectPriorityGroupCounters(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect stats for every registered ingress priority group
     for (const auto &kv: m_priorityGroupCounterIdsMap)
     {
@@ -1192,6 +1200,8 @@ void FlexCounter::collectPriorityGroupCounters(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectPriorityGroupAttrs(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect attrs for every registered priority group
     for (const auto &kv: m_priorityGroupAttrIdsMap)
     {
@@ -1237,6 +1247,8 @@ void FlexCounter::collectPriorityGroupAttrs(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectRifCounters(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect stats for every registered router interface
     for (const auto &kv: m_rifCounterIdsMap)
     {
@@ -1276,6 +1288,8 @@ void FlexCounter::collectRifCounters(_In_ swss::Table &countersTable)
 
 void FlexCounter::collectBufferPoolCounters(_In_ swss::Table &countersTable)
 {
+    SWSS_LOG_ENTER();
+
     // Collect stats for every registered buffer pool
     for (const auto &it : m_bufferPoolCounterIdsMap)
     {

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -569,7 +569,7 @@ void FlexCounter::removePort(
     }
 
     fc.m_portCounterIdsMap.erase(it);
-    if (!fc.m_portCounterIdsMap.size())
+    if (fc.m_portCounterIdsMap.empty())
     {
         fc.m_collectCountersHandlers.erase(PORT_COUNTER_ID_LIST);
     }
@@ -597,7 +597,7 @@ void FlexCounter::removeQueue(
     if (counterIter != fc.m_queueCounterIdsMap.end())
     {
         fc.m_queueCounterIdsMap.erase(counterIter);
-        if (!fc.m_queueCounterIdsMap.size())
+        if (fc.m_queueCounterIdsMap.empty())
         {
             fc.m_collectCountersHandlers.erase(QUEUE_COUNTER_ID_LIST);
         }
@@ -608,7 +608,7 @@ void FlexCounter::removeQueue(
     if (attrIter != fc.m_queueAttrIdsMap.end())
     {
         fc.m_queueAttrIdsMap.erase(attrIter);
-        if (!fc.m_queueAttrIdsMap.size())
+        if (fc.m_queueAttrIdsMap.empty())
         {
             fc.m_collectCountersHandlers.erase(QUEUE_ATTR_ID_LIST);
         }
@@ -644,7 +644,7 @@ void FlexCounter::removePriorityGroup(
     if (counterIter != fc.m_priorityGroupCounterIdsMap.end())
     {
         fc.m_priorityGroupCounterIdsMap.erase(counterIter);
-        if (!fc.m_priorityGroupCounterIdsMap.size())
+        if (fc.m_priorityGroupCounterIdsMap.empty())
         {
             fc.m_collectCountersHandlers.erase(PG_COUNTER_ID_LIST);
         }
@@ -655,7 +655,7 @@ void FlexCounter::removePriorityGroup(
     if (attrIter != fc.m_priorityGroupAttrIdsMap.end())
     {
         fc.m_priorityGroupAttrIdsMap.erase(attrIter);
-        if (!fc.m_priorityGroupAttrIdsMap.size())
+        if (fc.m_priorityGroupAttrIdsMap.empty())
         {
             fc.m_collectCountersHandlers.erase(PG_ATTR_ID_LIST);
         }
@@ -701,7 +701,7 @@ void FlexCounter::removeRif(
     }
 
     fc.m_rifCounterIdsMap.erase(it);
-    if (!fc.m_rifCounterIdsMap.size())
+    if (fc.m_rifCounterIdsMap.empty())
     {
         fc.m_collectCountersHandlers.erase(RIF_COUNTER_ID_LIST);
     }
@@ -729,7 +729,7 @@ void FlexCounter::removeBufferPool(
     if (it != fc.m_bufferPoolCounterIdsMap.end())
     {
         fc.m_bufferPoolCounterIdsMap.erase(it);
-        if (!fc.m_bufferPoolCounterIdsMap.size())
+        if (fc.m_bufferPoolCounterIdsMap.empty())
         {
             fc.m_collectCountersHandlers.erase(BUFFER_POOL_COUNTER_ID_LIST);
         }

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -188,7 +188,7 @@ void FlexCounter::setPortCounterList(
     auto portCounterIds = std::make_shared<PortCounterIds>(portId, supportedIds);
     fc.m_portCounterIdsMap.emplace(portVid, portCounterIds);
 
-    fc.m_collectCountersHandlers.insert(collectPortCounters);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPortCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -265,7 +265,7 @@ void FlexCounter::setQueueCounterList(
     auto queueCounterIds = std::make_shared<QueueCounterIds>(queueId, supportedIds);
     fc.m_queueCounterIdsMap.emplace(queueVid, queueCounterIds);
 
-    fc.m_collectCountersHandlers.insert(collectQueueCounters);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectQueueCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -296,7 +296,7 @@ void FlexCounter::setQueueAttrList(
     auto queueAttrIds = std::make_shared<QueueAttrIds>(queueId, attrIds);
     fc.m_queueAttrIdsMap.emplace(queueVid, queueAttrIds);
 
-    fc.m_collectCountersHandlers.insert(collectQueueAttrs);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectQueueAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -373,7 +373,7 @@ void FlexCounter::setPriorityGroupCounterList(
     auto priorityGroupCounterIds = std::make_shared<IngressPriorityGroupCounterIds>(priorityGroupId, supportedIds);
     fc.m_priorityGroupCounterIdsMap.emplace(priorityGroupVid, priorityGroupCounterIds);
 
-    fc.m_collectCountersHandlers.insert(collectPriorityGroupCounters);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPriorityGroupCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -404,7 +404,7 @@ void FlexCounter::setPriorityGroupAttrList(
     auto priorityGroupAttrIds = std::make_shared<IngressPriorityGroupAttrIds>(priorityGroupId, attrIds);
     fc.m_priorityGroupAttrIdsMap.emplace(priorityGroupVid, priorityGroupAttrIds);
 
-    fc.m_collectCountersHandlers.insert(collectPriorityGroupAttrs);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPriorityGroupAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -464,7 +464,7 @@ void FlexCounter::setRifCounterList(
     auto rifCounterIds = std::make_shared<RifCounterIds>(rifId, supportedIds);
     fc.m_rifCounterIdsMap.emplace(rifVid, rifCounterIds);
 
-    fc.m_collectCountersHandlers.insert(collectRifCounters);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectRifCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -535,7 +535,7 @@ void FlexCounter::setBufferPoolCounterList(
     auto bufferPoolCounterIds = std::make_shared<BufferPoolCounterIds>(bufferPoolId, supportedIds, bufferPoolStatsMode);
     fc.m_bufferPoolCounterIdsMap.emplace(bufferPoolVid, bufferPoolCounterIds);
 
-    fc.m_collectCountersHandlers.insert(collectBufferPoolCounters);
+    fc.m_collectCountersHandlers.insert(&FlexCounter::collectBufferPoolCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -571,8 +571,8 @@ void FlexCounter::removePort(
     fc.m_portCounterIdsMap.erase(it);
     if (!fc.m_portCounterIdsMap.size())
     {
-        fc.m_collectCountersHandlers.erase(collectPortCounters);
-    {
+        fc.m_collectCountersHandlers.erase(&FlexCounter::collectPortCounters);
+    }
 
     // Remove flex counter if all counter IDs and plugins are unregistered
     if (fc.isEmpty())
@@ -599,7 +599,7 @@ void FlexCounter::removeQueue(
         fc.m_queueCounterIdsMap.erase(counterIter);
         if (!fc.m_queueCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(collectQueueCounters);
+            fc.m_collectCountersHandlers.erase(&FlexCounter::collectQueueCounters);
         }
         found = true;
     }
@@ -610,7 +610,7 @@ void FlexCounter::removeQueue(
         fc.m_queueAttrIdsMap.erase(attrIter);
         if (!fc.m_queueAttrIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(collectQueueAttrs);
+            fc.m_collectCountersHandlers.erase(&FlexCounter::collectQueueAttrs);
         }
         found = true;
     }
@@ -646,7 +646,7 @@ void FlexCounter::removePriorityGroup(
         fc.m_priorityGroupCounterIdsMap.erase(counterIter);
         if (!fc.m_priorityGroupCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(collectPriorityGroupCounters);
+            fc.m_collectCountersHandlers.erase(&FlexCounter::collectPriorityGroupCounters);
         }
         found = true;
     }
@@ -657,7 +657,7 @@ void FlexCounter::removePriorityGroup(
         fc.m_priorityGroupAttrIdsMap.erase(attrIter);
         if (!fc.m_priorityGroupAttrIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(collectPriorityGroupAttrs);
+            fc.m_collectCountersHandlers.erase(&FlexCounter::collectPriorityGroupAttrs);
         }
         found = true;
     }
@@ -703,7 +703,7 @@ void FlexCounter::removeRif(
     fc.m_rifCounterIdsMap.erase(it);
     if (!fc.m_rifCounterIdsMap.size())
     {
-        fc.m_collectCountersHandlers.erase(collectRifCounters);
+        fc.m_collectCountersHandlers.erase(&FlexCounter::collectRifCounters);
     }
 
     // Remove flex counter if all counter IDs and plugins are unregistered
@@ -731,7 +731,7 @@ void FlexCounter::removeBufferPool(
         fc.m_bufferPoolCounterIdsMap.erase(it);
         if (!fc.m_bufferPoolCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(collectBufferPoolCounters);
+            fc.m_collectCountersHandlers.erase(&FlexCounter::collectBufferPoolCounters);
         }
         found = true;
     }
@@ -987,8 +987,9 @@ void FlexCounter::collectCounters(
 {
     SWSS_LOG_ENTER();
 
-    for (const auto &collectCountersHandler : m_collectCountersHandlers) {
-        collectCountersHandler(countersTable);
+    for (const auto &collectCountersHandler : m_collectCountersHandlers)
+    {
+        (this->*collectCountersHandler)(countersTable);
     }
 
     countersTable.flush();

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -987,8 +987,10 @@ void FlexCounter::collectCounters(
 {
     SWSS_LOG_ENTER();
 
+    SWSS_LOG_ERROR("Flex counter instance: %s", m_instanceId.c_str());
     for (const auto &it : m_collectCountersHandlers)
     {
+        SWSS_LOG_ERROR("Collect type: %s", it.first.c_str());
         (this->*(it.second))(countersTable);
     }
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -188,6 +188,8 @@ void FlexCounter::setPortCounterList(
     auto portCounterIds = std::make_shared<PortCounterIds>(portId, supportedIds);
     fc.m_portCounterIdsMap.emplace(portVid, portCounterIds);
 
+    fc.m_collectCountersHandlers.insert(collectPortCounters);
+
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
     {
@@ -263,6 +265,8 @@ void FlexCounter::setQueueCounterList(
     auto queueCounterIds = std::make_shared<QueueCounterIds>(queueId, supportedIds);
     fc.m_queueCounterIdsMap.emplace(queueVid, queueCounterIds);
 
+    fc.m_collectCountersHandlers.insert(collectQueueCounters);
+
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
     {
@@ -291,6 +295,8 @@ void FlexCounter::setQueueAttrList(
 
     auto queueAttrIds = std::make_shared<QueueAttrIds>(queueId, attrIds);
     fc.m_queueAttrIdsMap.emplace(queueVid, queueAttrIds);
+
+    fc.m_collectCountersHandlers.insert(collectQueueAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -367,6 +373,8 @@ void FlexCounter::setPriorityGroupCounterList(
     auto priorityGroupCounterIds = std::make_shared<IngressPriorityGroupCounterIds>(priorityGroupId, supportedIds);
     fc.m_priorityGroupCounterIdsMap.emplace(priorityGroupVid, priorityGroupCounterIds);
 
+    fc.m_collectCountersHandlers.insert(collectPriorityGroupCounters);
+
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
     {
@@ -395,6 +403,8 @@ void FlexCounter::setPriorityGroupAttrList(
 
     auto priorityGroupAttrIds = std::make_shared<IngressPriorityGroupAttrIds>(priorityGroupId, attrIds);
     fc.m_priorityGroupAttrIdsMap.emplace(priorityGroupVid, priorityGroupAttrIds);
+
+    fc.m_collectCountersHandlers.insert(collectPriorityGroupAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -453,6 +463,8 @@ void FlexCounter::setRifCounterList(
 
     auto rifCounterIds = std::make_shared<RifCounterIds>(rifId, supportedIds);
     fc.m_rifCounterIdsMap.emplace(rifVid, rifCounterIds);
+
+    fc.m_collectCountersHandlers.insert(collectRifCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -523,6 +535,8 @@ void FlexCounter::setBufferPoolCounterList(
     auto bufferPoolCounterIds = std::make_shared<BufferPoolCounterIds>(bufferPoolId, supportedIds, bufferPoolStatsMode);
     fc.m_bufferPoolCounterIdsMap.emplace(bufferPoolVid, bufferPoolCounterIds);
 
+    fc.m_collectCountersHandlers.insert(collectBufferPoolCounters);
+
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
     {
@@ -544,6 +558,7 @@ void FlexCounter::removePort(
     if (it == fc.m_portCounterIdsMap.end())
     {
         SWSS_LOG_NOTICE("Trying to remove nonexisting port counter Ids 0x%lx", portVid);
+
         // Remove flex counter if all counter IDs and plugins are unregistered
         if (fc.isEmpty())
         {
@@ -554,6 +569,10 @@ void FlexCounter::removePort(
     }
 
     fc.m_portCounterIdsMap.erase(it);
+    if (!fc.m_portCounterIdsMap.size())
+    {
+        fc.m_collectCountersHandlers.erase(collectPortCounters);
+    {
 
     // Remove flex counter if all counter IDs and plugins are unregistered
     if (fc.isEmpty())
@@ -578,6 +597,10 @@ void FlexCounter::removeQueue(
     if (counterIter != fc.m_queueCounterIdsMap.end())
     {
         fc.m_queueCounterIdsMap.erase(counterIter);
+        if (!fc.m_queueCounterIdsMap.size())
+        {
+            fc.m_collectCountersHandlers.erase(collectQueueCounters);
+        }
         found = true;
     }
 
@@ -585,6 +608,10 @@ void FlexCounter::removeQueue(
     if (attrIter != fc.m_queueAttrIdsMap.end())
     {
         fc.m_queueAttrIdsMap.erase(attrIter);
+        if (!fc.m_queueAttrIdsMap.size())
+        {
+            fc.m_collectCountersHandlers.erase(collectQueueAttrs);
+        }
         found = true;
     }
 
@@ -617,6 +644,10 @@ void FlexCounter::removePriorityGroup(
     if (counterIter != fc.m_priorityGroupCounterIdsMap.end())
     {
         fc.m_priorityGroupCounterIdsMap.erase(counterIter);
+        if (!fc.m_priorityGroupCounterIdsMap.size())
+        {
+            fc.m_collectCountersHandlers.erase(collectPriorityGroupCounters);
+        }
         found = true;
     }
 
@@ -624,6 +655,10 @@ void FlexCounter::removePriorityGroup(
     if (attrIter != fc.m_priorityGroupAttrIdsMap.end())
     {
         fc.m_priorityGroupAttrIdsMap.erase(attrIter);
+        if (!fc.m_priorityGroupAttrIdsMap.size())
+        {
+            fc.m_collectCountersHandlers.erase(collectPriorityGroupAttrs);
+        }
         found = true;
     }
 
@@ -655,6 +690,7 @@ void FlexCounter::removeRif(
     if (it == fc.m_rifCounterIdsMap.end())
     {
         SWSS_LOG_NOTICE("Trying to remove nonexisting router interface counter from Id 0x%lx", rifVid);
+
         // Remove flex counter if all counter IDs and plugins are unregistered
         if (fc.isEmpty())
         {
@@ -665,6 +701,10 @@ void FlexCounter::removeRif(
     }
 
     fc.m_rifCounterIdsMap.erase(it);
+    if (!fc.m_rifCounterIdsMap.size())
+    {
+        fc.m_collectCountersHandlers.erase(collectRifCounters);
+    }
 
     // Remove flex counter if all counter IDs and plugins are unregistered
     if (fc.isEmpty())
@@ -689,6 +729,10 @@ void FlexCounter::removeBufferPool(
     if (it != fc.m_bufferPoolCounterIdsMap.end())
     {
         fc.m_bufferPoolCounterIdsMap.erase(it);
+        if (!fc.m_bufferPoolCounterIdsMap.size())
+        {
+            fc.m_collectCountersHandlers.erase(collectBufferPoolCounters);
+        }
         found = true;
     }
 
@@ -943,6 +987,15 @@ void FlexCounter::collectCounters(
 {
     SWSS_LOG_ENTER();
 
+    for (const auto &collectCountersHandler : m_collectCountersHandlers) {
+        collectCountersHandler(countersTable);
+    }
+
+    countersTable.flush();
+}
+
+void FlexCounter::collectPortCounters(_In_ swss::Table &countersTable)
+{
     // Collect stats for every registered port
     for (const auto &kv: m_portCounterIdsMap)
     {
@@ -978,7 +1031,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(portVidStr, values, "");
     }
+}
 
+void FlexCounter::collectQueueCounters(_In_ swss::Table &countersTable)
+{
     // Collect stats for every registered queue
     for (const auto &kv: m_queueCounterIdsMap)
     {
@@ -1034,7 +1090,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(queueVidStr, values, "");
     }
+}
 
+void FlexCounter::collectQueueAttrs(_In_ swss::Table &countersTable)
+{
     // Collect attrs for every registered queue
     for (const auto &kv: m_queueAttrIdsMap)
     {
@@ -1076,7 +1135,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(queueVidStr, values, "");
     }
+}
 
+void FlexCounter::collectPriorityGroupCounters(_In_ swss::Table &countersTable)
+{
     // Collect stats for every registered ingress priority group
     for (const auto &kv: m_priorityGroupCounterIdsMap)
     {
@@ -1125,7 +1187,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(priorityGroupVidStr, values, "");
     }
+}
 
+void FlexCounter::collectPriorityGroupAttrs(_In_ swss::Table &countersTable)
+{
     // Collect attrs for every registered priority group
     for (const auto &kv: m_priorityGroupAttrIdsMap)
     {
@@ -1167,7 +1232,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(priorityGroupVidStr, values, "");
     }
+}
 
+void FlexCounter::collectRifCounters(_In_ swss::Table &countersTable)
+{
     // Collect stats for every registered router interface
     for (const auto &kv: m_rifCounterIdsMap)
     {
@@ -1203,7 +1271,10 @@ void FlexCounter::collectCounters(
 
         countersTable.set(rifVidStr, values, "");
     }
+}
 
+void FlexCounter::collectBufferPoolCounters(_In_ swss::Table &countersTable)
+{
     // Collect stats for every registered buffer pool
     for (const auto &it : m_bufferPoolCounterIdsMap)
     {
@@ -1259,8 +1330,6 @@ void FlexCounter::collectCounters(
 
         countersTable.set(sai_serialize_object_id(bufferPoolVid), fvTuples);
     }
-
-    countersTable.flush();
 }
 
 void FlexCounter::runPlugins(

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -987,10 +987,8 @@ void FlexCounter::collectCounters(
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("Flex counter instance: %s", m_instanceId.c_str());
     for (const auto &it : m_collectCountersHandlers)
     {
-        SWSS_LOG_ERROR("Collect type: %s", it.first.c_str());
         (this->*(it.second))(countersTable);
     }
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -188,7 +188,7 @@ void FlexCounter::setPortCounterList(
     auto portCounterIds = std::make_shared<PortCounterIds>(portId, supportedIds);
     fc.m_portCounterIdsMap.emplace(portVid, portCounterIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPortCounters);
+    fc.m_collectCountersHandlers.emplace(PORT_COUNTER_ID_LIST, &FlexCounter::collectPortCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -265,7 +265,7 @@ void FlexCounter::setQueueCounterList(
     auto queueCounterIds = std::make_shared<QueueCounterIds>(queueId, supportedIds);
     fc.m_queueCounterIdsMap.emplace(queueVid, queueCounterIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectQueueCounters);
+    fc.m_collectCountersHandlers.emplace(QUEUE_COUNTER_ID_LIST, &FlexCounter::collectQueueCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -296,7 +296,7 @@ void FlexCounter::setQueueAttrList(
     auto queueAttrIds = std::make_shared<QueueAttrIds>(queueId, attrIds);
     fc.m_queueAttrIdsMap.emplace(queueVid, queueAttrIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectQueueAttrs);
+    fc.m_collectCountersHandlers.emplace(QUEUE_ATTR_ID_LIST, &FlexCounter::collectQueueAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -373,7 +373,7 @@ void FlexCounter::setPriorityGroupCounterList(
     auto priorityGroupCounterIds = std::make_shared<IngressPriorityGroupCounterIds>(priorityGroupId, supportedIds);
     fc.m_priorityGroupCounterIdsMap.emplace(priorityGroupVid, priorityGroupCounterIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPriorityGroupCounters);
+    fc.m_collectCountersHandlers.emplace(PG_COUNTER_ID_LIST, &FlexCounter::collectPriorityGroupCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -404,7 +404,7 @@ void FlexCounter::setPriorityGroupAttrList(
     auto priorityGroupAttrIds = std::make_shared<IngressPriorityGroupAttrIds>(priorityGroupId, attrIds);
     fc.m_priorityGroupAttrIdsMap.emplace(priorityGroupVid, priorityGroupAttrIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectPriorityGroupAttrs);
+    fc.m_collectCountersHandlers.emplace(PG_ATTR_ID_LIST, &FlexCounter::collectPriorityGroupAttrs);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -464,7 +464,7 @@ void FlexCounter::setRifCounterList(
     auto rifCounterIds = std::make_shared<RifCounterIds>(rifId, supportedIds);
     fc.m_rifCounterIdsMap.emplace(rifVid, rifCounterIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectRifCounters);
+    fc.m_collectCountersHandlers.emplace(RIF_COUNTER_ID_LIST, &FlexCounter::collectRifCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -535,7 +535,7 @@ void FlexCounter::setBufferPoolCounterList(
     auto bufferPoolCounterIds = std::make_shared<BufferPoolCounterIds>(bufferPoolId, supportedIds, bufferPoolStatsMode);
     fc.m_bufferPoolCounterIdsMap.emplace(bufferPoolVid, bufferPoolCounterIds);
 
-    fc.m_collectCountersHandlers.insert(&FlexCounter::collectBufferPoolCounters);
+    fc.m_collectCountersHandlers.emplace(BUFFER_POOL_COUNTER_ID_LIST, &FlexCounter::collectBufferPoolCounters);
 
     // Start flex counter thread in case it was not running due to empty counter IDs map
     if (fc.m_pollInterval > 0)
@@ -571,7 +571,7 @@ void FlexCounter::removePort(
     fc.m_portCounterIdsMap.erase(it);
     if (!fc.m_portCounterIdsMap.size())
     {
-        fc.m_collectCountersHandlers.erase(&FlexCounter::collectPortCounters);
+        fc.m_collectCountersHandlers.erase(PORT_COUNTER_ID_LIST);
     }
 
     // Remove flex counter if all counter IDs and plugins are unregistered
@@ -599,7 +599,7 @@ void FlexCounter::removeQueue(
         fc.m_queueCounterIdsMap.erase(counterIter);
         if (!fc.m_queueCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(&FlexCounter::collectQueueCounters);
+            fc.m_collectCountersHandlers.erase(QUEUE_COUNTER_ID_LIST);
         }
         found = true;
     }
@@ -610,7 +610,7 @@ void FlexCounter::removeQueue(
         fc.m_queueAttrIdsMap.erase(attrIter);
         if (!fc.m_queueAttrIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(&FlexCounter::collectQueueAttrs);
+            fc.m_collectCountersHandlers.erase(QUEUE_ATTR_ID_LIST);
         }
         found = true;
     }
@@ -646,7 +646,7 @@ void FlexCounter::removePriorityGroup(
         fc.m_priorityGroupCounterIdsMap.erase(counterIter);
         if (!fc.m_priorityGroupCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(&FlexCounter::collectPriorityGroupCounters);
+            fc.m_collectCountersHandlers.erase(PG_COUNTER_ID_LIST);
         }
         found = true;
     }
@@ -657,7 +657,7 @@ void FlexCounter::removePriorityGroup(
         fc.m_priorityGroupAttrIdsMap.erase(attrIter);
         if (!fc.m_priorityGroupAttrIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(&FlexCounter::collectPriorityGroupAttrs);
+            fc.m_collectCountersHandlers.erase(PG_ATTR_ID_LIST);
         }
         found = true;
     }
@@ -703,7 +703,7 @@ void FlexCounter::removeRif(
     fc.m_rifCounterIdsMap.erase(it);
     if (!fc.m_rifCounterIdsMap.size())
     {
-        fc.m_collectCountersHandlers.erase(&FlexCounter::collectRifCounters);
+        fc.m_collectCountersHandlers.erase(RIF_COUNTER_ID_LIST);
     }
 
     // Remove flex counter if all counter IDs and plugins are unregistered
@@ -731,7 +731,7 @@ void FlexCounter::removeBufferPool(
         fc.m_bufferPoolCounterIdsMap.erase(it);
         if (!fc.m_bufferPoolCounterIdsMap.size())
         {
-            fc.m_collectCountersHandlers.erase(&FlexCounter::collectBufferPoolCounters);
+            fc.m_collectCountersHandlers.erase(BUFFER_POOL_COUNTER_ID_LIST);
         }
         found = true;
     }
@@ -987,9 +987,9 @@ void FlexCounter::collectCounters(
 {
     SWSS_LOG_ENTER();
 
-    for (const auto &collectCountersHandler : m_collectCountersHandlers)
+    for (const auto &it : m_collectCountersHandlers)
     {
-        (this->*collectCountersHandler)(countersTable);
+        (this->*(it.second))(countersTable);
     }
 
     countersTable.flush();

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -210,7 +210,7 @@ class FlexCounter
         void collectRifCounters(_In_ swss::Table &countersTable);
         void collectBufferPoolCounters(_In_ swss::Table &countersTable);
 
-        void addCollectCountersHandler(const std::string &key, collect_counters_handler_t);
+        void addCollectCountersHandler(const std::string &key, const collect_counters_handler_t &handler);
         void removeCollectCountersHandler(const std::string &key);
 
         // Key is a Virtual ID

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <vector>
 #include <set>
 #include <condition_variable>
-#include <unordered_set>
+#include <unordered_map>
 #include "swss/table.h"
 
 class FlexCounter
@@ -199,7 +199,8 @@ class FlexCounter
         bool allIdsEmpty();
         bool allPluginsEmpty();
 
-        typedef void (FlexCounter::*collectCountersHandler_t)(_In_ swss::Table &countersTable);
+        typedef void (FlexCounter::*collect_counters_handler_t)(_In_ swss::Table &countersTable);
+        typedef std::unordered_map<std::string, collect_counters_handler_t> collect_counters_handler_unordered_map_t;
 
         void collectPortCounters(_In_ swss::Table &countersTable);
         void collectQueueCounters(_In_ swss::Table &countersTable);
@@ -236,7 +237,7 @@ class FlexCounter
         sai_stats_mode_t m_statsMode;
         bool m_enable = false;
 
-        std::unordered_set<collectCountersHandler_t> m_collectCountersHandlers;
+        collect_counters_handler_unordered_map_t m_collectCountersHandlers;
 };
 
 #endif

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -9,6 +9,7 @@ extern "C" {
 #include <vector>
 #include <set>
 #include <condition_variable>
+#include <unordered_set>
 #include "swss/table.h"
 
 class FlexCounter
@@ -198,7 +199,7 @@ class FlexCounter
         bool allIdsEmpty();
         bool allPluginsEmpty();
 
-        typedef void (*collectCountersHandler_t)(_In_ swss::Table &countersTable);
+        typedef void (FlexCounter::*collectCountersHandler_t)(_In_ swss::Table &countersTable);
 
         void collectPortCounters(_In_ swss::Table &countersTable);
         void collectQueueCounters(_In_ swss::Table &countersTable);

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -210,6 +210,9 @@ class FlexCounter
         void collectRifCounters(_In_ swss::Table &countersTable);
         void collectBufferPoolCounters(_In_ swss::Table &countersTable);
 
+        void addCollectCountersHandler(const std::string &key, collect_counters_handler_t);
+        void removeCollectCountersHandler(const std::string &key);
+
         // Key is a Virtual ID
         std::map<sai_object_id_t, std::shared_ptr<PortCounterIds>> m_portCounterIdsMap;
         std::map<sai_object_id_t, std::shared_ptr<QueueCounterIds>> m_queueCounterIdsMap;

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -198,6 +198,16 @@ class FlexCounter
         bool allIdsEmpty();
         bool allPluginsEmpty();
 
+        typedef void (*collectCountersHandler_t)(_In_ swss::Table &countersTable);
+
+        void collectPortCounters(_In_ swss::Table &countersTable);
+        void collectQueueCounters(_In_ swss::Table &countersTable);
+        void collectQueueAttrs(_In_ swss::Table &countersTable);
+        void collectPriorityGroupCounters(_In_ swss::Table &countersTable);
+        void collectPriorityGroupAttrs(_In_ swss::Table &countersTable);
+        void collectRifCounters(_In_ swss::Table &countersTable);
+        void collectBufferPoolCounters(_In_ swss::Table &countersTable);
+
         // Key is a Virtual ID
         std::map<sai_object_id_t, std::shared_ptr<PortCounterIds>> m_portCounterIdsMap;
         std::map<sai_object_id_t, std::shared_ptr<QueueCounterIds>> m_queueCounterIdsMap;
@@ -224,6 +234,8 @@ class FlexCounter
         std::string m_instanceId;
         sai_stats_mode_t m_statsMode;
         bool m_enable = false;
+
+        std::unordered_set<collectCountersHandler_t> m_collectCountersHandlers;
 };
 
 #endif


### PR DESCRIPTION
Each time a new counter/attribute type is added to flex counter infrastructure, collectCounters() is tailed with the logic of collecting the stats for the new type. As more and more possible id lists are being added to the flex counter, the collectCounters() member function is becoming bulky to check against all possible id lists, both existing and newly added ones.

Current list is already significantly long---port counters, queue counters, queue attributes, pg counters, pg attributes, and buffer pool counters. And most of them are irrelevant to a particular flex counter instance thread. E.g., For buffer pool watermark thread, only buffer pool counters matter, not the rest, port counters, queue counters, queue attributes, pg counters, pg attributes.

Improvement:
1. Separate each counter/attribute type to be a member function of FlexCounter with the same function prototype.

2. Have a data member (unordered_map) to maintain pointers to member functions for each flex counter instance, and install only the essential counter collection member functions at the counter/attribute list set operation.

- Choice of data member structure: Originally considered unordered_set with element T to be a pointer to member function. However, the element type does not support a certain operations, and thus can not be taken as a key, but only as a value.

In doing so, we can avoid checking against irrelevant counter/attribute id lists, and keep a fixed size for collectCounters function.

Test on dut with debugging messages:
```
Jul 18 19:45:23.127582 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Flex counter instance: QUEUE_STAT_COUNTER
Jul 18 19:45:23.127582 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Collect type: QUEUE_COUNTER_ID_LIST
Jul 18 19:45:23.128843 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Flex counter instance: QUEUE_WATERMARK_STAT_COUNTER
Jul 18 19:45:23.128843 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Collect type: QUEUE_COUNTER_ID_LIST
Jul 18 19:45:23.134331 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Flex counter instance: PG_WATERMARK_STAT_COUNTER
Jul 18 19:45:23.134331 str-a7050-acs-1 ERR syncd#syncd: :- collectCounters: Collect type: PG_COUNTER_ID_LIST
```