### PR TITLE
[syncd] Use lua script to update db when using bulk api

### DIFF
--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -593,7 +593,14 @@ void RedisClient::createAsicObjects(
     // we need to rewrite hash to add table prefix
     for (const auto& kvp: multiHash)
     {
-        hash[(ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+        if (kvp.second.size() == 0)
+        {
+            hash[(ASIC_STATE_TABLE ":") + kvp.first].emplace_back(std::make_pair<std::string, std::string>("NULL","NULL"));
+        }
+        else
+        {
+            hash[(ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+        }
     }
 
     m_dbAsic->hmset(hash);
@@ -609,7 +616,14 @@ void RedisClient::createTempAsicObjects(
     // we need to rewrite hash to add table prefix
     for (const auto& kvp: multiHash)
     {
-        hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+        if (kvp.second.size() == 0)
+        {
+            hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first].emplace_back(std::make_pair<std::string, std::string>("NULL","NULL"));
+        }
+        else
+        {
+            hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+        }
     }
 
     m_dbAsic->hmset(hash);

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -487,6 +487,38 @@ void RedisClient::removeTempAsicObject(
     m_dbAsic->del(key);
 }
 
+void RedisClient::removeAsicObjects(
+        _In_ const std::vector<std::string>& keys)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> prefixKeys;
+
+    // we need to rewrite keys to add table prefix
+    for (const auto& key: keys)
+    {
+         prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
+    }
+
+    m_dbAsic->hdel(prefixKeys);
+}
+
+void RedisClient::removeTempAsicObjects(
+        _In_ const std::vector<std::string>& keys)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> prefixKeys;
+
+    // we need to rewrite keys to add table prefix
+    for (const auto& key: keys)
+    {
+         prefixKeys.push_back((TEMP_PREFIX ASIC_STATE_TABLE ":") + key);
+    }
+
+    m_dbAsic->hdel(prefixKeys);
+}
+
 void RedisClient::setAsicObject(
         _In_ const sai_object_meta_key_t& metaKey,
         _In_ const std::string& attr,
@@ -549,6 +581,38 @@ void RedisClient::createTempAsicObject(
     {
         m_dbAsic->hset(key, fvField(e), fvValue(e));
     }
+}
+
+void RedisClient::createAsicObjects(
+        _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash)
+{
+    SWSS_LOG_ENTER();
+
+    std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> hash;
+
+    // we need to rewrite hash to add table prefix
+    for (const auto& kvp: multiHash)
+    {
+        hash[(ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+    }
+
+    m_dbAsic->hmset(hash);
+}
+
+void RedisClient::createTempAsicObjects(
+        _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash)
+{
+    SWSS_LOG_ENTER();
+
+    std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> hash;
+
+    // we need to rewrite hash to add table prefix
+    for (const auto& kvp: multiHash)
+    {
+        hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+    }
+
+    m_dbAsic->hmset(hash);
 }
 
 void RedisClient::setVidAndRidMap(

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -500,7 +500,7 @@ void RedisClient::removeAsicObjects(
          prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
     }
 
-    m_dbAsic->hdel(prefixKeys);
+    m_dbAsic->del(prefixKeys);
 }
 
 void RedisClient::removeTempAsicObjects(
@@ -516,7 +516,7 @@ void RedisClient::removeTempAsicObjects(
          prefixKeys.push_back((TEMP_PREFIX ASIC_STATE_TABLE ":") + key);
     }
 
-    m_dbAsic->hdel(prefixKeys);
+    m_dbAsic->del(prefixKeys);
 }
 
 void RedisClient::setAsicObject(

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -593,13 +593,11 @@ void RedisClient::createAsicObjects(
     // we need to rewrite hash to add table prefix
     for (const auto& kvp: multiHash)
     {
+        hash[(ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+
         if (kvp.second.size() == 0)
         {
             hash[(ASIC_STATE_TABLE ":") + kvp.first].emplace_back(std::make_pair<std::string, std::string>("NULL","NULL"));
-        }
-        else
-        {
-            hash[(ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
         }
     }
 
@@ -616,13 +614,11 @@ void RedisClient::createTempAsicObjects(
     // we need to rewrite hash to add table prefix
     for (const auto& kvp: multiHash)
     {
+        hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
+
         if (kvp.second.size() == 0)
         {
             hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first].emplace_back(std::make_pair<std::string, std::string>("NULL","NULL"));
-        }
-        else
-        {
-            hash[(TEMP_PREFIX ASIC_STATE_TABLE ":") + kvp.first] = kvp.second;
         }
     }
 

--- a/syncd/RedisClient.h
+++ b/syncd/RedisClient.h
@@ -85,6 +85,12 @@ namespace syncd
             void removeTempAsicObject(
                     _In_ const sai_object_meta_key_t& metaKey);
 
+            void removeAsicObjects(
+                    _In_ const std::vector<std::string>& keys);
+
+            void removeTempAsicObjects(
+                    _In_ const std::vector<std::string>& keys);
+
             void createAsicObject(
                     _In_ const sai_object_meta_key_t& metaKey,
                     _In_ const std::vector<swss::FieldValueTuple>& attrs);
@@ -92,6 +98,12 @@ namespace syncd
             void createTempAsicObject(
                     _In_ const sai_object_meta_key_t& metaKey,
                     _In_ const std::vector<swss::FieldValueTuple>& attrs);
+
+            void createAsicObjects(
+                    _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash);
+
+            void createTempAsicObjects(
+                    _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash);
 
             void setVidAndRidMap(
                     _In_ const std::unordered_map<sai_object_id_t, sai_object_id_t>& map);


### PR DESCRIPTION
When using SAI bulk in syncd, like create/remove route_entry, we want to have ability to update database as fast as possible, so best way would be to execute every mutable db command inside lua script to make things faster, rather than execute 1 by 1 operation which is done currently inside syncd

depends on https://github.com/Azure/sonic-swss-common/pull/406