### PR TITLE
Add synchronous switch controlled by CONFIG_DB

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -24,6 +24,12 @@ fi
 # Use temporary view between init and apply
 CMD_ARGS+=" -u"
 
+# Set synchronous mode if it is enabled in CONFIG_DB
+SYNC_MODE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.synchronous_mode)
+if [ "$SYNC_MODE" == "enable" ]; then
+    CMD_ARGS+=" -s"
+fi
+
 case "$(cat /proc/cmdline)" in
   *SONIC_BOOT_TYPE=fastfast*)
     if [ -e /var/warmboot/warm-starting ]; then


### PR DESCRIPTION
**-What I did**
Let syncd check CONFIG_DB for whether to enable synchronous mode and initialize with the mode selected.

**-Why I did it**
To allow master control of synchronous mode and allow configuring the mode for orchagent and syncd.

**-How I did it**
Let syncd check the mode in CONFIG_DB in `syncd_init_common.sh`

**-How I verified it**
Test locally with a virtual switch.

**-Details if related**
Related to #Azure/sonic-buildimage/pull/5237
