### PR TITLE
Disable Fast-Reboot start if uptime is greater than 3 minutes

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -32,11 +32,7 @@ case "$(cat /proc/cmdline)" in
     ;;
   *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
     # check that the key exists
-    if [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
-       FAST_REBOOT='yes'
-    else
-       FAST_REBOOT='no'
-    fi
+    FAST_REBOOT=$(awk '{ if ($1 <= 180) print "yes"; else print "no" }' /proc/uptime)
     ;;
   *)
      FAST_REBOOT='no'


### PR DESCRIPTION
Add a solution to don't start in fast-reboot mode if uptime greater than 180 seconds.
But it will not prevent a case when someone restarted syncd within 180 seconds. In this case syncd will start in FR mode.
This would be fixed by https://github.com/Azure/sonic-buildimage/pull/3741