### PR TITLE
Fix Warmboot Issue when upgraded Image SAI return Switch Internal OID not accounted in previous image.

### DIFF
--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -517,7 +517,7 @@ sai_object_id_t SaiSwitch::helperGetSwitchAttrOid(
          * Redis value of this attribute is not present yet, save it!
          */
 
-        redisSetDummyAsicStateForRealObjectId(rid);
+        redisSaveInternalOids(rid);
 
         SWSS_LOG_INFO("redis %s id is not defined yet in redis", meta->attridname);
 
@@ -742,6 +742,25 @@ std::set<sai_object_id_t> SaiSwitch::getWarmBootDiscoveredVids() const
     SWSS_LOG_ENTER();
 
     return m_warmBootDiscoveredVids;
+}
+
+void SaiSwitch::redisSaveInternalOids(_In_ sai_object_id_t rid) const
+{
+    SWSS_LOG_ENTER();
+
+    std::set<sai_object_id_t> coldVids;
+
+    sai_object_id_t vid = m_translator->translateRidToVid(rid, m_switch_vid);
+
+    coldVids.insert(vid);
+
+    m_client->setDummyAsicStateObject(vid);
+
+    m_client->saveColdBootDiscoveredVids(m_switch_vid, coldVids);
+
+    SWSS_LOG_NOTICE("put switch internal discovered rid %s to Asic View and COLDVIDS", 
+                    sai_serialize_object_id(rid).c_str());
+
 }
 
 void SaiSwitch::redisSaveColdBootDiscoveredVids() const

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -748,7 +748,8 @@ std::set<sai_object_id_t> SaiSwitch::getWarmBootDiscoveredVids() const
     return m_warmBootDiscoveredVids;
 }
 
-void SaiSwitch::redisSaveInternalOids(_In_ sai_object_id_t rid) const
+void SaiSwitch::redisSaveInternalOids(
+                                      _In_ sai_object_id_t rid) const
 {
     SWSS_LOG_ENTER();
 
@@ -762,7 +763,10 @@ void SaiSwitch::redisSaveInternalOids(_In_ sai_object_id_t rid) const
      * in ColdVid Table discovered as cold or warm boot.
      * Please note it is possible to discover new Switch internal OID in warm-boot also
      * if SAI gets upgraded as part of warm-boot so we are adding to ColdVid also
-     * so that comparison logic do not remove this OID in warm-boot case */
+     * so that comparison logic do not remove this OID in warm-boot case. One example
+     * is SAI_SWITCH_ATTR_DEFAULT_STP_INST_ID which is discovered in warm-boot 
+     * when upgrading to new SAI Version*/
+
 
     m_client->setDummyAsicStateObject(vid);
 

--- a/syncd/SaiSwitch.h
+++ b/syncd/SaiSwitch.h
@@ -299,7 +299,8 @@ namespace syncd
 
             void helperInternalOids();
 
-            void redisSaveInternalOids(_In_ sai_object_id_t rid) const;
+            void redisSaveInternalOids(
+                     _In_ sai_object_id_t rid) const;
 
             void helperLoadColdVids();
 

--- a/syncd/SaiSwitch.h
+++ b/syncd/SaiSwitch.h
@@ -299,6 +299,8 @@ namespace syncd
 
             void helperInternalOids();
 
+            void redisSaveInternalOids(_In_ sai_object_id_t rid) const;
+
             void helperLoadColdVids();
 
             void helperPopulateWarmBootVids();


### PR DESCRIPTION
Why I did:
Fix is for the issue as reported in https://github.com/Azure/sonic-buildimage/issues/5274
Fix https://github.com/Azure/sonic-buildimage/issues/5274

Basically Switch Internal OID should always be accounted in Temp and
Current Logic Comparison. It should never trigger remove operation.

Changes is to always add Switch Internal OID to COLDVIDS (even in case of
warm-boot)

Signed-off-by: Abhishek Dosi <abdosi@microsoft.com>

How I verfiy:

a) After change above issue is resolved
b) Dump COLDVIDS/ASIC_VIEW/HIDDEN Table and Switch Internal OID's are accounted in all 3 tables