### PR TITLE
Enable FastReboot if we have key "FAST_REBOOT|system" in State db

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -31,7 +31,12 @@ case "$(cat /proc/cmdline)" in
     fi
     ;;
   *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
-     FAST_REBOOT='yes'
+    # check that the key exists
+    if [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
+       FAST_REBOOT='yes'
+    else
+       FAST_REBOOT='no'
+    fi
     ;;
   *)
      FAST_REBOOT='no'


### PR DESCRIPTION
Enable fast-reboot only if "FAST_REBOOT|system" key exists in STATE db.
This PR is required to be included into https://github.com/Azure/sonic-buildimage/pull/3741 to fix https://github.com/Azure/sonic-buildimage/issues/3697