### PR TITLE
Add Identity attribute for LAG

### DIFF
--- a/meta/SaiAttributeList.cpp
+++ b/meta/SaiAttributeList.cpp
@@ -35,9 +35,6 @@ SaiAttributeList::SaiAttributeList(
             SWSS_LOG_THROW("FATAL: failed to find metadata for object type %d and attr id %d", objectType, attr.id);
         }
 
-        if (SAI_HAS_FLAG_IDENTIFY(meta->flags))
-            continue;
-
         sai_deserialize_attr_value(str_attr_value, *meta, attr, countOnly);
 
         m_attr_list.push_back(attr);
@@ -73,9 +70,6 @@ SaiAttributeList::SaiAttributeList(
         {
             SWSS_LOG_THROW("FATAL: failed to find metadata for object type %d and attr id %d", objectType, attr.id);
         }
-
-        if (SAI_HAS_FLAG_IDENTIFY(meta->flags))
-            continue;
 
         sai_deserialize_attr_value(str_attr_value, *meta, attr, countOnly);
 

--- a/meta/SaiAttributeList.cpp
+++ b/meta/SaiAttributeList.cpp
@@ -35,6 +35,9 @@ SaiAttributeList::SaiAttributeList(
             SWSS_LOG_THROW("FATAL: failed to find metadata for object type %d and attr id %d", objectType, attr.id);
         }
 
+        if (SAI_HAS_FLAG_IDENTIFY(meta->flags))
+            continue;
+
         sai_deserialize_attr_value(str_attr_value, *meta, attr, countOnly);
 
         m_attr_list.push_back(attr);
@@ -70,6 +73,9 @@ SaiAttributeList::SaiAttributeList(
         {
             SWSS_LOG_THROW("FATAL: failed to find metadata for object type %d and attr id %d", objectType, attr.id);
         }
+
+        if (SAI_HAS_FLAG_IDENTIFY(meta->flags))
+            continue;
 
         sai_deserialize_attr_value(str_attr_value, *meta, attr, countOnly);
 


### PR DESCRIPTION
- What I did
  Use the Identify attribute to fix the issue that view comparison for LAG [Azure/SONiC#354](https://github.com/Azure/sonic-sairedis/issues/354)

- How I did it
  Add SAI_LAG_ATTR_NAME to identify the LAG.
  It needs to set SAI_LAG_ATTR_NAME when create LAG.
  For view comparison, it uses this attribute to find the matched LAG.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>