### PR TITLE
Fix bug: Restore sai log levels from LOGLEVEL_DB after saiDiscover

### DIFF
--- a/syncd/syncd.h
+++ b/syncd/syncd.h
@@ -136,6 +136,8 @@ sai_status_t processBulkEvent(
         _In_ sai_common_api_t api,
         _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
+void set_sai_api_loglevel();
+
 void set_sai_api_log_min_prio(
         _In_ const std::string &prio);
 

--- a/syncd/syncd_saiswitch.cpp
+++ b/syncd/syncd_saiswitch.cpp
@@ -967,11 +967,13 @@ void SaiSwitch::helperDiscover()
     {
         SWSS_LOG_TIMER("discover");
 
+        // Change sai log level before discovery to prevent SAI ERR spam to the log
         set_sai_api_log_min_prio("SAI_LOG_LEVEL_CRITICAL");
 
         saiDiscover(m_switch_rid, m_discovered_rids);
 
-        set_sai_api_log_min_prio("SAI_LOG_LEVEL_NOTICE");
+        // Restore sai log levels from LOGLEVEL_DB
+        set_sai_api_loglevel();
     }
 
     SWSS_LOG_NOTICE("discovered objects count: %zu", m_discovered_rids.size());


### PR DESCRIPTION
This bug is introduced from https://github.com/Azure/sonic-sairedis/pull/316#issuecomment-512007085

The bug is exposed by below steps. The expected log level for SAI_API_SWITCH is SAI_LOG_LEVEL_DEBUG.
```
admin@sonic:~$ swssloglevel -l SAI_LOG_LEVEL_DEBUG -s -c SWITCH
admin@sonic:~$ redis-cli -n 3 hgetall "SAI_API_SWITCH:SAI_API_SWITCH"
1) "LOGLEVEL"
2) "SAI_LOG_LEVEL_DEBUG"
3) "LOGOUTPUT"
4) "SYSLOG"
admin@sonic:~$ sudo systemctl restart swss
admin@sonic:~$ redis-cli -n 3 hgetall "SAI_API_SWITCH:SAI_API_SWITCH"
1) "LOGLEVEL"
2) "SAI_LOG_LEVEL_DEBUG"
3) "LOGOUTPUT"
4) "SYSLOG"
admin@sonic:~$ sudo grep "loglevel SAI_API_SWITCH" /var/log/syslog
Jul 25 00:00:28.280667 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_DEBUG
Jul 25 00:04:47.411408 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_DEBUG
Jul 25 00:06:31.440304 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_CRITICAL
Jul 25 00:06:31.663183 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_NOTICE
```

The first syslog line is for `swssloglevel`
The 3 later syslog lines are for `systemctl restart swss`

After this fix:
```
admin@sonic:~$ sudo systemctl restart swss
admin@sonic:~$ sudo grep "loglevel SAI_API_SWITCH" /var/log/syslog
Jul 25 00:10:43.058437 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_DEBUG
Jul 25 00:12:07.920069 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_CRITICAL
Jul 25 00:12:08.133814 sonic NOTICE syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_API_SWITCH to SAI_LOG_LEVEL_DEBUG
```
The 3 syslog lines are for `systemctl restart swss`