### PR TITLE
[MultiDB]: repalce old APIs with New APIs incuding testing

### DIFF
--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -119,8 +119,8 @@ sai_status_t sai_api_initialize(
 
     memcpy(&g_services, services, sizeof(g_services));
 
-    g_db                 = std::make_shared<swss::DBConnector>(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    g_dbNtf              = std::make_shared<swss::DBConnector>(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    g_db                 = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    g_dbNtf              = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
     g_redisPipeline      = std::make_shared<swss::RedisPipeline>(g_db.get()); //enable default pipeline 128
     g_asicState          = std::make_shared<swss::ProducerTable>(g_redisPipeline.get(), ASIC_STATE_TABLE, true);
     g_redisGetConsumer   = std::make_shared<swss::ConsumerTable>(g_db.get(), "GETRESPONSE");

--- a/saidump/saidump.cpp
+++ b/saidump/saidump.cpp
@@ -410,7 +410,7 @@ int main(int argc, char ** argv)
 
     g_cmdOptions = handleCmdLine(argc, argv);
 
-    swss::DBConnector db(ASIC_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    swss::DBConnector db("ASIC_DB", 0);
 
     std::string table = ASIC_STATE_TABLE;
 

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -32,7 +32,7 @@ case "$(cat /proc/cmdline)" in
     ;;
   *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
     # check that the key exists
-    if [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
+    if [[ $(sonic-db-cli STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
        FAST_REBOOT='yes'
     else
        FAST_REBOOT='no'

--- a/syncd/syncd.cpp
+++ b/syncd/syncd.cpp
@@ -3947,10 +3947,10 @@ int syncd_main(int argc, char **argv)
     }
 #endif // SAITHRIFT
 
-    dbAsic = std::make_shared<swss::DBConnector>(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    std::shared_ptr<swss::DBConnector> dbNtf = std::make_shared<swss::DBConnector>(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    std::shared_ptr<swss::DBConnector> dbFlexCounter = std::make_shared<swss::DBConnector>(FLEX_COUNTER_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    std::shared_ptr<swss::DBConnector> dbState = std::make_shared<swss::DBConnector>(STATE_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    std::shared_ptr<swss::DBConnector> dbNtf = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    std::shared_ptr<swss::DBConnector> dbFlexCounter = std::make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+    std::shared_ptr<swss::DBConnector> dbState = std::make_shared<swss::DBConnector>("STATE_DB", 0);
     std::unique_ptr<swss::Table> warmRestartTable = std::unique_ptr<swss::Table>(new swss::Table(dbState.get(), STATE_WARM_RESTART_TABLE_NAME));
 
     g_redisClient = std::make_shared<swss::RedisClient>(dbAsic.get());

--- a/syncd/syncd_applyview.cpp
+++ b/syncd/syncd_applyview.cpp
@@ -1809,7 +1809,7 @@ void redisGetAsicView(
 
     SWSS_LOG_TIMER("get asic view from %s", tableName.c_str());
 
-    swss::DBConnector db(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    swss::DBConnector db("ASIC_DB", 0);
 
     swss::Table table(&db, tableName);
 

--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1690,7 +1690,7 @@ void FlexCounter::flexCounterThread(void)
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector db(COUNTERS_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    swss::DBConnector db("COUNTERS_DB", 0);
     swss::RedisPipeline pipeline(&db);
     swss::Table countersTable(&pipeline, COUNTERS_TABLE, true);
 

--- a/syncd/syncd_request_shutdown.cpp
+++ b/syncd/syncd_request_shutdown.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    swss::DBConnector db(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    swss::DBConnector db("ASIC_DB", 0);
     swss::NotificationProducer restartQuery(&db, "RESTARTQUERY");
 
     std::vector<swss::FieldValueTuple> values;

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -63,7 +63,7 @@ void clearDB()
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector db(ASIC_DB, "localhost", 6379, 0);
+    swss::DBConnector db("ASIC_DB", 0, true);
     swss::RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -168,7 +168,7 @@ void bulk_nhgm_consumer_worker()
     SWSS_LOG_ENTER();
 
     std::string tableName = ASIC_STATE_TABLE;
-    swss::DBConnector db(ASIC_DB, "localhost", 6379, 0);
+    swss::DBConnector db("ASIC_DB", 0, true);
     swss::ConsumerTable c(&db, tableName);
     swss::Select cs;
     swss::Selectable *selectcs;

--- a/vslib/src/sai_vs_interfacequery.cpp
+++ b/vslib/src/sai_vs_interfacequery.cpp
@@ -787,7 +787,7 @@ sai_status_t sai_api_initialize(
 
     clear_local_state();
 
-    g_dbNtf = std::make_shared<swss::DBConnector>(ASIC_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+    g_dbNtf = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
     g_unittestChannelNotificationConsumer = std::make_shared<swss::NotificationConsumer>(g_dbNtf.get(), SAI_VS_UNITTEST_CHANNEL);
 
     g_unittestChannelRun = true;

--- a/vslib/src/tests.cpp
+++ b/vslib/src/tests.cpp
@@ -208,7 +208,7 @@ void test_set_readonly_attribute_via_redis()
 
     // this scope contains all operations needed to perform set operation on readonly attribute
     {
-        swss::DBConnector db(ASIC_DB, "localhost", 6379, 0);
+        swss::DBConnector db("ASIC_DB", 0, true);
         swss::NotificationProducer vsntf(&db, SAI_VS_UNITTEST_CHANNEL);
 
         std::vector<swss::FieldValueTuple> entry;
@@ -271,7 +271,7 @@ void test_set_stats_via_redis()
 
     // this scope contains all operations needed to perform set stats on object
     {
-        swss::DBConnector db(ASIC_DB, "localhost", 6379, 0);
+        swss::DBConnector db("ASIC_DB", 0, true);
         swss::NotificationProducer vsntf(&db, SAI_VS_UNITTEST_CHANNEL);
 
         std::vector<swss::FieldValueTuple> entry;


### PR DESCRIPTION
* using new APIs DBConnector("DBNAME", TIMEOUT) and sonic-db-cli wrapper
* add database_config.json to dh_auto_testing cases to pass tests when building deb pkg 
* since using sonic-db-cli, we need to update sonic-py-swsssdk to https://github.com/Azure/sonic-py-swsssdk/pull/54 at least. Otherwise, sonic-db-cli is not there.


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com