### PR TITLE
Prevent syncd from stopping swss in the presence of SAI failures in synchronous mode

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1244,15 +1244,6 @@ void Syncd::sendApiResponse(
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        /*
-         * TODO: If api fill fail in sync mode, we need to take some actions to
-         * handle that, and those are not trivial tasks:
-         *
-         * - in case create fail, remove object from redis database
-         * - in case remove fail, bring back removed object to database
-         * - in case set fail, bring back previous value if it was set
-         */
-
         SWSS_LOG_ERROR("api %s failed in syncd mode: %s, FIXME",
                     sai_serialize_common_api(api).c_str(),
                     sai_serialize_status(status).c_str());

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1244,7 +1244,7 @@ void Syncd::sendApiResponse(
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("api %s failed in syncd mode: %s, FIXME",
+        SWSS_LOG_ERROR("api %s failed in syncd mode: %s",
                     sai_serialize_common_api(api).c_str(),
                     sai_serialize_status(status).c_str());
     }

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1253,7 +1253,7 @@ void Syncd::sendApiResponse(
          * - in case set fail, bring back previous value if it was set
          */
 
-        SWSS_LOG_THROW("api %s failed in syncd mode: %s, FIXME",
+        SWSS_LOG_ERROR("api %s failed in syncd mode: %s, FIXME",
                     sai_serialize_common_api(api).c_str(),
                     sai_serialize_status(status).c_str());
     }


### PR DESCRIPTION
**What I did**
Let syncd send statuses to orchagent rather than stopping swss in the presence of SAI failures in synchronous mode.

**Why I did it**
I expect syncd to send the failure status to orchagent and let orchagent process the failure in synchronous mode when SAI failures happen. Currently, syncd would throw an exception and stop swss before the failure information is sent to orchagent. 

**How I did it**
Let syncd log the error message rather than throw the exception. As such, the syncd would not trigger swss shutdown in the presence of SAI failures.

**How I verified it**
Test locally with a virtual switch.
