### PR TITLE
[meta/sai_meta]Fix the issue that fdb learnt during create switch fails removeDefaultBridgePorts

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -7006,31 +7006,16 @@ void Meta::meta_sai_on_fdb_flush_event_consolidated(
     }
 }
 
-void Meta::meta_fdb_event_snoop_oid(
+int Meta::meta_fdb_event_snoop_oid(
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
 
     if (oid == SAI_NULL_OBJECT_ID)
-        return;
+        return -1;
 
-    if (m_oids.objectReferenceExists(oid))
-        return;
-
-    sai_object_type_t ot = objectTypeQuery(oid);
-
-    if (ot == SAI_OBJECT_TYPE_NULL)
-    {
-        SWSS_LOG_ERROR("failed to get object type on fdb_event oid: 0x%" PRIx64 "", oid);
-        return;
-    }
-
-    sai_object_meta_key_t key = { .objecttype = ot, .objectkey = { .key = { .object_id = oid } } };
-
-    m_oids.objectReferenceInsert(oid);
-
-    if (!m_saiObjectCollection.objectExists(key))
-        m_saiObjectCollection.createObject(key);
+    if (m_oids.object_reference_exists(oid))
+        return 0;
 
     /*
      * In normal operation orch agent should query or create all bridge, vlan
@@ -7038,11 +7023,26 @@ void Meta::meta_fdb_event_snoop_oid(
      * warning for better visibility. Most likely if this happen  there is a
      * vendor bug in SAI and we should also see warnings or errors reported
      * from syncd in logs.
+     *
+     * Originally the solution was to create the object and then continue to
+     * learn fdb_entry, which causes other issue on SONiC. Consider the following
+     * scenario:
+     * 1. SWITCH ASIC reports fdb learnt on a certain vlan/port
+     * 2. Create object for the vlan/port
+     * 3. Learn the mac address, which will increase the reference count of port
+     * 4. On SONiC, all port will be removed from bridge during creating switch,
+     *    which is done by calling removeDefaultBridgePorts. It contains a logic
+     *    of checking the reference number of ports being removed and fails if 
+     *    not zero. For the ports have fdb learnt ahead of this, their were
+     *    referenced by the fdb and thus fails.
+     * This issue can be reproduced on a normal switch.
+     * As eventually we will remove ports from the bridge, we don't need to learn
+     * the fdb here.
      */
 
-    SWSS_LOG_WARN("fdb_entry oid (snoop): %s: %s",
-            sai_serialize_object_type(ot).c_str(),
+    SWSS_LOG_WARN("fdb_entry oid (snoop): oid doesn't exist, ignored %s",
             sai_serialize_object_id(oid).c_str());
+    return -1;
 }
 
 void Meta::meta_sai_on_fdb_event_single(
@@ -7067,7 +7067,11 @@ void Meta::meta_sai_on_fdb_event_single(
      * query yet.
      */
 
-    meta_fdb_event_snoop_oid(data.fdb_entry.bv_id);
+    if (meta_fdb_event_snoop_oid(data.fdb_entry.bv_id) < 0)
+    {
+        SWSS_LOG_WARN("fdb_entry oid (snoop): ignore the mac address learning during creating switch");
+        return;
+    }
 
     for (uint32_t i = 0; i < data.attr_count; i++)
     {

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -7014,7 +7014,7 @@ int Meta::meta_fdb_event_snoop_oid(
     if (oid == SAI_NULL_OBJECT_ID)
         return -1;
 
-    if (m_oids.object_reference_exists(oid))
+    if (m_oids.objectReferenceExists(oid))
         return 0;
 
     /*

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -281,7 +281,7 @@ namespace saimeta
             void meta_sai_on_fdb_flush_event_consolidated(
                     _In_ const sai_fdb_event_notification_data_t& data);
 
-            void meta_fdb_event_snoop_oid(
+            int meta_fdb_event_snoop_oid(
                     _In_ sai_object_id_t oid);
 
             void meta_sai_on_fdb_event_single(


### PR DESCRIPTION
In normal operation orch agent should query or create all bridge, vlan and bridge port, so we should not get this message. Let's put it as warning for better visibility. Most likely if this happen  there is a vendor bug in SAI and we should also see warnings or errors reported from syncd in logs.
Originally the solution was to create the object and then continue to learn fdb_entry, which causes other issue on SONiC. Consider the following scenario:
1. SWITCH ASIC reports fdb learnt on a certain vlan/port
2. Create object for the vlan/port
3. Learn the mac address, which will increase the reference count of port
4. On SONiC, all port will be removed from bridge during creating switch, which is done by calling removeDefaultBridgePorts. It contains a logic of checking the reference number of ports being removed and fails if not zero. For the ports have fdb learnt ahead of this, their were referenced by the fdb and thus fails.

This issue can be reproduced on a normal switch.
As eventually we will remove ports from the bridge, we don't need to learn the fdb here.
