### PR TITLE
Update the meta code to support DNAT Pool changes

### DIFF
--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -153,6 +153,9 @@ std::string sai_serialize_l2mc_entry_type(
 std::string sai_serialize_ipmc_entry_type(
         _In_ const sai_ipmc_entry_type_t type);
 
+std::string sai_serialize_nat_entry_type(
+        _In_ const sai_nat_type_t type);
+
 std::string sai_serialize_qos_map_item(
         _In_ const sai_qos_map_t& qosmap);
 
@@ -209,6 +212,10 @@ void sai_deserialize_neighbor_entry(
 void sai_deserialize_route_entry(
         _In_ const std::string& s,
         _In_ sai_route_entry_t &route_entry);
+
+void sai_deserialize_nat_entry_type(
+        _In_ const std::string& s,
+        _Out_ sai_nat_type_t& type);
 
 void sai_deserialize_nat_entry(
         _In_ const std::string& s,

--- a/meta/saiserialize.cpp
+++ b/meta/saiserialize.cpp
@@ -1691,6 +1691,14 @@ json sai_serialize_nat_entry_data(
     return j;
 }
 
+std::string sai_serialize_nat_entry_type(
+        _In_ const sai_nat_type_t type)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_enum(type, &sai_metadata_enum_sai_nat_type_t);
+}
+
 std::string sai_serialize_nat_entry(
         _In_ const sai_nat_entry_t& nat_entry)
 {
@@ -1700,6 +1708,7 @@ std::string sai_serialize_nat_entry(
 
     j["switch_id"] = sai_serialize_object_id(nat_entry.switch_id);
     j["vr"]        = sai_serialize_object_id(nat_entry.vr_id);
+    j["nat_type"]  = sai_serialize_nat_entry_type(nat_entry.nat_type);
     j["nat_data"]  = sai_serialize_nat_entry_data(nat_entry.data);
 
     return j.dump();
@@ -2755,6 +2764,15 @@ void sai_deserialize_nat_entry_data(
     sai_deserialize_nat_entry_key(j["key"], nat_entry_data.key);
     sai_deserialize_nat_entry_mask(j["mask"], nat_entry_data.mask);
 }
+
+void sai_deserialize_nat_entry_type(
+        _In_ const std::string& s,
+        _Out_ sai_nat_type_t& type)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_enum(s, &sai_metadata_enum_sai_nat_type_t, (int32_t&)type);
+}
  
 void sai_deserialize_nat_entry(
         _In_ const std::string &s,
@@ -2766,6 +2784,7 @@ void sai_deserialize_nat_entry(
 
     sai_deserialize_object_id(j["switch_id"], nat_entry.switch_id);
     sai_deserialize_object_id(j["vr"], nat_entry.vr_id);
+    sai_deserialize_nat_entry_type(j["nat_type"], nat_entry.nat_type);
     sai_deserialize_nat_entry_data(j["nat_data"], nat_entry.data);
 }
 

--- a/syncd/syncd_applyview.cpp
+++ b/syncd/syncd_applyview.cpp
@@ -1704,7 +1704,8 @@ class AsicView
 
                     switch (meta->attrid)
                     {
-
+                        case SAI_NAT_ENTRY_ATTR_PACKET_COUNT:
+                        case SAI_NAT_ENTRY_ATTR_BYTE_COUNT:
                         case SAI_NAT_ENTRY_ATTR_HIT_BIT_COR:
                         case SAI_NAT_ENTRY_ATTR_HIT_BIT:
 


### PR DESCRIPTION
Added nat_type attribute in serialize and deserialize meta code to support DNAT Pool.

Addressing the issue - https://github.com/Azure/sonic-swss/issues/1234 

Depends on :
https://github.com/Azure/sonic-swss/pull/1297
https://github.com/Azure/sonic-utilities/pull/921

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>