### PR TITLE
Fix synchronous with bulk API

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1497,7 +1497,7 @@ void Syncd::syncUpdateRedisBulkQuadEvent(
                     else
                         m_client->createAsicObject(metaKey, values);
 
-                    return;
+                    break;
                 }
 
             case SAI_COMMON_API_BULK_REMOVE:
@@ -1508,7 +1508,7 @@ void Syncd::syncUpdateRedisBulkQuadEvent(
                     else
                         m_client->removeAsicObject(metaKey);
 
-                    return;
+                    break;
                 }
 
             case SAI_COMMON_API_BULK_SET:
@@ -1524,11 +1524,11 @@ void Syncd::syncUpdateRedisBulkQuadEvent(
                     else
                         m_client->setAsicObject(metaKey, attr, value);
 
-                    return;
+                    break;
                 }
 
             case SAI_COMMON_API_GET:
-                return; // ignore get since get is not modifying db
+                break; // ignore get since get is not modifying db
 
             default:
 


### PR DESCRIPTION
- Why I did it
This PR contains the code changes so that the synchronous bulk API processes all events.

- How I did it
Let the syncUpdateRedisBulkQuadEvent function loop across all events in a bulk rather than returning after processing the first one.

- How to verify it
Verify route entries in ASIC_DB after loading multiple routes using swssconfig in vs tests with synchronous mode enabled.
