### PR TITLE
fully support bulk_remove in sairedis

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2917,6 +2917,10 @@ sai_status_t processEvent(
         {
             return processBulkEvent((sai_common_api_t)SAI_COMMON_API_BULK_CREATE, kco);
         }
+        else if (op == "bulkremove")
+        {
+            return processBulkEvent((sai_common_api_t)SAI_COMMON_API_BULK_REMOVE, kco);
+        }
         else if (op == "notify")
         {
             return notifySyncd(key);


### PR DESCRIPTION
* add redis_dummy_remove_route_entry() for meta_sai_remove_route_entry() calls, which is the same logic as create/set

* add NULL pointer check and add meta_sai_remove_route_entry() calls which will remove meta data after remove entries. The logic is the same as create/set

* syncd add bulkremove option for processEvent() to select  processBulkEvent()

* together with this , there should be a consumer_table_pops.lua script changes to handle bulkremove in sonic_swss_common
https://github.com/Azure/sonic-swss-common/pull/306

* after these changes , when we call bulk_create and bulk_remove, the meta data is cleared and we can bulk_create again, otherwise it raise error entry already exists.


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com