### PR TITLE
Support for snat available entry switch attribute in vslib (needed to run vs pytests)

### DIFF
--- a/vslib/src/sai_vs_switch_BCM56850.cpp
+++ b/vslib/src/sai_vs_switch_BCM56850.cpp
@@ -68,6 +68,21 @@ static sai_status_t set_switch_default_attributes()
 
     CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
 
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY;
+    attr.value.u32 = 100;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY;
+    attr.value.u32 = 100;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY;
+    attr.value.u32 = 50; /* Half of single NAT entry */
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
     attr.id = SAI_SWITCH_ATTR_WARM_RECOVER;
     attr.value.booldata = false;
 
@@ -1334,6 +1349,11 @@ sai_status_t refresh_read_only_BCM56850(
                 return refresh_port_list(meta, switch_id);
 
             case SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_CHILDS_PER_SCHEDULER_GROUP:
+                return SAI_STATUS_SUCCESS;
+
+            case SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY:
+            case SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY:
+            case SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY:
                 return SAI_STATUS_SUCCESS;
         }
     }

--- a/vslib/src/sai_vs_switch_MLNX2700.cpp
+++ b/vslib/src/sai_vs_switch_MLNX2700.cpp
@@ -66,6 +66,21 @@ static sai_status_t set_switch_default_attributes()
 
     CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
 
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY;
+    attr.value.u32 = 100;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY;
+    attr.value.u32 = 100;
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
+    attr.id = SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY;
+    attr.value.u32 = 50; /* Half of single NAT entry */
+
+    CHECK_STATUS(vs_generic_set(SAI_OBJECT_TYPE_SWITCH, ss->getSwitchId(), &attr));
+
     attr.id = SAI_SWITCH_ATTR_WARM_RECOVER;
     attr.value.booldata = false;
 
@@ -1191,6 +1206,11 @@ sai_status_t refresh_read_only_MLNX2700(
                 return SAI_STATUS_SUCCESS;
 
             case SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_CHILDS_PER_SCHEDULER_GROUP:
+                return SAI_STATUS_SUCCESS;
+
+            case SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY:
+            case SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY:
+            case SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY:
                 return SAI_STATUS_SUCCESS;
         }
     }


### PR DESCRIPTION
Adding support for below NAT switch attributes in vslib (needed to run vs pytests)
SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY
SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY
SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY
 
Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>