### PR TITLE
syncd cannot be executed using -s option, remove unuseful buffer

### DIFF
--- a/lib/src/sai_redis_generic_remove.cpp
+++ b/lib/src/sai_redis_generic_remove.cpp
@@ -134,7 +134,7 @@ sai_status_t internal_redis_bulk_generic_remove(
         g_asicState->set(key, entries, "bulkremove");
     }
 
-    return internal_api_wait_for_response(SAI_COMMON_API_CREATE);
+    return internal_api_wait_for_response(SAI_COMMON_API_REMOVE);
 }
 
 

--- a/lib/src/sai_redis_generic_set.cpp
+++ b/lib/src/sai_redis_generic_set.cpp
@@ -187,7 +187,7 @@ sai_status_t internal_redis_bulk_generic_set(
         g_asicState->set(key, entries, "bulkset");
     }
 
-    return internal_api_wait_for_response(SAI_COMMON_API_CREATE);
+    return internal_api_wait_for_response(SAI_COMMON_API_SET);
 }
 
 

--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -124,8 +124,6 @@ sai_status_t sai_api_initialize(
     g_redisNotifications = std::make_shared<swss::NotificationConsumer>(g_dbNtf.get(), "NOTIFICATIONS");
     g_redisClient        = std::make_shared<swss::RedisClient>(g_db.get());
 
-    g_asicState->setBuffered(false); // in sync mode, always false
-
     clear_local_state();
 
     g_asicInitViewMode = false;

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3302,9 +3302,9 @@ void handleCmdLine(int argc, char **argv)
 
 #ifdef SAITHRIFT
     options.run_rpc_server = false;
-    const char* const optstring = "dNUCt:p:i:rm:huS";
+    const char* const optstring = "dNUCt:p:i:rm:huSs";
 #else
-    const char* const optstring = "dNUCt:p:i:huS";
+    const char* const optstring = "dNUCt:p:i:huSs";
 #endif // SAITHRIFT
 
     while(true)


### PR DESCRIPTION
* fix wrong API type in internal_api_wait_for_response()

* add cmdline parse option "s" , otherwise syncd cannot be executed via -s option, system cannot be up with syncd

    * current behavior:
```
root@ASW-7005:/# /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile -s
/usr/bin/syncd: invalid option -- 's'
Usage: syncd [-N] [-U] [-d] [-p profile] [-i interval] [-t [cold|warm|fast|fastfast]] [-h] [-u] [-S] [-s]
    -N --nocounters
        Disable counter thread
    -d --diag
        Enable diagnostic shell
    -p --profile profile
        Provide profile map file
    -i --countersInterval interval
        Provide counter thread interval
    -t --startType type
        Specify cold|warm|fast|fastfast start type
    -u --useTempView:
        Use temporary view between init and apply
    -S --disableExitSleep
        Disable sleep when syncd crashes
    -U --eableUnittests
        Metadata enable unittests
    -C --eableConsistencyCheck
        Enable consisteny check DB vs ASIC after comparison logic
    -s --syncMode
        Enable synchronous mode
    -h --help
        Print out this message
```

    * after the fix :

```
root@ASW-7005:/# ps -ef | grep syncd
root        56     1  0 07:16 pts/0    00:00:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile -s
root        63    56 20 07:16 pts/0    00:01:50 /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile -s
root       290    92  0 07:25 pts/2    00:00:00 grep syncd
root@ASW-7005:/# 
```

* remove unuseful api call g_asicState->setBuffered(false)
    * when orchagent is executed, orchagent will set switch attribute to decide the setBuffer is true or false, it is not needed to set the value here.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com