### PR TITLE
Adding support for new SAI API sai_query_attribute_capability()

### DIFF
--- a/lib/inc/Recorder.h
+++ b/lib/inc/Recorder.h
@@ -290,7 +290,7 @@ namespace sairedis
                     _In_ sai_status_t status,
                     _In_ const uint64_t *count);
 
-            void recordQueryAattributeCapability(
+            void recordQueryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/lib/inc/Recorder.h
+++ b/lib/inc/Recorder.h
@@ -296,7 +296,7 @@ namespace sairedis
                     _In_ sai_attr_id_t attr_id,
                     _Out_ sai_attr_capability_t *capability);
 
-            void recordQueryAattributeCapabilityResponse(
+            void recordQueryAttributeCapabilityResponse(
                     _In_ sai_status_t status,
                     _In_ sai_object_type_t objectType,
                     _In_ sai_attr_id_t attrId,

--- a/lib/inc/Recorder.h
+++ b/lib/inc/Recorder.h
@@ -290,6 +290,18 @@ namespace sairedis
                     _In_ sai_status_t status,
                     _In_ const uint64_t *count);
 
+            void recordQueryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability);
+
+            void recordQueryAattributeCapabilityResponse(
+                    _In_ sai_status_t status,
+                    _In_ sai_object_type_t objectType,
+                    _In_ sai_attr_id_t attrId,
+                    _In_ const sai_attr_capability_t* capability);
+
             void recordQueryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
@@ -303,6 +315,14 @@ namespace sairedis
                     _In_ const sai_s32_list_t* enumValuesCapability);
 
             // TODO move to private
+            void recordQueryAttributeCapability(
+                    _In_ const std::string& key,
+                    _In_ const std::vector<swss::FieldValueTuple>& arguments);
+
+            void recordQueryAttributeCapabilityResponse(
+                    _In_ sai_status_t status,
+                    _In_ const std::vector<swss::FieldValueTuple>& arguments);
+
             void recordQueryAttributeEnumValuesCapability(
                     _In_ const std::string& key,
                     _In_ const std::vector<swss::FieldValueTuple>& arguments);

--- a/lib/inc/RedisRemoteSaiInterface.h
+++ b/lib/inc/RedisRemoteSaiInterface.h
@@ -240,6 +240,12 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
@@ -385,6 +391,9 @@ namespace sairedis
             sai_status_t waitForFlushFdbEntriesResponse();
 
         private: // SAI API response
+
+            sai_status_t waitForQueryAattributeCapabilityResponse(
+                    _Out_ sai_attr_capability_t* capability);
 
             sai_status_t waitForQueryAattributeEnumValuesCapabilityResponse(
                     _Inout_ sai_s32_list_t* enumValuesCapability);

--- a/lib/inc/RedisRemoteSaiInterface.h
+++ b/lib/inc/RedisRemoteSaiInterface.h
@@ -240,7 +240,7 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,
@@ -392,7 +392,7 @@ namespace sairedis
 
         private: // SAI API response
 
-            sai_status_t waitForQueryAattributeCapabilityResponse(
+            sai_status_t waitForQueryAttributeCapabilityResponse(
                     _Out_ sai_attr_capability_t* capability);
 
             sai_status_t waitForQueryAattributeEnumValuesCapabilityResponse(

--- a/lib/inc/Sai.h
+++ b/lib/inc/Sai.h
@@ -231,6 +231,12 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/lib/inc/Sai.h
+++ b/lib/inc/Sai.h
@@ -231,7 +231,7 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/lib/inc/SaiInterface.h
+++ b/lib/inc/SaiInterface.h
@@ -242,6 +242,12 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) = 0;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) = 0;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/lib/inc/SaiInterface.h
+++ b/lib/inc/SaiInterface.h
@@ -242,7 +242,7 @@ namespace sairedis
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) = 0;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/lib/inc/sairediscommon.h
+++ b/lib/inc/sairediscommon.h
@@ -37,6 +37,9 @@
 #define REDIS_ASIC_STATE_COMMAND_FLUSH              "flush"
 #define REDIS_ASIC_STATE_COMMAND_FLUSHRESPONSE      "flushresponse"
 
+#define REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_QUERY      "attribute_capability_query"
+#define REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_RESPONSE   "attribute_capability_response"
+
 #define REDIS_ASIC_STATE_COMMAND_ATTR_ENUM_VALUES_CAPABILITY_QUERY      "attr_enum_values_capability_query"
 #define REDIS_ASIC_STATE_COMMAND_ATTR_ENUM_VALUES_CAPABILITY_RESPONSE   "attr_enum_values_capability_response"
 

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -265,6 +265,25 @@ void Recorder::recordFlushFdbEntriesResponse(
     recordLine("F|" + sai_serialize_status(status));
 }
 
+void Recorder::recordQueryAttributeCapability(
+        _In_ const std::string& key,
+        _In_ const std::vector<swss::FieldValueTuple>& arguments)
+{
+    SWSS_LOG_ENTER();
+
+    recordLine("q|attribute_capability|" + key + "|" + joinFieldValues(arguments));
+}
+
+void Recorder::recordQueryAttributeCapabilityResponse(
+        _In_ sai_status_t status,
+        _In_ const std::vector<swss::FieldValueTuple>& arguments)
+{
+    SWSS_LOG_ENTER();
+
+    recordLine("Q|attribute_capability|" + sai_serialize_status(status) + "|" + joinFieldValues(arguments));
+}
+
+
 void Recorder::recordQueryAttributeEnumValuesCapability(
         _In_ const std::string& key,
         _In_ const std::vector<swss::FieldValueTuple>& arguments)
@@ -884,6 +903,76 @@ void Recorder::recordObjectTypeGetAvailabilityResponse(
     values.push_back(swss::FieldValueTuple("COUNT", std::to_string(*count)));
 
     recordObjectTypeGetAvailabilityResponse(status, values);
+}
+
+void Recorder::recordQueryAattributeCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
+        _Out_ sai_attr_capability_t *Capability)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(objectType, attrId);
+
+    if (meta == NULL)
+    {
+        SWSS_LOG_ERROR("Failed to find attribute metadata: object type %s, attr id %d",
+                sai_serialize_object_type(objectType).c_str(), attrId);
+        return;
+    }
+
+    auto key = sai_serialize_object_type(SAI_OBJECT_TYPE_SWITCH) + ":" + sai_serialize_object_id(switchId);
+
+    auto object_type_str = sai_serialize_object_type(objectType);
+    const std::string attr_id_str = meta->attridname;
+    const std::vector<swss::FieldValueTuple> values =
+    {
+        swss::FieldValueTuple("OBJECT_TYPE", object_type_str),
+        swss::FieldValueTuple("ATTR_ID", attr_id_str)
+    };
+
+    SWSS_LOG_DEBUG("Query arguments: switch %s, object_type: %s, attribute: %s",
+                key.c_str(),
+                object_type_str.c_str(),
+                meta->attridname);
+
+    recordQueryAttributeCapability(key, values);
+}
+
+
+void Recorder::recordQueryAattributeCapabilityResponse(
+        _In_ sai_status_t status,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
+        _In_ const sai_attr_capability_t* capability)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(objectType, attrId);
+
+    if (meta == NULL)
+    {
+        SWSS_LOG_ERROR("Failed to find attribute metadata: object type %s, attr id %d",
+                sai_serialize_object_type(objectType).c_str(), attrId);
+        return;
+    }
+
+    auto object_type_str = sai_serialize_object_type(objectType);
+    const std::string attr_id_str = meta->attridname;
+    const std::string create_str = (status == SAI_STATUS_SUCCESS ? (capability->create_implemented? "true":"false"): "false");
+    const std::string set_str    = (status == SAI_STATUS_SUCCESS ? (capability->set_implemented? "true":"false"): "false");
+    const std::string get_str    = (status == SAI_STATUS_SUCCESS ? (capability->get_implemented? "true":"false"): "false");
+    const std::vector<swss::FieldValueTuple> values =
+    {
+        swss::FieldValueTuple("OBJECT_TYPE", object_type_str),
+        swss::FieldValueTuple("ATTR_ID", attr_id_str),
+        swss::FieldValueTuple("CREATE_IMP", create_str),
+        swss::FieldValueTuple("SET_IMP", set_str),
+        swss::FieldValueTuple("GET_IMP", get_str)
+    };
+
+    recordQueryAttributeCapabilityResponse(status, values);
 }
 
 void Recorder::recordQueryAattributeEnumValuesCapability(

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -905,7 +905,7 @@ void Recorder::recordObjectTypeGetAvailabilityResponse(
     recordObjectTypeGetAvailabilityResponse(status, values);
 }
 
-void Recorder::recordQueryAattributeCapability(
+void Recorder::recordQueryAttributeCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -941,7 +941,7 @@ void Recorder::recordQueryAattributeCapability(
 }
 
 
-void Recorder::recordQueryAattributeCapabilityResponse(
+void Recorder::recordQueryAttributeCapabilityResponse(
         _In_ sai_status_t status,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -895,38 +895,12 @@ sai_status_t RedisRemoteSaiInterface::waitForQueryAttributeCapabilityResponse(
             return SAI_STATUS_FAILURE;
         }
 
-        const uint32_t create_implemented = std::stoi(fvValue(values[0]));
-        const uint32_t set_implemented = std::stoi(fvValue(values[1]));
-        const uint32_t get_implemented = std::stoi(fvValue(values[2]));
+        capability->create_implemented = (fvValue(values[0]) == "true" ? true : false);
+        capability->set_implemented    = (fvValue(values[1]) == "true" ? true : false);
+        capability->get_implemented    = (fvValue(values[2]) == "true" ? true : false);
 
-        SWSS_LOG_DEBUG("Received payload: create_implemented:%d, set_implemented:%d, get_implemented:%d",
-            create_implemented, set_implemented, get_implemented);
-
-        if(create_implemented)
-        {
-            capability->create_implemented = true;
-        }
-        else
-        {
-            capability->create_implemented = false;
-        }
-        if(set_implemented)
-        {
-            capability->set_implemented = true;
-        }
-        else
-        {
-            capability->set_implemented = false;
-        }
-
-        if(get_implemented)
-        {
-            capability->get_implemented = true;
-        }
-        else
-        {
-            capability->get_implemented = false;
-        }
+        SWSS_LOG_DEBUG("Received payload: create_implemented:%s, set_implemented:%s, get_implemented:%s",
+            (capability->create_implemented? "true":"false"), (capability->set_implemented? "true":"false"), (capability->get_implemented? "true":"false"));
     }
 
     return status;

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -827,7 +827,7 @@ sai_status_t RedisRemoteSaiInterface::waitForObjectTypeGetAvailabilityResponse(
     return status;
 }
 
-sai_status_t RedisRemoteSaiInterface::queryAattributeCapability(
+sai_status_t RedisRemoteSaiInterface::queryAttributeCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,
@@ -835,30 +835,30 @@ sai_status_t RedisRemoteSaiInterface::queryAattributeCapability(
 {
     SWSS_LOG_ENTER();
 
-    auto switch_id_str = sai_serialize_object_id(switchId);
-    auto object_type_str = sai_serialize_object_type(objectType);
+    auto switchIdStr = sai_serialize_object_id(switchId);
+    auto objectTypeStr = sai_serialize_object_type(objectType);
 
     auto meta = sai_metadata_get_attr_metadata(objectType, attrId);
 
     if (meta == NULL)
     {
-        SWSS_LOG_ERROR("Failed to find attribute metadata: object type %s, attr id %d", object_type_str.c_str(), attrId);
+        SWSS_LOG_ERROR("Failed to find attribute metadata: object type %s, attr id %d", objectTypeStr.c_str(), attrId);
         return SAI_STATUS_INVALID_PARAMETER;
     }
 
-    const std::string attr_id_str = meta->attridname;
+    const std::string attrIdStr = meta->attridname;
 
     const std::vector<swss::FieldValueTuple> entry =
     {
-        swss::FieldValueTuple("OBJECT_TYPE", object_type_str),
-        swss::FieldValueTuple("ATTR_ID", attr_id_str)
+        swss::FieldValueTuple("OBJECT_TYPE", objectTypeStr),
+        swss::FieldValueTuple("ATTR_ID", attrIdStr)
     };
 
     SWSS_LOG_DEBUG(
             "Query arguments: switch %s, object type: %s, attribute: %s",
-            switch_id_str.c_str(),
-            object_type_str.c_str(),
-            attr_id_str.c_str()
+            switchIdStr.c_str(),
+            objectTypeStr.c_str(),
+            attrIdStr.c_str()
     );
 
     // This query will not put any data into the ASIC view, just into the
@@ -866,16 +866,16 @@ sai_status_t RedisRemoteSaiInterface::queryAattributeCapability(
 
     m_recorder->recordQueryAattributeCapability(switchId, objectType, attrId, capability);
 
-    m_redisChannel->set(switch_id_str, entry, REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_QUERY);
+    m_redisChannel->set(switchIdStr, entry, REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_QUERY);
 
-    auto status = waitForQueryAattributeCapabilityResponse(capability);
+    auto status = waitForQueryAttributeCapabilityResponse(capability);
 
     m_recorder->recordQueryAattributeCapabilityResponse(status, objectType, attrId, capability);
 
     return status;
 }
 
-sai_status_t RedisRemoteSaiInterface::waitForQueryAattributeCapabilityResponse(
+sai_status_t RedisRemoteSaiInterface::waitForQueryAttributeCapabilityResponse(
         _Out_ sai_attr_capability_t* capability)
 {
     SWSS_LOG_ENTER();
@@ -916,12 +916,6 @@ sai_status_t RedisRemoteSaiInterface::waitForQueryAattributeCapabilityResponse(
             capability->get_implemented = true;
         else
             capability->get_implemented = false;
-    }
-    else if (status ==  SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        // TODO on sai status overflow we should populate correct count on the list
-
-        SWSS_LOG_ERROR("TODO need to handle SAI_STATUS_BUFFER_OVERFLOW, FIXME");
     }
 
     return status;

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -864,7 +864,7 @@ sai_status_t RedisRemoteSaiInterface::queryAttributeCapability(
     // This query will not put any data into the ASIC view, just into the
     // message queue
 
-    m_recorder->recordQueryAattributeCapability(switchId, objectType, attrId, capability);
+    m_recorder->recordQueryAttributeCapability(switchId, objectType, attrId, capability);
 
     m_redisChannel->set(switchIdStr, entry, REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_QUERY);
 

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -870,7 +870,7 @@ sai_status_t RedisRemoteSaiInterface::queryAttributeCapability(
 
     auto status = waitForQueryAttributeCapabilityResponse(capability);
 
-    m_recorder->recordQueryAattributeCapabilityResponse(status, objectType, attrId, capability);
+    m_recorder->recordQueryAttributeCapabilityResponse(status, objectType, attrId, capability);
 
     return status;
 }
@@ -903,19 +903,30 @@ sai_status_t RedisRemoteSaiInterface::waitForQueryAttributeCapabilityResponse(
             create_implemented, set_implemented, get_implemented);
 
         if(create_implemented)
+        {
             capability->create_implemented = true;
+        }
         else
+        {
             capability->create_implemented = false;
-
+        }
         if(set_implemented)
+        {
             capability->set_implemented = true;
+        }
         else
+        {
             capability->set_implemented = false;
+        }
 
         if(get_implemented)
+        {
             capability->get_implemented = true;
+        }
         else
+        {
             capability->get_implemented = false;
+        }
     }
 
     return status;

--- a/lib/src/Sai.cpp
+++ b/lib/src/Sai.cpp
@@ -576,7 +576,7 @@ sai_status_t Sai::objectTypeGetAvailability(
             count);
 }
 
-sai_status_t Sai::queryAattributeCapability(
+sai_status_t Sai::queryAttributeCapability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
         _In_ sai_attr_id_t attr_id,
@@ -587,7 +587,7 @@ sai_status_t Sai::queryAattributeCapability(
     REDIS_CHECK_API_INITIALIZED();
     REDIS_CHECK_CONTEXT(switch_id);
 
-    return context->m_meta->queryAattributeCapability(
+    return context->m_meta->queryAttributeCapability(
             switch_id,
             object_type,
             attr_id,

--- a/lib/src/Sai.cpp
+++ b/lib/src/Sai.cpp
@@ -576,6 +576,24 @@ sai_status_t Sai::objectTypeGetAvailability(
             count);
 }
 
+sai_status_t Sai::queryAattributeCapability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ sai_attr_id_t attr_id,
+        _Out_ sai_attr_capability_t *capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+    REDIS_CHECK_CONTEXT(switch_id);
+
+    return context->m_meta->queryAattributeCapability(
+            switch_id,
+            object_type,
+            attr_id,
+            capability);
+}
+
 sai_status_t Sai::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,

--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -105,6 +105,21 @@ sai_status_t sai_api_query(
     return SAI_STATUS_INVALID_PARAMETER;
 }
 
+sai_status_t sai_query_attribute_capability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ sai_attr_id_t attr_id,
+        _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    return redis_sai->queryAattributeCapability(
+            switch_id,
+            object_type,
+            attr_id,
+            capability);
+}
+
 sai_status_t sai_query_attribute_enum_values_capability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,

--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -113,7 +113,7 @@ sai_status_t sai_query_attribute_capability(
 {
     SWSS_LOG_ENTER();
 
-    return redis_sai->queryAattributeCapability(
+    return redis_sai->queryAttributeCapability(
             switch_id,
             object_type,
             attr_id,

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -153,7 +153,7 @@ sai_status_t DummySaiInterface::objectTypeGetAvailability(
     return m_status;
 }
 
-sai_status_t DummySaiInterface::queryAattributeCapability(
+sai_status_t DummySaiInterface::queryAttributeCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -153,6 +153,17 @@ sai_status_t DummySaiInterface::objectTypeGetAvailability(
     return m_status;
 }
 
+sai_status_t DummySaiInterface::queryAattributeCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
+        _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    return m_status;
+}
+
 sai_status_t DummySaiInterface::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -230,7 +230,7 @@ namespace saimeta
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -230,6 +230,12 @@ namespace saimeta
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1856,6 +1856,37 @@ sai_status_t Meta::objectTypeGetAvailability(
     return status;
 }
 
+sai_status_t Meta::queryAattributeCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
+        _Out_ sai_attr_capability_t *Capability)
+{
+    SWSS_LOG_ENTER();
+
+    PARAMETER_CHECK_OID_OBJECT_TYPE(switchId, SAI_OBJECT_TYPE_SWITCH);
+    PARAMETER_CHECK_OID_EXISTS(switchId, SAI_OBJECT_TYPE_SWITCH);
+    PARAMETER_CHECK_OBJECT_TYPE_VALID(objectType);
+
+    auto mdp = sai_metadata_get_attr_metadata(objectType, attrId);
+
+    if (!mdp)
+    {
+        SWSS_LOG_ERROR("unable to find attribute: %s:%d",
+                sai_serialize_object_type(objectType).c_str(),
+                attrId);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    PARAMETER_CHECK_IF_NOT_NULL(Capability);
+
+    auto status = m_implementation->queryAattributeCapability(switchId, objectType, attrId, Capability);
+
+    return status;
+}
+
+
 sai_status_t Meta::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1856,11 +1856,11 @@ sai_status_t Meta::objectTypeGetAvailability(
     return status;
 }
 
-sai_status_t Meta::queryAattributeCapability(
+sai_status_t Meta::queryAttributeCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,
-        _Out_ sai_attr_capability_t *Capability)
+        _Out_ sai_attr_capability_t *capability)
 {
     SWSS_LOG_ENTER();
 
@@ -1879,9 +1879,9 @@ sai_status_t Meta::queryAattributeCapability(
         return SAI_STATUS_INVALID_PARAMETER;
     }
 
-    PARAMETER_CHECK_IF_NOT_NULL(Capability);
+    PARAMETER_CHECK_IF_NOT_NULL(capability);
 
-    auto status = m_implementation->queryAattributeCapability(switchId, objectType, attrId, Capability);
+    auto status = m_implementation->queryAttributeCapability(switchId, objectType, attrId, capability);
 
     return status;
 }

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -235,6 +235,12 @@ namespace saimeta
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -235,7 +235,7 @@ namespace saimeta
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -352,9 +352,9 @@ sai_status_t Syncd::processAttrCapabilityQuery(
     {
         entry =
         {
-            swss::FieldValueTuple("CREATE_IMPLEMENTED", std::to_string(capability.create_implemented)),
-            swss::FieldValueTuple("SET_IMPLEMENTED", std::to_string(capability.set_implemented)),
-            swss::FieldValueTuple("GET_IMPLEMENTED", std::to_string(capability.get_implemented))
+            swss::FieldValueTuple("CREATE_IMPLEMENTED", (capability.create_implemented ? "true" : "false")),
+            swss::FieldValueTuple("SET_IMPLEMENTED",    (capability.set_implemented    ? "true" : "false")),
+            swss::FieldValueTuple("GET_IMPLEMENTED",    (capability.get_implemented    ? "true" : "false"))
         };
 
         SWSS_LOG_INFO("Sending response: create_implemented:%d, set_implemented:%d, get_implemented:%d",

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -344,7 +344,7 @@ sai_status_t Syncd::processAttrCapabilityQuery(
 
     sai_attr_capability_t capability;
 
-    sai_status_t status = m_vendorSai->queryAattributeCapability(switchRid, objectType, attrId, &capability);
+    sai_status_t status = m_vendorSai->queryAttributeCapability(switchRid, objectType, attrId, &capability);
 
     std::vector<swss::FieldValueTuple> entry;
 
@@ -357,7 +357,7 @@ sai_status_t Syncd::processAttrCapabilityQuery(
             swss::FieldValueTuple("GET_IMPLEMENTED", std::to_string(capability.get_implemented))
         };
 
-        SWSS_LOG_DEBUG("Sending response: create_implemented:%d, set_implemented:%d, get_implemented:%d",
+        SWSS_LOG_INFO("Sending response: create_implemented:%d, set_implemented:%d, get_implemented:%d",
             capability.create_implemented, capability.set_implemented, capability.get_implemented);
     }
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -301,6 +301,9 @@ sai_status_t Syncd::processSingleEvent(
     if (op == REDIS_ASIC_STATE_COMMAND_FLUSH)
         return processFdbFlush(kco);
 
+    if (op == REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_QUERY)
+        return processAttrCapabilityQuery(kco);
+
     if (op == REDIS_ASIC_STATE_COMMAND_ATTR_ENUM_VALUES_CAPABILITY_QUERY)
         return processAttrEnumValuesCapabilityQuery(kco);
 
@@ -308,6 +311,59 @@ sai_status_t Syncd::processSingleEvent(
         return processObjectTypeGetAvailabilityQuery(kco);
 
     SWSS_LOG_THROW("event op '%s' is not implemented, FIXME", op.c_str());
+}
+
+sai_status_t Syncd::processAttrCapabilityQuery(
+        _In_ const swss::KeyOpFieldsValuesTuple &kco)
+{
+    SWSS_LOG_ENTER();
+
+    auto& strSwitchVid = kfvKey(kco);
+
+    sai_object_id_t switchVid;
+    sai_deserialize_object_id(strSwitchVid, switchVid);
+
+    sai_object_id_t switchRid = m_translator->translateVidToRid(switchVid);
+
+    auto& values = kfvFieldsValues(kco);
+
+    if (values.size() != 2)
+    {
+        SWSS_LOG_ERROR("Invalid input: expected 2 arguments, received %zu", values.size());
+
+        m_getResponse->set(sai_serialize_status(SAI_STATUS_INVALID_PARAMETER), {}, REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_RESPONSE);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_type_t objectType;
+    sai_deserialize_object_type(fvValue(values[0]), objectType);
+
+    sai_attr_id_t attrId;
+    sai_deserialize_attr_id(fvValue(values[1]), attrId);
+
+    sai_attr_capability_t capability;
+
+    sai_status_t status = m_vendorSai->queryAattributeCapability(switchRid, objectType, attrId, &capability);
+
+    std::vector<swss::FieldValueTuple> entry;
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        entry =
+        {
+            swss::FieldValueTuple("CREATE_IMPLEMENTED", std::to_string(capability.create_implemented)),
+            swss::FieldValueTuple("SET_IMPLEMENTED", std::to_string(capability.set_implemented)),
+            swss::FieldValueTuple("GET_IMPLEMENTED", std::to_string(capability.get_implemented))
+        };
+
+        SWSS_LOG_DEBUG("Sending response: create_implemented:%d, set_implemented:%d, get_implemented:%d",
+            capability.create_implemented, capability.set_implemented, capability.get_implemented);
+    }
+
+    m_getResponse->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_ATTR_CAPABILITY_RESPONSE);
+
+    return status;
 }
 
 sai_status_t Syncd::processAttrEnumValuesCapabilityQuery(

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -120,6 +120,9 @@ namespace syncd
             sai_status_t processSingleEvent(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
+            sai_status_t processAttrCapabilityQuery(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
             sai_status_t processAttrEnumValuesCapabilityQuery(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -941,7 +941,7 @@ sai_status_t VendorSai::objectTypeGetAvailability(
             count);
 }
 
-sai_status_t VendorSai::queryAattributeCapability(
+sai_status_t VendorSai::queryAttributeCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,
         _In_ sai_attr_id_t attrId,

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -941,6 +941,27 @@ sai_status_t VendorSai::objectTypeGetAvailability(
             count);
 }
 
+sai_status_t VendorSai::queryAattributeCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
+        _Out_ sai_attr_capability_t *capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+#if 0 // Wait until BRCM fix their SAI issue then enable this
+    return sai_query_attribute_capability(
+            switchId,
+            objectType,
+            attrId,
+            capability);
+#else
+    return SAI_STATUS_NOT_IMPLEMENTED;
+#endif
+}
+
 sai_status_t VendorSai::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t objectType,

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -227,6 +227,12 @@ namespace syncd
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -227,7 +227,7 @@ namespace syncd
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/vslib/inc/Sai.h
+++ b/vslib/inc/Sai.h
@@ -232,6 +232,12 @@ namespace saivs
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/vslib/inc/Sai.h
+++ b/vslib/inc/Sai.h
@@ -232,7 +232,7 @@ namespace saivs
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/vslib/inc/VirtualSwitchSaiInterface.h
+++ b/vslib/inc/VirtualSwitchSaiInterface.h
@@ -234,7 +234,7 @@ namespace saivs
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
-            virtual sai_status_t queryAattributeCapability(
+            virtual sai_status_t queryAttributeCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,
                     _In_ sai_attr_id_t attr_id,

--- a/vslib/inc/VirtualSwitchSaiInterface.h
+++ b/vslib/inc/VirtualSwitchSaiInterface.h
@@ -234,6 +234,12 @@ namespace saivs
                     _In_ const sai_attribute_t *attrList,
                     _Out_ uint64_t *count) override;
 
+            virtual sai_status_t queryAattributeCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_attr_id_t attr_id,
+                    _Out_ sai_attr_capability_t *capability) override;
+
             virtual sai_status_t queryAattributeEnumValuesCapability(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_type_t object_type,

--- a/vslib/src/Sai.cpp
+++ b/vslib/src/Sai.cpp
@@ -706,20 +706,20 @@ sai_status_t Sai::objectTypeGetAvailability(
             count);
 }
 
-sai_status_t Sai::queryAattributeCapability(
-        _In_ sai_object_id_t switch_id,
-        _In_ sai_object_type_t object_type,
-        _In_ sai_attr_id_t attr_id,
+sai_status_t Sai::queryAttributeCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _In_ sai_attr_id_t attrId,
         _Out_ sai_attr_capability_t *capability)
 {
     MUTEX();
     SWSS_LOG_ENTER();
     VS_CHECK_API_INITIALIZED();
 
-    return m_meta->queryAattributeCapability(
-            switch_id,
-            object_type,
-            attr_id,
+    return m_meta->queryAttributeCapability(
+            switchId,
+            objectType,
+            attrId,
             capability);
 }
 

--- a/vslib/src/Sai.cpp
+++ b/vslib/src/Sai.cpp
@@ -706,6 +706,23 @@ sai_status_t Sai::objectTypeGetAvailability(
             count);
 }
 
+sai_status_t Sai::queryAattributeCapability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ sai_attr_id_t attr_id,
+        _Out_ sai_attr_capability_t *capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VS_CHECK_API_INITIALIZED();
+
+    return m_meta->queryAattributeCapability(
+            switch_id,
+            object_type,
+            attr_id,
+            capability);
+}
+
 sai_status_t Sai::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -789,6 +789,37 @@ sai_status_t VirtualSwitchSaiInterface::objectTypeGetAvailability(
     return SAI_STATUS_NOT_SUPPORTED;
 }
 
+sai_status_t VirtualSwitchSaiInterface::queryAattributeCapability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ sai_attr_id_t attr_id,
+        _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO: We should generate this metadata for the virtual switch rather
+    // than hard-coding it here.
+
+    if (object_type == SAI_OBJECT_TYPE_PORT && attr_id == SAI_PORT_ATTR_TPID)
+    {
+        capability->create_implemented = true;
+        capability->set_implemented    = true;
+        capability->get_implemented    = true;
+
+        return SAI_STATUS_SUCCESS;
+    }
+    else if (object_type == SAI_OBJECT_TYPE_LAG && attr_id == SAI_LAG_ATTR_TPID)
+    {
+        capability->create_implemented = true;
+        capability->set_implemented    = true;
+        capability->get_implemented    = true;
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    return SAI_STATUS_NOT_SUPPORTED;
+}
+
 sai_status_t VirtualSwitchSaiInterface::queryAattributeEnumValuesCapability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -789,7 +789,7 @@ sai_status_t VirtualSwitchSaiInterface::objectTypeGetAvailability(
     return SAI_STATUS_NOT_SUPPORTED;
 }
 
-sai_status_t VirtualSwitchSaiInterface::queryAattributeCapability(
+sai_status_t VirtualSwitchSaiInterface::queryAttributeCapability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
         _In_ sai_attr_id_t attr_id,
@@ -800,24 +800,13 @@ sai_status_t VirtualSwitchSaiInterface::queryAattributeCapability(
     // TODO: We should generate this metadata for the virtual switch rather
     // than hard-coding it here.
 
-    if (object_type == SAI_OBJECT_TYPE_PORT && attr_id == SAI_PORT_ATTR_TPID)
-    {
-        capability->create_implemented = true;
-        capability->set_implemented    = true;
-        capability->get_implemented    = true;
+    // in virtual switch by default all apis are implemented for all objects. SUCCESS for all attributes
 
-        return SAI_STATUS_SUCCESS;
-    }
-    else if (object_type == SAI_OBJECT_TYPE_LAG && attr_id == SAI_LAG_ATTR_TPID)
-    {
-        capability->create_implemented = true;
-        capability->set_implemented    = true;
-        capability->get_implemented    = true;
+    capability->create_implemented = true;
+    capability->set_implemented    = true;
+    capability->get_implemented    = true;
 
-        return SAI_STATUS_SUCCESS;
-    }
-
-    return SAI_STATUS_NOT_SUPPORTED;
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t VirtualSwitchSaiInterface::queryAattributeEnumValuesCapability(

--- a/vslib/src/sai_vs_interfacequery.cpp
+++ b/vslib/src/sai_vs_interfacequery.cpp
@@ -104,6 +104,21 @@ sai_status_t sai_api_query(
     return SAI_STATUS_INVALID_PARAMETER;
 }
 
+sai_status_t sai_query_attribute_capability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ sai_attr_id_t attr_id,
+        _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    return vs_sai->queryAattributeCapability(
+            switch_id,
+            object_type,
+            attr_id,
+            capability);
+}
+
 sai_status_t sai_query_attribute_enum_values_capability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,

--- a/vslib/src/sai_vs_interfacequery.cpp
+++ b/vslib/src/sai_vs_interfacequery.cpp
@@ -112,7 +112,7 @@ sai_status_t sai_query_attribute_capability(
 {
     SWSS_LOG_ENTER();
 
-    return vs_sai->queryAattributeCapability(
+    return vs_sai->queryAttributeCapability(
             switch_id,
             object_type,
             attr_id,


### PR DESCRIPTION
This change adds the support of allowing application to invoking SAI API "sai_query_attribute_capability()" from the sonic application side. 
This change has been tested using the Mellanox platform by exercising this new change to query the port object attribute SAI_PORT_ATTR_TPID

    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_TPID, &capability);

as well as LAG object attribute SAI_LAG_ATTR_TPID.

    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_LAG, SAI_LAG_ATTR_TPID, &capability);

These two calls were exercised at orchagent init time in order to test out the changes are working.
I could not test this with BRCM platform due to the required SAI API "sai_query_attribute_capability()" although is defined in the SAI header file but was not part of the BRCM SAI code in 3.7.5.1 and causes link issue during build.  So the final change that I am asking to check in comments out the final call to "sai_query_attribute_capability()".  When BRCM SAI 4.2 (which has this SAI API support) is finally integrated into the master branch, I will have this uncommented out, tested and raise another PR to enable this full functionality.

Please see attached for the syslog and sairedis record captured during my testing using the Mellanox platform.
[AttrCapabilityQueryTestLog.txt](https://github.com/Azure/sonic-sairedis/files/4954988/AttrCapabilityQueryTestLog.txt)

Please note that this PR has a dependency on https://github.com/Azure/sonic-swss-common/pull/362
If this PR is needed in other branches, one must ensure that the change for https://github.com/Azure/sonic-swss-common/pull/362 is already picked up in that branch as well.