### PR TITLE
Fix SAI_FDB_EVENT_MOVE not supported error

### DIFF
--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -160,7 +160,7 @@ void NotificationProcessor::redisPutFdbEntryToAsicView(
         return;
     }
 
-    if (fdb->event_type == SAI_FDB_EVENT_LEARNED)
+    if (fdb->event_type == SAI_FDB_EVENT_LEARNED || fdb->event_type == SAI_FDB_EVENT_MOVE)
     {
         // currently we need to add type manually since fdb event don't contain type
         sai_attribute_t attr;


### PR DESCRIPTION
The event SAI_FDB_EVENT_MOVE should do the same operation like SAI_FDB_EVENT_LEARNED.

Signed-off-by: Vincent Chiang (vincent_chiang@edge-core.com)