### PR TITLE
Re-enable support for new SAI API sai_query_attribute_capability()

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -951,15 +951,11 @@ sai_status_t VendorSai::queryAttributeCapability(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
-#if 0 // Wait until BRCM fix their SAI issue then enable this
     return sai_query_attribute_capability(
             switchId,
             objectType,
             attrId,
             capability);
-#else
-    return SAI_STATUS_NOT_IMPLEMENTED;
-#endif
 }
 
 sai_status_t VendorSai::queryAattributeEnumValuesCapability(


### PR DESCRIPTION
Previously the code to support query SAI attribute capabilities were commented out due to discovered missing BRCM Vendor SAI API missing in their 3.7.5.1 debian package that caused linking error during image build.  
See https://github.com/Azure/sonic-sairedis/pull/645 for details on the SAI attribute capability query support.

Since BRCM has provided the patch for the missing API stub code and included them in BRCM SAI 3.7.5.1-2 (see https://github.com/Azure/sonic-buildimage/pull/5101), I am raising this PR to re-enable the calling to Vendor SAI API sai_query_attribute_capability().

I have tested this with the new BRCM SAI 3.7.5.1-2 debians and ensured that the linking issue was fixed by that patch.
