### PR TITLE
add option to build without syncd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,7 @@
-SUBDIRS = meta lib vslib syncd saiplayer saidump saidiscovery tests saisdkdump python
+SUBDIRS = meta lib vslib python
+
+if SYNCD
+SUBDIRS += syncd saiplayer saidump saidiscovery saisdkdump tests
+endif
+
+ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -33,15 +33,27 @@ AM_CONDITIONAL(SAIVS,   test x$sai = xvs)
 
 AC_ARG_WITH(swss-common-inc,
 [  --with-swss-common-inc=DIR
-                          prefix where swss-common includes are installed],
+                           prefix where swss-common includes are installed],
 [AC_SUBST(CPPFLAGS, "$CPPFLAGS -I${withval}")
  AC_SUBST(SWSS_COMMON_INC_DIR, "${withval}")])
 
 AC_ARG_WITH(swss-common-lib,
 [  --with-swss-common-lib=DIR
-                          prefix where swss-common libraries are installed],
+                           prefix where swss-common libraries are installed],
 [AC_SUBST(LDFLAGS, "$LDFLAGS -L${withval}")
  AC_SUBST(SWSS_COMMON_LIB_DIR, "${withval}")])
+
+AC_ARG_ENABLE(syncd,
+[  --enable-syncd          build syncd],
+[case "${enableval}" in
+   yes) syncd=true ;;
+   no)  syncd=false ;;
+   *) AC_MSG_ERROR(bad value ${enableval} for --enable-syncd) ;;
+esac],[syncd=true])
+AM_CONDITIONAL(SYNCD, test x$syncd = xtrue)
+AM_COND_IF([SYNCD], [
+        AM_COND_IF([SAIVS], [], [AC_CHECK_LIB([sai], [main], [AC_MSG_NOTICE(libsai found)], [AC_MSG_ERROR(libsai is required for syncd)])
+])])
 
 AC_ARG_ENABLE(rpcserver,
 [  --enable-rpcserver      compile with thrift rpcserver included],

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,12 @@ build:
 
 binary: binary-syncd-rpc binary-syncd
 
+binary-sairedis:
+	echo '--enable-syncd=no' > /tmp/syncd-build
+	dh clean  --with autotools-dev
+	dh build  -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
+	dh binary -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
+
 binary-syncd:
 	echo > /tmp/syncd-build
 	dh clean  --with autotools-dev

--- a/debian/syncd.install
+++ b/debian/syncd.install
@@ -1,5 +1,6 @@
 usr/bin/saidump
 usr/bin/saiplayer
 usr/bin/saisdkdump
+usr/bin/saidiscovery
 usr/bin/syncd*
 syncd/scripts/* usr/bin


### PR DESCRIPTION
this allows to build swss docker without building syncd with requires vendor SAI library.