### PR TITLE
Copp changes for supporting genetlink in vs

### DIFF
--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -69,6 +69,7 @@ FDBs
 filename
 FIXME
 FlexCounter
+genetlink
 getInstance
 getSwitchId
 getVid
@@ -111,10 +112,12 @@ metadata
 mlnx
 mpls
 MTU
+multicast
 mutex
 mutexes
 namespace
 namespaces
+netdev
 NHG
 nhgm
 nlog

--- a/vslib/src/sai_vs_hostintf.cpp
+++ b/vslib/src/sai_vs_hostintf.cpp
@@ -1122,6 +1122,9 @@ sai_status_t vs_create_hostif_tap_interface(
         return SAI_STATUS_FAILURE;
     }
 
+    /* The genetlink host interface is created to associate trap group to genetlink family and multicast group
+     * created by driver. It does not create any netdev interface. Hence skipping tap interface creation
+     */
     if (attr_type->value.s32 == SAI_HOSTIF_TYPE_GENETLINK)
     {
         SWSS_LOG_DEBUG("Skipping tap create for hostif type genetlink");

--- a/vslib/src/sai_vs_hostintf.cpp
+++ b/vslib/src/sai_vs_hostintf.cpp
@@ -1122,6 +1122,13 @@ sai_status_t vs_create_hostif_tap_interface(
         return SAI_STATUS_FAILURE;
     }
 
+    if (attr_type->value.s32 == SAI_HOSTIF_TYPE_GENETLINK)
+    {
+        SWSS_LOG_DEBUG("Skipping tap create for hostif type genetlink");
+
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr_type->value.s32 != SAI_HOSTIF_TYPE_NETDEV)
     {
         SWSS_LOG_ERROR("only SAI_HOSTIF_TYPE_NETDEV is supported");


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added support in swss for SFLOW. It includes sfloworch and sflowmgr changes.

**Why I did it**
Added support for supporting genetlink attribute in vs
**How I verified it**
Loaded vs image. Enabled sflow and checked the redis-db

**Details if related**
These changes are required for supporting sflow. When sflow is enabled, the genetlink attributes are programmed and vslib shouldn't return any errors which might crash orchagent.
