### PR TITLE
[meta] Flush fdb entries after flush api success (#581)

### DIFF
--- a/meta/sai_meta.cpp
+++ b/meta/sai_meta.cpp
@@ -6438,7 +6438,7 @@ int meta_fdb_event_snoop_oid(
      * 3. Learn the mac address, which will increase the reference count of port
      * 4. On SONiC, all port will be removed from bridge during creating switch,
      *    which is done by calling removeDefaultBridgePorts. It contains a logic
-     *    of checking the reference number of ports being removed and fails if 
+     *    of checking the reference number of ports being removed and fails if
      *    not zero. For the ports have fdb learnt ahead of this, their were
      *    referenced by the fdb and thus fails.
      * This issue can be reproduced on a normal switch.
@@ -6759,7 +6759,66 @@ sai_status_t meta_sai_flush_fdb_entries(
     // there are no mandatory attributes
     // there are no conditional attributes
 
-    return flush_fdb_entries(switch_id, attr_count, attr_list);
+    auto status = flush_fdb_entries(switch_id, attr_count, attr_list);
+
+    if (status = SAI_STATUS_SUCCESS)
+    {
+        // use same logic as notification, so create notification event
+
+        std::vector<int32_t> types;
+
+        auto *et = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_ENTRY_TYPE, attr_count, attr_list);
+
+        if (et)
+        {
+            switch (et->value.s32)
+            {
+                case SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+                    break;
+
+                case SAI_FDB_FLUSH_ENTRY_TYPE_STATIC:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+                    break;
+
+                default:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+                    types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+                    break;
+            }
+        }
+        else
+        {
+            // no type specified so we need to flush static and dynamic entries
+
+            types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+            types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+        }
+
+        for (auto type: types)
+        {
+            sai_fdb_event_notification_data_t data = {};
+
+            auto *bv_id = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_BV_ID, attr_count, attr_list);
+            auto *bp_id = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID, attr_count, attr_list);
+
+            sai_attribute_t list[2];
+
+            list[0].id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+            list[0].value.oid = bp_id ? bp_id->value.oid : SAI_NULL_OBJECT_ID;
+
+            list[1].id = SAI_FDB_ENTRY_ATTR_TYPE;
+            list[1].value.s32 = type;
+
+            data.event_type = SAI_FDB_EVENT_FLUSHED;
+            data.fdb_entry.switch_id = switch_id;
+            data.fdb_entry.bv_id = (bv_id) ? bv_id->value.oid : SAI_NULL_OBJECT_ID;
+            data.attr_count = 2;
+            data.attr = list;
+
+            meta_sai_on_fdb_flush_event_consolidated(data);
+        }
+    }
 }
 
 // NAT


### PR DESCRIPTION
* [meta] Flush fdb entries after flush api success
* [meta] Use correct fdb entry type
* [meta] Use correct enum values for fdb entry

Back porting https://github.com/Azure/sonic-sairedis/pull/581