### PR TITLE
Fixing hostif For Genetlink host interfaces

### DIFF
--- a/vslib/src/SwitchStateBaseHostif.cpp
+++ b/vslib/src/SwitchStateBaseHostif.cpp
@@ -722,9 +722,30 @@ sai_status_t SwitchStateBase::vs_remove_hostif_tap_interface(
 
     sai_attribute_t attr;
 
+
+    attr.id = SAI_HOSTIF_ATTR_TYPE;
+    sai_status_t status = get(SAI_OBJECT_TYPE_HOSTIF, hostif_id, 1, &attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("failed to get attr type for hostif %s",
+                sai_serialize_object_id(hostif_id).c_str());
+        return status;
+    }
+
+
+    /* The genetlink host interface is created to associate trap group to genetlink family and multicast group
+     * created by driver. It does not create any netdev interface. Hence skipping tap interface deletion
+     */
+    if (attr.value.s32 == SAI_HOSTIF_TYPE_GENETLINK)
+    {
+        SWSS_LOG_DEBUG("Skipping tap delete for hostif type genetlink");
+        return SAI_STATUS_SUCCESS;
+    }
+
     attr.id = SAI_HOSTIF_ATTR_NAME;
 
-    sai_status_t status = get(SAI_OBJECT_TYPE_HOSTIF, hostif_id, 1, &attr);
+    status = get(SAI_OBJECT_TYPE_HOSTIF, hostif_id, 1, &attr);
 
     if (status != SAI_STATUS_SUCCESS)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed the delete API for Hostif type genetlink in vs

**Why I did it**
The hostif type genetlink does not create any tap interfaces. Hence during remove there is no tap interfaces to be removed. Without the check to skip removing tap interfaces the remove hostif API would fail

**How I verified it**
The verification is done using manual testing and by pytests simluating create and remove genetlink hostif scenarios.

**Details if related**

