### PR TITLE
Change log level 

### DIFF
--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -557,7 +557,7 @@ sai_status_t SwitchStateBase::get(
 
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("%s read only not implemented on %s",
+                SWSS_LOG_INFO("%s read only not implemented on %s",
                         meta->attridname,
                         serializedObjectId.c_str());
 
@@ -569,7 +569,7 @@ sai_status_t SwitchStateBase::get(
 
         if (ait == attrHash.end())
         {
-            SWSS_LOG_ERROR("%s not implemented on %s",
+            SWSS_LOG_INFO("%s not implemented on %s",
                     meta->attridname,
                     serializedObjectId.c_str());
 


### PR DESCRIPTION
Change log level for not implemented port attributes and skipped mac learning
What I did:

Change log level from warning/error to debug.

Why I did:

Due to execessive logging we were observing that, orchagent or syncd or bot get stuck in send() system call of logging. This was happening because rsyslog was NOT reading from socket buffer. Verified this by sending SIGSTOP and SIGCONT to rsyslogd. This problem happened everytime we ran Dynamic Port Brteakout scale test case. (test_port_dpb.py)

How I verified:

Ran DPB test case again in Jenkins, the problem did NOT occur