### PR TITLE
Error Handling Framework: Syncd Changes to report SAI failures

### DIFF
--- a/syncd/syncd.h
+++ b/syncd/syncd.h
@@ -32,6 +32,7 @@ extern "C" {
 #include "swss/producertable.h"
 #include "swss/consumertable.h"
 #include "swss/consumerstatetable.h"
+#include "swss/subscriberstatetable.h"
 #include "swss/notificationconsumer.h"
 #include "swss/notificationproducer.h"
 #include "swss/selectableevent.h"
@@ -92,6 +93,7 @@ sai_object_type_t getObjectTypeFromVid(
         _In_ sai_object_id_t sai_object_id);
 
 extern std::shared_ptr<swss::NotificationProducer>  notifications;
+extern std::shared_ptr<swss::NotificationProducer>  errorNotifications;
 extern std::shared_ptr<swss::RedisClient>   g_redisClient;
 
 extern bool g_enableConsistencyCheck;
@@ -142,5 +144,14 @@ void set_sai_api_log_min_prio(
         _In_ const std::string &prio);
 
 bool enableUnittests();
+
+void sendSaiApiStatusNotification(
+        _In_ std::string op,
+        _In_ std::string data,
+        _In_ std::vector<swss::FieldValueTuple> &entry);
+
+void sendSaiApiStatusNotification(
+        _In_ std::string op,
+        _In_ std::string data);
 
 #endif // __SYNCD_H__

--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -31,6 +31,29 @@ void send_notification(
     send_notification(op, data, entry);
 }
 
+void sendSaiApiStatusNotification(
+        _In_ std::string op,
+        _In_ std::string data,
+        _In_ std::vector<swss::FieldValueTuple> &entry)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_INFO("%s %s", op.c_str(), data.c_str());
+
+    errorNotifications->send(op, data, entry);
+}
+
+void sendSaiApiStatusNotification(
+        _In_ std::string op,
+        _In_ std::string data)
+{
+    SWSS_LOG_ENTER();
+    std::vector<swss::FieldValueTuple> entry;
+
+    sendSaiApiStatusNotification(op, data, entry);
+}
+
+
 void process_on_switch_state_change(
         _In_ sai_object_id_t switch_rid,
         _In_ sai_switch_oper_status_t switch_oper_status)


### PR DESCRIPTION
Error handling framework is responsible for notifying ASIC/SAI programming failures to the applications.

Changes in syncd includes:
- Capture the SAI return codes
- Send the return codes to OrchAgent through a channel
- Provision to enable or disable the notification to OrchAgent

Functional specification PR:
  https://github.com/Azure/SONiC/pull/391

Dependent PRs:
  https://github.com/Azure/sonic-swss-common/pull/309
  https://github.com/Azure/sonic-utilities/pull/709

Related PRs:
  https://github.com/Azure/sonic-utilities/pull/666
  https://github.com/Azure/sonic-swss/pull/1100

Signed-off-by: Siva Mukka (siva.mukka@broadcom.com)