### PR TITLE
[fast-reboot] fix boot type for fast boot in virtual switch

### DIFF
--- a/vslib/src/SwitchConfig.cpp
+++ b/vslib/src/SwitchConfig.cpp
@@ -98,7 +98,7 @@ bool SwitchConfig::parseBootType(
     {
         bootType = SAI_VS_BOOT_TYPE_WARM;
     }
-    else if (bt == "fast" || bt == SAI_VALUE_VS_BOOT_TYPE_COLD)
+    else if (bt == "fast" || bt == SAI_VALUE_VS_BOOT_TYPE_FAST)
     {
         bootType = SAI_VS_BOOT_TYPE_FAST;
     }


### PR DESCRIPTION
Fix `parseBootType()` function so that it could work with fast reboot in virtual switch.