### PR TITLE
Improved the initialization time by a few minutes by optimizing the flex counter queue configurations

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -80,7 +80,7 @@ void FlexCounter::setPollInterval(
     fc.m_pollInterval = pollInterval;
     if (pollInterval > 0)
     {
-        fc.startFlexCounterThread();
+        fc.startFlexCounterThread(true);
     }
 }
 
@@ -95,7 +95,7 @@ void FlexCounter::updateFlexCounterStatus(
     {
         std::lock_guard<std::mutex> lkMgr(fc.m_mtx);
         fc.m_enable = true;
-        fc.startFlexCounterThread();
+        fc.startFlexCounterThread(true);
     }
     else if (status == "disable")
     {
@@ -1462,13 +1462,16 @@ void FlexCounter::flexCounterThread(void)
     }
 }
 
-void FlexCounter::startFlexCounterThread(void)
+void FlexCounter::startFlexCounterThread(bool notify)
 {
     SWSS_LOG_ENTER();
 
     if (m_runFlexCounterThread == true)
     {
-        m_pollCond.notify_all();
+		// Notifying will lead to back to back counter collection during reload.
+		// This has to be done carefully on case to case basis. e.g. change in polling interval.
+		if(notify)
+			m_pollCond.notify_all();
         return;
     }
 

--- a/syncd/syncd_flex_counter.h
+++ b/syncd/syncd_flex_counter.h
@@ -180,7 +180,7 @@ class FlexCounter
         void collectCounters(_In_ swss::Table &countersTable);
         void runPlugins(_In_ swss::DBConnector& db);
         void flexCounterThread(void);
-        void startFlexCounterThread(void);
+        void startFlexCounterThread(bool notify=false);
         void endFlexCounterThread(void);
 
         void saiUpdateSupportedPortCounters(sai_object_id_t portId);


### PR DESCRIPTION
Synd gets busy collecting counters when flex counter config replay happens during init.
Each queue list update for flex counter results in waking-up the counter collection thread.
This makes syncd busy for a few minutes.
Waking up the stats collection thread is required when there is a change in polling interval or when a flex counter is enabled.

How to Test?
Measure the initialization time with this change during normal boot-up and config-reload. 

Signed-off-by: Prasanth Kunjum Veettil <prasanth.kunjumveettil@broadcom.com>