### PR TITLE
Modify the lanes of port in SYNCD

### DIFF
--- a/syncd/syncd_saiswitch.cpp
+++ b/syncd/syncd_saiswitch.cpp
@@ -148,7 +148,7 @@ std::unordered_map<sai_uint32_t, sai_object_id_t> SaiSwitch::saiGetHardwareLaneM
      * addressed in future.
      */
 
-    const int lanesPerPort = 4;
+    const int lanesPerPort = 8;
 
     for (const auto &port_rid : portList)
     {


### PR DESCRIPTION
What I did
Support 8 lanes for port
Why I did it
In 201811 branch, lanes of port are for 4, it results orchagent exception for 32x400G of TH3