### PR TITLE
[syncd][sairedis] Change pub/sub model to push/pull in zmq notification

### DIFF
--- a/syncd/ZeroMQNotificationProducer.cpp
+++ b/syncd/ZeroMQNotificationProducer.cpp
@@ -13,7 +13,7 @@ ZeroMQNotificationProducer::ZeroMQNotificationProducer(
 
     m_ntfContext = zmq_ctx_new();
 
-    m_ntfSocket = zmq_socket(m_ntfContext, ZMQ_PUB);
+    m_ntfSocket = zmq_socket(m_ntfContext, ZMQ_PUSH);
 
     SWSS_LOG_NOTICE("opening zmq ntf endpoint: %s", ntfEndpoint.c_str());
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I$(top_srcdir)/vslib/inc -I$(top_srcdir)/lib/inc -I$(top_srcdir)/SAI/inc -I$(top_srcdir)/SAI/meta -I$(top_srcdir)/SAI/experimental
 
-bin_PROGRAMS = vssyncd
+bin_PROGRAMS = vssyncd tests
 
 if DEBUG
 DBGFLAGS = -ggdb -DDEBUG
@@ -19,4 +19,13 @@ if SAITHRIFT
 vssyncd_LDADD += -lrpcserver -lthrift
 endif
 
-TESTS = aspellcheck.pl conflictnames.pl swsslogentercheck.sh BCM56850.pl MLNX2700.pl
+tests_SOURCES = tests.cpp
+tests_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
+tests_LDADD = -lhiredis -lswsscommon -lpthread \
+			  $(top_srcdir)/meta/libsaimetadata.la \
+			  $(top_srcdir)/meta/libsaimeta.la \
+			  $(top_srcdir)/lib/src/libsairedis.la \
+			  $(top_srcdir)/syncd/libSyncd.a \
+			  -lzmq
+
+TESTS = aspellcheck.pl conflictnames.pl swsslogentercheck.sh tests BCM56850.pl MLNX2700.pl

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,10 +22,8 @@ endif
 tests_SOURCES = tests.cpp
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
 tests_LDADD = -lhiredis -lswsscommon -lpthread \
-			  $(top_srcdir)/meta/libsaimetadata.la \
-			  $(top_srcdir)/meta/libsaimeta.la \
 			  $(top_srcdir)/lib/src/libsairedis.la \
 			  $(top_srcdir)/syncd/libSyncd.a \
-			  -lzmq
+			  -lsaimetadata -lsaimeta -lzmq
 
 TESTS = aspellcheck.pl conflictnames.pl swsslogentercheck.sh tests BCM56850.pl MLNX2700.pl

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,7 @@ tests_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
 tests_LDADD = -lhiredis -lswsscommon -lpthread \
 			  $(top_srcdir)/lib/src/libsairedis.la \
 			  $(top_srcdir)/syncd/libSyncd.a \
+			  -L$(top_srcdir)/meta/.libs \
 			  -lsaimetadata -lsaimeta -lzmq
 
 TESTS = aspellcheck.pl conflictnames.pl swsslogentercheck.sh tests BCM56850.pl MLNX2700.pl

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,0 +1,97 @@
+#include <zmq.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "lib/inc/ZeroMQChannel.h"
+#include "syncd/ZeroMQNotificationProducer.h"
+
+#include "meta/sai_serialize.h"
+
+#include <thread>
+#include <memory>
+
+using namespace sairedis;
+using namespace syncd;
+
+#define ASSERT_EQ(a,b) if ((a) != (b)) { SWSS_LOG_THROW("ASSERT EQ FAILED: " #a " != " #b); }
+
+/*
+ * Test if destructor proper clean and join zeromq socket and context, and
+ * break recv method.
+ */
+static void test_zeromqchannel_destructor()
+{
+    SWSS_LOG_ENTER();
+
+    std::cout << " * " << __FUNCTION__ << std::endl;
+
+    for (int i = 0; i < 10; i++)
+    {
+        ZeroMQChannel z("ipc:///tmp/feeds1", "ipc:///tmp/feeds2", nullptr);
+
+        usleep(10*1000);
+    }
+}
+
+/*
+ * Test if first notification sent from notification producer will arrive at
+ * zeromq channel notification thread. There is an issue with PUB/SUB inside
+ * zeromq, and in our model this was changed to push/pull model.
+ */
+static void test_zeromqchannel_first_notification()
+{
+    SWSS_LOG_ENTER();
+
+    std::cout << " * " << __FUNCTION__ << std::endl;
+
+    for (int i = 0; i < 10; i++)
+    {
+        std::string rop;
+        std::string rdata;
+
+        bool got = false;
+
+        auto callback = [&](
+                const std::string& op,
+                const std::string& data,
+                const std::vector<swss::FieldValueTuple>& values)
+        {
+            SWSS_LOG_NOTICE("got: %s %s", op.c_str(), data.c_str());
+
+            rop = op;
+            rdata = data;
+
+            got = true;
+        };
+
+        ZeroMQChannel z("ipc:///tmp/feeds1", "ipc:///tmp/feeds2", callback);
+
+        ZeroMQNotificationProducer p("ipc:///tmp/feeds2");
+
+        p.send("foo", "bar", {});
+
+        int count = 0;
+
+        while (!got && count++ < 200) // in total we will wait max 2 seconds
+        {
+            usleep(10*1000);
+        }
+
+        ASSERT_EQ(rop, "foo");
+        ASSERT_EQ(rdata, "bar");
+    }
+}
+
+int main()
+{
+    SWSS_LOG_ENTER();
+
+    test_zeromqchannel_destructor();
+
+    test_zeromqchannel_first_notification();
+
+    return 0;
+}


### PR DESCRIPTION
There is issue with publisher/subscriber, which I use in notification delivery in zmq channel in sairedis. Issue is that first message/notification I never delivered from publisher to subscriber, and seems like this issue is still not solved ☹ Here are details: https://github.com/zeromq/libzmq/issues/2267