### PR TITLE
Do not translateVidToRid for processBulkQuadEvent in InitViewMode

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -625,6 +625,11 @@ sai_status_t Syncd::processBulkQuadEvent(
             strObjectType.c_str(),
             objectIds.size());
 
+    if (isInitViewMode())
+    {
+        return processBulkQuadEventInInitViewMode(objectType, objectIds, api, attributes);
+    }
+
     if (api != SAI_COMMON_API_BULK_GET)
     {
         // translate attributes for all objects
@@ -636,11 +641,6 @@ sai_status_t Syncd::processBulkQuadEvent(
 
             m_translator->translateVidToRid(objectType, attr_count, attr_list);
         }
-    }
-
-    if (isInitViewMode())
-    {
-        return processBulkQuadEventInInitViewMode(objectType, objectIds, api, attributes);
     }
 
     auto info = sai_metadata_get_object_type_info(objectType);


### PR DESCRIPTION
I met below error message in syslog when running test `test_FdbWarmRestartNotifications`.

```
Apr  9 00:32:53.543918 84bbea71037f NOTICE #syncd: :- processBulkQuadEvent: bulk SAI_OBJECT_TYPE_ROUTE_ENTRY execute with 3 items
Apr  9 00:32:53.543994 84bbea71037f ERR #syncd: :- translateVidToRid: unable to get RID for VID oid:0x6000000000607
Apr  9 00:32:53.544118 84bbea71037f ERR #syncd: :- run: Runtime error: :- translateVidToRid: unable to get RID for VID oid:0x6000000000607
Apr  9 00:32:53.544129 84bbea71037f NOTICE #syncd: :- sendShutdownRequest: sending switch_shutdown_request notification to OA for switch: oid:0x21000000000000
Apr  9 00:32:53.544197 84bbea71037f NOTICE #syncd: :- sendShutdownRequestAfterException: notification send successfull
```