### PR TITLE
[syncd] Notify orchagent instead of shutting down swss when translateVidToRid fails in processClearStatsEvent

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -538,7 +538,13 @@ sai_status_t Syncd::processClearStatsEvent(
     sai_object_meta_key_t metaKey;
     sai_deserialize_object_meta_key(key, metaKey);
 
-    m_translator->translateVidToRid(metaKey);
+    if (!m_translator->tryTranslateVidToRid(metaKey))
+    {
+        SWSS_LOG_WARN("VID to RID translation failure: %s", key.c_str());
+        sai_status_t status = SAI_STATUS_INVALID_OBJECT_ID;
+        m_getResponse->set(sai_serialize_status(status), {}, REDIS_ASIC_STATE_COMMAND_GETRESPONSE);
+        return status;
+    }
 
     auto info = sai_metadata_get_object_type_info(metaKey.objecttype);
 

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -288,6 +288,23 @@ bool VirtualOidTranslator::tryTranslateVidToRid(
     }
 }
 
+bool VirtualOidTranslator::tryTranslateVidToRid(
+        _Inout_ sai_object_meta_key_t &metaKey)
+{
+    SWSS_LOG_ENTER();
+
+    try
+    {
+        translateVidToRid(metaKey);
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        // message was logged already when throwing
+        return false;
+    }
+}
+
 void VirtualOidTranslator::translateVidToRid(
         _Inout_ sai_object_list_t &element)
 {

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -86,6 +86,9 @@ namespace syncd
             void translateVidToRid(
                     _Inout_ sai_object_meta_key_t &metaKey);
 
+            bool tryTranslateVidToRid(
+                    _Inout_ sai_object_meta_key_t &metaKey);
+
             void eraseRidAndVid(
                     _In_ sai_object_id_t rid,
                     _In_ sai_object_id_t vid);


### PR DESCRIPTION
**What I did**
Let `processClearStatsEvent` notify orchagent instead of crashing orchagent when `TranslateVidToRid` fails.

**Why I did it**
In INIT_VIEW during warm-reboot, the FlexCounterOrch tries to clear stats for BUFFER_POOL_WATERMARK. This is expected to fail in INIT_VIEW in `TranslateVidToRid` since the object is not yet created. In such a scenario, the syncd should respond with a failure rather than crashing orchagent.

**How I verified it**
Verified using virtual switch.

