### PR TITLE
Fix debian/rules makefile: use shell commands instead of dollar replacements

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -63,7 +63,7 @@ binary-syncd-vs:
 
 override_dh_auto_configure:
 	./autogen.sh
-	dh_auto_configure -- $(cat /tmp/syncd-build) ${SWSS_COMMON_CONFIG}
+	dh_auto_configure -- $(shell cat /tmp/syncd-build) ${SWSS_COMMON_CONFIG}
 
 override_dh_install:
 	dh_install

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,10 @@
 # output every command that modifies files on the build system.
 #export DH_VERBOSE = 1
 
+.ONESHELL:
+SHELL = /bin/bash
+.SHELLFLAGS += -x
+
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
@@ -34,13 +38,13 @@ build:
 binary: binary-syncd-rpc binary-syncd
 
 binary-syncd:
-	$(shell echo > /tmp/syncd-build)
+	echo > /tmp/syncd-build
 	dh clean  --with autotools-dev
 	dh build  -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 	dh binary -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 
 binary-syncd-rpc: | binary-syncd
-	$(shell echo '--enable-rpcserver=yes' > /tmp/syncd-build)
+	echo '--enable-rpcserver=yes' > /tmp/syncd-build
 	dh clean  --with autotools-dev
 	dh build  -N syncd -N syncd-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 	dh binary -N syncd -N syncd-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
@@ -59,13 +63,15 @@ binary-syncd-vs:
 
 override_dh_auto_configure:
 	./autogen.sh
-	dh_auto_configure -- $(shell cat /tmp/syncd-build) ${SWSS_COMMON_CONFIG}
+	dh_auto_configure -- $(cat /tmp/syncd-build) ${SWSS_COMMON_CONFIG}
 
 override_dh_install:
 	dh_install
-ifeq ($(shell cat /tmp/syncd-build), --enable-rpcserver=yes)
-	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
-endif
+	echo "override_dh_install!!"
+	# Note: escape $ with an extra $
+	if egrep -q '(^| )--enable-rpcserver=yes( |$$)' /tmp/syncd-build
+		sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
+	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd

--- a/debian/rules
+++ b/debian/rules
@@ -67,8 +67,8 @@ override_dh_auto_configure:
 
 override_dh_install:
 	dh_install
-	# Note: escape $ with an extra $
-	if egrep -q '(^| )--enable-rpcserver=yes( |$$)' /tmp/syncd-build
+	# Note: escape $ with an extra $ symbol
+	if egrep -q '(^| )--enable-rpcserver=yes( |$$)' /tmp/syncd-build && [ -f debian/syncd-rpc/usr/bin/syncd_init_common.sh ] ; then
 		sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 	fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -50,7 +50,7 @@ binary-syncd-rpc: | binary-syncd
 	dh binary -N syncd -N syncd-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 
 binary-syncd-vs:
-	$(shell echo '--with-sai=vs' > /tmp/syncd-build)
+	echo '--with-sai=vs' > /tmp/syncd-build
 	dh clean  --with autotools-dev
 	dh build  -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg --with autotools-dev
 	dh binary -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg --with autotools-dev
@@ -67,7 +67,6 @@ override_dh_auto_configure:
 
 override_dh_install:
 	dh_install
-	echo "override_dh_install!!"
 	# Note: escape $ with an extra $
 	if egrep -q '(^| )--enable-rpcserver=yes( |$$)' /tmp/syncd-build
 		sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh


### PR DESCRIPTION
because:
1. `make` evaluates conditionals (e.g., `ifeq`) at the time it reads a Makefile.
2. no need to replace with shell command outputs

ref: https://stackoverflow.com/a/11994561/2514803