### PR TITLE
[syncd] Fix crash during stats polling

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -537,7 +537,7 @@ sai_status_t Syncd::processGetStatsEvent(
         counter_ids.push_back(val);
     }
 
-    std::vector<uint64_t> result;
+    std::vector<uint64_t> result(counter_ids.size());
 
     auto status = m_vendorSai->getStats(
             metaKey.objecttype,

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -388,6 +388,12 @@ sai_status_t VendorSai::getStats(
             _In_ const sai_stat_id_t *counter_ids,
             _Out_ uint64_t *counters);
 
+    if (!counter_ids || !counters)
+    {
+        SWSS_LOG_ERROR("NULL pointer function argument");
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
     switch ((int)object_type)
     {
         case SAI_OBJECT_TYPE_PORT:


### PR DESCRIPTION
The crash is observed during pfc_wd CT execution on BFN platform.

Null pointer is passed to VendorSai::getStats() function due to data() method call for empty "result"  vector. Then NULL pointer is passed to SAI handler where it causes crash.

In order to fix this "result" vector size is set to the size of counter_ids vector. In addition to this checks for NULL pointers are added to VendorSai::getStats().

