### PR TITLE
[syncd] Enable synchronous mode by default

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -26,7 +26,7 @@ CMD_ARGS+=" -u"
 
 # Set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.synchronous_mode)
-if [ "$SYNC_MODE" == "enable" ]; then
+if [ "$SYNC_MODE" != "disable" ]; then
     CMD_ARGS+=" -s"
 fi
 


### PR DESCRIPTION
**What I did**
Enable synchronous mode by default when starting syncd

**How I did it**
Add the synchronous mode option at syncd start as long as the synchronous mode configuration is config_db is now explicitly set as "disable".

**How I verified it**
Verified using a virtual switch.