### PR TITLE
[syncd/FlexCounter]:Fix last remove bug

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -821,10 +821,7 @@ void FlexCounter::removeCounterPlugins()
     m_priorityGroupPlugins.clear();
     m_bufferPoolPlugins.clear();
 
-    if (isEmpty())
-    {
-        m_is_discard = true;
-    }
+    m_is_discard = true;
 }
 
 void FlexCounter::addCounterPlugin(

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -26,7 +26,7 @@ FlexCounter::FlexCounter(
     SWSS_LOG_ENTER();
 
     m_enable = false;
-    m_is_discard = false;
+    m_isDiscarded = false;
 
     startFlexCounterThread();
 }
@@ -821,7 +821,7 @@ void FlexCounter::removeCounterPlugins()
     m_priorityGroupPlugins.clear();
     m_bufferPoolPlugins.clear();
 
-    m_is_discard = true;
+    m_isDiscarded = true;
 }
 
 void FlexCounter::addCounterPlugin(
@@ -831,7 +831,7 @@ void FlexCounter::addCounterPlugin(
 
     SWSS_LOG_ENTER();
 
-    m_is_discard = false;
+    m_isDiscarded = false;
 
     for (auto& fvt: values)
     {
@@ -906,9 +906,9 @@ bool FlexCounter::isEmpty()
     return allIdsEmpty() && allPluginsEmpty();
 }
 
-bool FlexCounter::isDiscard()
+bool FlexCounter::isDiscarded()
 {
-    return isEmpty() && m_is_discard;
+    return isEmpty() && m_isDiscarded;
 }
 
 bool FlexCounter::allIdsEmpty() const

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -26,6 +26,7 @@ FlexCounter::FlexCounter(
     SWSS_LOG_ENTER();
 
     m_enable = false;
+    m_is_discard = false;
 
     startFlexCounterThread();
 }
@@ -819,6 +820,11 @@ void FlexCounter::removeCounterPlugins()
     m_rifPlugins.clear();
     m_priorityGroupPlugins.clear();
     m_bufferPoolPlugins.clear();
+
+    if (isEmpty())
+    {
+        m_is_discard = true;
+    }
 }
 
 void FlexCounter::addCounterPlugin(
@@ -827,6 +833,8 @@ void FlexCounter::addCounterPlugin(
     MUTEX;
 
     SWSS_LOG_ENTER();
+
+    m_is_discard = false;
 
     for (auto& fvt: values)
     {
@@ -899,6 +907,11 @@ bool FlexCounter::isEmpty()
     SWSS_LOG_ENTER();
 
     return allIdsEmpty() && allPluginsEmpty();
+}
+
+bool FlexCounter::isDiscard()
+{
+    return isEmpty() && m_is_discard;
 }
 
 bool FlexCounter::allIdsEmpty() const

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -48,6 +48,8 @@ namespace syncd
 
             bool isEmpty();
 
+            bool isDiscard();
+
         private:
 
             void setPollInterval(
@@ -405,5 +407,7 @@ namespace syncd
             std::shared_ptr<sairedis::SaiInterface> m_vendorSai;
 
             std::string m_dbCounters;
+
+            bool m_is_discard;
     };
 }

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -48,7 +48,7 @@ namespace syncd
 
             bool isEmpty();
 
-            bool isDiscard();
+            bool isDiscarded();
 
         private:
 
@@ -408,6 +408,6 @@ namespace syncd
 
             std::string m_dbCounters;
 
-            bool m_is_discard;
+            bool m_isDiscarded;
     };
 }

--- a/syncd/FlexCounterManager.cpp
+++ b/syncd/FlexCounterManager.cpp
@@ -62,7 +62,7 @@ void FlexCounterManager::removeCounterPlugins(
 
     fc->removeCounterPlugins();
 
-    if (fc->isDiscard())
+    if (fc->isDiscarded())
     {
         removeInstance(instanceId);
     }
@@ -91,7 +91,7 @@ void FlexCounterManager::addCounter(
 
     fc->addCounter(vid, rid, values);
 
-    if (fc->isDiscard())
+    if (fc->isDiscarded())
     {
         removeInstance(instanceId);
     }
@@ -107,7 +107,7 @@ void FlexCounterManager::removeCounter(
 
     fc->removeCounter(vid);
 
-    if (fc->isDiscard())
+    if (fc->isDiscarded())
     {
         removeInstance(instanceId);
     }

--- a/syncd/FlexCounterManager.cpp
+++ b/syncd/FlexCounterManager.cpp
@@ -62,7 +62,7 @@ void FlexCounterManager::removeCounterPlugins(
 
     fc->removeCounterPlugins();
 
-    if (fc->isEmpty())
+    if (fc->isDiscard())
     {
         removeInstance(instanceId);
     }
@@ -91,7 +91,7 @@ void FlexCounterManager::addCounter(
 
     fc->addCounter(vid, rid, values);
 
-    if (fc->isEmpty())
+    if (fc->isDiscard())
     {
         removeInstance(instanceId);
     }
@@ -107,7 +107,7 @@ void FlexCounterManager::removeCounter(
 
     fc->removeCounter(vid);
 
-    if (fc->isEmpty())
+    if (fc->isDiscard())
     {
         removeInstance(instanceId);
     }


### PR DESCRIPTION
- The bug description
When the last object in FlexCounter was removed, the FlexCounter is also removed from FlexCounterManager. At the next time, when a new observed object is added and a new FlexCounter will be created. But the new FlexCounter cannot get the configuration. Because the configuration message from FlexCounterDB has been consumed at the first time.

- How to fix it
Add a flag to indicate whether the configuration also be removed from the FlexCounterDB. If not, don't delete the FlexCounter from FlexCounterManager even no observed objects in the FlexCounter.


Signed-off-by: Ze Gan <ganze718@gmail.com>