### PR TITLE
[Sai]: Change Sai::set log to level INFO

### DIFF
--- a/lib/src/Sai.cpp
+++ b/lib/src/Sai.cpp
@@ -206,7 +206,7 @@ sai_status_t Sai::set(
 
             success &= (status == SAI_STATUS_SUCCESS);
 
-            SWSS_LOG_NOTICE("setting attribute 0x%x status: %s",
+            SWSS_LOG_INFO("setting attribute 0x%x status: %s",
                     attr->id,
                     sai_serialize_status(status).c_str());
         }


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

Fixes Azure/sonic-buildimage#5570

At the current log level of NOTICE, it is possible for this message to get spammed thousands of times, leading to syslog rate-limiting at the default orchagent log level of NOTICE.