### PR TITLE
[vs] Send port status notification when creating hostif interface

### DIFF
--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -351,7 +351,7 @@ sai_status_t sai_query_attribute_enum_values_capability(
                         recordLine("Q|attribute_enum_values_capability|SAI_STATUS_FAILURE");
                     }
 
-                    SWSS_LOG_ERROR("Invalid response from syncd: expected 2 values, received %d", values.size());
+                    SWSS_LOG_ERROR("Invalid response from syncd: expected 2 values, received %zu", values.size());
                     return SAI_STATUS_FAILURE;
                 }
 
@@ -375,7 +375,7 @@ sai_status_t sai_query_attribute_enum_values_capability(
                     {
                         if (num_capabilities != i + 1)
                         {
-                            SWSS_LOG_WARN("Query returned less attributes than expected: expected %d, recieved %d");
+                            SWSS_LOG_WARN("Query returned less attributes than expected: expected %d, recieved %d", num_capabilities, i+1);
                         }
 
                         break;
@@ -492,7 +492,7 @@ sai_status_t sai_object_type_get_availability(
                         recordLine("Q|object_type_get_availability|SAI_STATUS_FAILURE");
                     }
 
-                    SWSS_LOG_ERROR("Invalid response from syncd: expected 1 value, received %d", values.size());
+                    SWSS_LOG_ERROR("Invalid response from syncd: expected 1 value, received %zu", values.size());
                     return SAI_STATUS_FAILURE;
                 }
 

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -2883,7 +2883,7 @@ sai_status_t processAttrEnumValuesCapabilityQuery(
 
     if (values.size() != 3)
     {
-        SWSS_LOG_ERROR("Invalid input: expected 3 arguments, received %d", values.size());
+        SWSS_LOG_ERROR("Invalid input: expected 3 arguments, received %zu", values.size());
         getResponse->set(sai_serialize_status(SAI_STATUS_INVALID_PARAMETER), {}, attrEnumValuesCapabilityResponse);
         return SAI_STATUS_INVALID_PARAMETER;
     }

--- a/vslib/inc/sai_vs_state.h
+++ b/vslib/inc/sai_vs_state.h
@@ -328,4 +328,11 @@ void processFdbInfo(
         _In_ const fdb_info_t &fi,
         _In_ sai_fdb_event_t fdb_event);
 
+void update_port_oper_status(
+        _In_ sai_object_id_t port_id,
+        _In_ sai_port_oper_status_t port_oper_status);
+
+std::shared_ptr<SwitchState> vs_get_switch_state(
+        _In_ sai_object_id_t switch_id);
+
 #endif // __SAI_VS_STATE__


### PR DESCRIPTION
When interfaces are already created in the system and when rebooting syncd port status won't change when creating tap device, Linux won't send link message again. Lets explicitly sent notification with port status.