### PR TITLE
[syncd_init_common.sh] Use template file to retrieve vars

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -11,7 +11,10 @@ ENABLE_SAITHRIFT=0
 PLATFORM_DIR=/usr/share/sonic/platform
 HWSKU_DIR=/usr/share/sonic/hwsku
 
-SONIC_ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
+VARS_FILE=/usr/share/sonic/templates/swss_vars.j2
+# Retrieve vars from sonic-cfggen
+SYNCD_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t $VARS_FILE) || exit 1
+SONIC_ASIC_TYPE=$(echo $SYNCD_VARS | jq -r '.asic_type')
 
 if [ -x $CMD_DSSERVE ]; then
     CMD=$CMD_DSSERVE
@@ -28,7 +31,7 @@ CMD_ARGS+=" -u"
 CMD_ARGS+=" -l"
 
 # Set synchronous mode if it is enabled in CONFIG_DB
-SYNC_MODE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.synchronous_mode)
+SYNC_MODE=$(echo $SYNCD_VARS | jq -r '.synchronous_mode')
 if [ "$SYNC_MODE" == "enable" ]; then
     CMD_ARGS+=" -s"
 fi


### PR DESCRIPTION
**- Why I did it**
This PR follows https://github.com/Azure/sonic-buildimage/pull/5644 to use template file `/usr/share/sonic/templates/swss_vars.j2` to retrieve vars for orchagent and syncd.

**- How I did it**
Use template file `/usr/share/sonic/templates/swss_vars.j2` to retrieve vars in `syncd_init_common.sh`

**- How to verify it**
Verified with on kvm

