### PR TITLE
[flex counter] Lower the severity of log during rif counter support check

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -456,7 +456,7 @@ void FlexCounter::setRifCounterList(
 
     if (supportedIds.empty())
     {
-        SWSS_LOG_ERROR("Router interface %s does not have supported counters", sai_serialize_object_id(rifId).c_str());
+        SWSS_LOG_NOTICE("Router interface %s does not have supported counters", sai_serialize_object_id(rifId).c_str());
 
         // Remove flex counter if all counter IDs and plugins are unregistered
         if (fc.isEmpty())


### PR DESCRIPTION
We check to see which counters are supported, if something is not, that is not an error.
It may cause some Ansible tests fail because of the loganalyzer found errors in syslog.