### PR TITLE
Fix typo at SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32

### DIFF
--- a/meta/saiserialize.cpp
+++ b/meta/saiserialize.cpp
@@ -288,8 +288,8 @@ sai_status_t transfer_attribute(
 
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32:
             transfer_primitive(src_attr.value.aclfield.enable, dst_attr.value.aclfield.enable);
-            transfer_primitive(src_attr.value.aclfield.mask.u16, dst_attr.value.aclfield.mask.u16);
-            transfer_primitive(src_attr.value.aclfield.data.u16, dst_attr.value.aclfield.data.u16);
+            transfer_primitive(src_attr.value.aclfield.mask.u32, dst_attr.value.aclfield.mask.u32);
+            transfer_primitive(src_attr.value.aclfield.data.u32, dst_attr.value.aclfield.data.u32);
             break;
 
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT32:


### PR DESCRIPTION
Looks like a typo. It should be 32 instead of 16.

Signed-off-by: Ze Gan <ganze718@gmail.com>