### PR TITLE
[orchagent] Process Event -graceful error handling for unimplemented and unsupported SAI APIs

### DIFF
--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3136,9 +3136,9 @@ sai_status_t processEvent(
             }
 
             /*
-             * Handling SAI errors (not implemented or not supported) objects
-             * like qos_map, bufferPool objects etc gracefully by logging error
-             * and not throwing run time error to avoid OA abort.
+             * Handling SAI errors (not implemented or not supported) for objects
+             * like qos_map, buffer pool etc gracefully by logging error and not
+             * throwing run time error to avoid orchagent abort.
              */
             if (checkErrorAndSkipOAAbort(object_type, status))
             {


### PR DESCRIPTION
SAI return error code (NOT_SUPPORTED/NOT_IMPLEMENTED) for the API which are not yet implemented or are not supported. Instead of crashing the orchagent, handle it gracefully by throwing an error and ignoring such errors. 