### PR TITLE
Workaround getSwitchType failure due to NPU SAI not yet supporting it

### DIFF
--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -140,7 +140,6 @@ void SaiSwitch::getDefaultMacAddress(
 sai_switch_type_t SaiSwitch::getSwitchType() const
 {
     SWSS_LOG_ENTER();
-
     sai_attribute_t attr;
 
     attr.id = SAI_SWITCH_ATTR_TYPE;
@@ -149,10 +148,12 @@ sai_switch_type_t SaiSwitch::getSwitchType() const
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_THROW("failed to get switch type");
+        SWSS_LOG_ERROR("failed to get switch type with status:0x%x. Assume default SAI_SWITCH_TYPE_NPU", status);
+        // Set to SAI_SWITCH_TYPE_NPU and move on
+        attr.value.s32 = SAI_SWITCH_TYPE_NPU;
     }
 
-    SWSS_LOG_ERROR("switch type: '%s'", (attr.value.s32 == SAI_SWITCH_TYPE_NPU ? "SAI_SWITCH_TYPE_NPU" : "SAI_SWITCH_TYPE_PHY"));
+    SWSS_LOG_INFO("switch type: '%s'", (attr.value.s32 == SAI_SWITCH_TYPE_NPU ? "SAI_SWITCH_TYPE_NPU" : "SAI_SWITCH_TYPE_PHY"));
 
     return (sai_switch_type_t) attr.value.s32;
 }


### PR DESCRIPTION
Changes from https://github.com/Azure/sonic-sairedis/pull/632 is causing BRCM DUT not able to bootup.
The newly introduced getSwithType at SONiC boot time to support BRCM GearBox SAI is not yet supported by ASIC SAI result to error that causes Orchagent termination at boot up.
This workaround is added to default the switch type to NPU in case receiving a failure from the SAI call so that BRCM DUT can boot up successfully.

I have validated this change using the Force10-S6000 (BRCM ASIC).

Kamil has also reviewed and OKed this change.