### PR TITLE
[fabric] Extend supported counter list in syncd's FlexCounter for fabric

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1651,7 +1651,7 @@ void FlexCounter::updateSupportedPortCounters(
 
     uint64_t value;
 
-    for (int id = SAI_PORT_STAT_IF_IN_OCTETS; id <= SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS; ++id)
+    for (int id = SAI_PORT_STAT_IF_IN_OCTETS; id <= SAI_PORT_STAT_IF_OUT_FABRIC_DATA_UNITS; ++id)
     {
         sai_port_stat_t counter = static_cast<sai_port_stat_t>(id);
 


### PR DESCRIPTION
New SAI version provides more counters for fabric ports. Extend the supported counter list to cover those counters.

    /** SAI port stat if in FEC correctable pkts */
    SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES,

    /** SAI port stat if in FEC not correctable pkts */
    SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES,

    /** SAI port stat if in FEC symbol errors */
    SAI_PORT_STAT_IF_IN_FEC_SYMBOL_ERRORS,

    /** Fabric port stat in data units */
    SAI_PORT_STAT_IF_IN_FABRIC_DATA_UNITS,

    /** Fabric port stat out data units */
    SAI_PORT_STAT_IF_OUT_FABRIC_DATA_UNITS,

    /** Port stat in drop reasons range start */
    SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE = 0x00001000,

Signed-off-by: ngocdo <ngocdo@arista.com>