### PR TITLE
[vstest]VS test support for VOQ system ports

### DIFF
--- a/vslib/inc/CorePortIndexMap.h
+++ b/vslib/inc/CorePortIndexMap.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "swss/sal.h"
+
+#include <inttypes.h>
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace saivs
+{
+    class CorePortIndexMap
+    {
+        public:
+
+            constexpr static uint32_t DEFAULT_SWITCH_INDEX = 0;
+
+        public:
+
+            CorePortIndexMap(
+                    _In_ uint32_t switchIndex);
+
+            virtual ~CorePortIndexMap() = default;
+
+        public:
+
+            bool add(
+                    _In_ const std::string& ifname,
+                    _In_ const std::vector<uint32_t>& lanes);
+
+            bool remove(
+                    _In_ const std::string& ifname);
+
+            uint32_t getSwitchIndex() const;
+
+            bool isEmpty() const;
+
+            bool hasInterface(
+                    _In_ const std::string& ifname) const;
+
+            const std::vector<std::vector<uint32_t>> getCorePortIndexVector() const;
+
+            /**
+             * @brief Get interface from core and core port index.
+             *
+             * @return Interface name or empty string if core and core port index are not found.
+             */
+            std::string getInterfaceFromCorePortIndex(
+                    _In_ std::vector<uint32_t> corePortIndex) const;
+
+        public:
+
+            static std::shared_ptr<CorePortIndexMap> getDefaultCorePortIndexMap(
+                    _In_ uint32_t switchIndex = DEFAULT_SWITCH_INDEX);
+
+        private:
+
+            uint32_t m_switchIndex;
+
+            std::map<std::vector<uint32_t>, std::string> m_coreportindex_to_ifname;
+
+            std::map<std::string, std::vector<uint32_t>> m_ifname_to_coreportindex;
+
+            std::vector<std::vector<uint32_t>> m_corePortIndexMap;
+    };
+}

--- a/vslib/inc/CorePortIndexMapContainer.h
+++ b/vslib/inc/CorePortIndexMapContainer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CorePortIndexMap.h"
+
+#include <memory>
+#include <map>
+
+namespace saivs
+{
+    class CorePortIndexMapContainer
+    {
+        public:
+
+            CorePortIndexMapContainer() = default;
+
+            virtual ~CorePortIndexMapContainer() = default;
+
+        public:
+
+            void insert(
+                    _In_ std::shared_ptr<CorePortIndexMap> corePortIndexMap);
+
+            void remove(
+                    _In_ uint32_t switchIndex);
+
+            std::shared_ptr<CorePortIndexMap> getCorePortIndexMap(
+                    _In_ uint32_t switchIndex) const;
+
+            void clear();
+
+            bool hasCorePortIndexMap(
+                    _In_ uint32_t switchIndex) const;
+
+            size_t size() const;
+
+            void removeEmptyCorePortIndexMaps();
+
+        private:
+
+            std::map<uint32_t, std::shared_ptr<CorePortIndexMap>> m_map;
+    };
+}
+

--- a/vslib/inc/CorePortIndexMapFileParser.h
+++ b/vslib/inc/CorePortIndexMapFileParser.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CorePortIndexMapContainer.h"
+
+#include <vector>
+#include <memory>
+
+namespace saivs
+{
+    class CorePortIndexMapFileParser
+    {
+        private:
+
+            CorePortIndexMapFileParser() = delete;
+            ~CorePortIndexMapFileParser() = delete;
+
+        public:
+
+            static std::shared_ptr<CorePortIndexMapContainer> parseCorePortIndexMapFile(
+                    _In_ const char* file);
+
+            static std::shared_ptr<CorePortIndexMapContainer> parseCorePortIndexMapFile(
+                    _In_ const std::string& file);
+
+            static bool isInterfaceNameValid(
+                    _In_ const std::string& name);
+
+        private:
+
+            static void parseLineWithIndex(
+                    _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+                    _In_ const std::vector<std::string>& tokens);
+
+            static void parseLineWithNoIndex(
+                    _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+                    _In_ const std::vector<std::string>& tokens);
+
+            static void parse(
+                    _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+                    _In_ uint32_t switchIndex,
+                    _In_ const std::string& ifname,
+                    _In_ const std::string& slanes);
+
+    };
+}

--- a/vslib/inc/Sai.h
+++ b/vslib/inc/Sai.h
@@ -5,6 +5,7 @@
 #include "EventQueue.h"
 #include "EventPayloadNotification.h"
 #include "ResourceLimiterContainer.h"
+#include "CorePortIndexMapContainer.h"
 
 #include "meta/Meta.h"
 
@@ -416,5 +417,7 @@ namespace saivs
             std::shared_ptr<LaneMapContainer> m_laneMapContainer;
 
             std::shared_ptr<ResourceLimiterContainer> m_resourceLimiterContainer;
+
+            std::shared_ptr<CorePortIndexMapContainer> m_corePortIndexMapContainer;
     };
 }

--- a/vslib/inc/SwitchConfig.h
+++ b/vslib/inc/SwitchConfig.h
@@ -3,6 +3,7 @@
 #include "LaneMap.h"
 #include "EventQueue.h"
 #include "ResourceLimiter.h"
+#include "CorePortIndexMap.h"
 
 #include <string>
 #include <memory>
@@ -79,5 +80,7 @@ namespace saivs
             std::shared_ptr<EventQueue> m_eventQueue;
 
             std::shared_ptr<ResourceLimiter> m_resourceLimiter;
+
+            std::shared_ptr<CorePortIndexMap> m_corePortIndexMap;
     };
 }

--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -89,12 +89,25 @@ namespace saivs
                     _In_ sai_switch_attr_t acl_resource,
                     _In_ int max_count);
 
+            sai_status_t create_system_ports(
+                    _In_ int32_t voq_switch_id,
+                    _In_ uint32_t sys_port_count,
+                    _In_ sai_system_port_config_t *sys_port_cfg_list);
+            sai_status_t set_system_port_list();
+            sai_status_t set_voq_switch_attributes(
+                    _In_ int32_t voq_switch_id,
+                    _In_ uint32_t voq_max_cores);
+
         public:
 
             virtual sai_status_t initialize_default_objects();
 
             virtual sai_status_t create_port_dependencies(
                     _In_ sai_object_id_t port_id);
+
+            sai_status_t initialize_voq_switch_objects(
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
 
         protected : // refresh
 
@@ -437,6 +450,8 @@ namespace saivs
             sai_object_id_t m_default_1q_bridge;
             sai_object_id_t m_default_bridge_port_1q_router;
             sai_object_id_t m_default_vlan_id;
+
+            std::vector<sai_object_id_t> m_system_port_list;
 
         protected:
 

--- a/vslib/inc/saivs.h
+++ b/vslib/inc/saivs.h
@@ -84,6 +84,19 @@ extern "C" {
  */
 #define SAI_VS_UNITTEST_ENABLE_UNITTESTS  "enable_unittests"
 
+/**
+ * @def SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE
+ *
+ * For VOQ systems if specified in profile.ini it should point to eth interface to
+ * core and core port index map as port name:core_index,core_port_index
+ *
+ * Example:
+ * eth1:0,1
+ * eth17:1,1
+ *
+ */
+#define SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE  "SAI_VS_CORE_PORT_INDEX_MAP_FILE"
+
 typedef enum _sai_vs_switch_attr_t
 {
     /**

--- a/vslib/src/CorePortIndexMap.cpp
+++ b/vslib/src/CorePortIndexMap.cpp
@@ -1,0 +1,181 @@
+#include "CorePortIndexMap.h"
+
+#include "swss/logger.h"
+
+#include <set>
+
+using namespace saivs;
+
+CorePortIndexMap::CorePortIndexMap(
+        _In_ uint32_t switchIndex):
+    m_switchIndex(switchIndex)
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+uint32_t CorePortIndexMap::getSwitchIndex() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_switchIndex;
+}
+
+bool CorePortIndexMap::add(
+        _In_ const std::string& ifname,
+        _In_ const std::vector<uint32_t>& corePortIndex)
+{
+    SWSS_LOG_ENTER();
+
+    auto n = corePortIndex.size();
+
+    if (n != 2)
+    {
+        SWSS_LOG_ERROR("Invalid corePortIndex. Core port index must have core and core port index %d, %s", n, ifname.c_str());
+        return false;
+    }
+
+    if (m_ifname_to_coreportindex.find(ifname) != m_ifname_to_coreportindex.end())
+    {
+        SWSS_LOG_ERROR("interface %s already in core port index map (%d, %d)", ifname.c_str(), corePortIndex[0], corePortIndex[1]);
+        return false;
+    }
+
+    m_corePortIndexMap.push_back(corePortIndex);
+
+    m_coreportindex_to_ifname[corePortIndex] = ifname;
+
+    m_ifname_to_coreportindex[ifname] = corePortIndex;
+
+    return true;
+}
+
+bool CorePortIndexMap::remove(
+        _In_ const std::string& ifname)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_ifname_to_coreportindex.find(ifname);
+
+    if (it == m_ifname_to_coreportindex.end())
+    {
+        SWSS_LOG_ERROR("interfce %s does not have core port index in switch %d", ifname.c_str(), m_switchIndex);
+        return false;
+    }
+
+    auto corePortIndex = it->second;
+
+    m_coreportindex_to_ifname.erase(corePortIndex);
+
+    for (size_t idx = 0; idx < m_corePortIndexMap.size(); idx++)
+    {
+        if (m_corePortIndexMap[idx][0] == corePortIndex[0] && m_corePortIndexMap[idx][1] == corePortIndex[1])
+        {
+            m_corePortIndexMap.erase(m_corePortIndexMap.begin() + idx);
+            break;
+        }
+    }
+
+    m_ifname_to_coreportindex.erase(it);
+
+    return true;
+}
+
+std::shared_ptr<CorePortIndexMap> CorePortIndexMap::getDefaultCorePortIndexMap(
+        _In_ uint32_t switchIndex)
+{
+    SWSS_LOG_ENTER();
+
+    const uint32_t defaultPortCount = 32;
+
+    uint32_t defaultCorePortIndexMap[defaultPortCount * 2] = {
+        0,1,
+        0,2,
+        0,3,
+        0,4,
+        0,5,
+        0,6,
+        0,7,
+        0,8,
+        0,9,
+        0,10,
+        0,11,
+        0,12,
+        0,13,
+        0,14,
+        0,15,
+        0,16,
+        1,1,
+        1,2,
+        1,3,
+        1,4,
+        1,5,
+        1,6,
+        1,7,
+        1,8,
+        1,9,
+        1,10,
+        1,11,
+        1,12,
+        1,13,
+        1,14,
+        1,15,
+        1,16
+    };
+
+    auto corePortIndexMap = std::make_shared<CorePortIndexMap>(switchIndex);
+
+    for (uint32_t idx = 0; idx < defaultPortCount; idx++)
+    {
+        auto ifname = "eth" + std::to_string(idx);
+
+        std::vector<uint32_t> cpidx;
+
+        cpidx.push_back(defaultCorePortIndexMap[idx * 2]);
+        cpidx.push_back(defaultCorePortIndexMap[idx * 2 + 1]);
+
+        corePortIndexMap->add(ifname, cpidx);
+    }
+
+    return corePortIndexMap;
+}
+
+bool CorePortIndexMap::isEmpty() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_ifname_to_coreportindex.size() == 0;
+}
+
+bool CorePortIndexMap::hasInterface(
+        _In_ const std::string& ifname) const
+{
+    SWSS_LOG_ENTER();
+
+    return m_ifname_to_coreportindex.find(ifname) != m_ifname_to_coreportindex.end();
+}
+
+const std::vector<std::vector<uint32_t>> CorePortIndexMap::getCorePortIndexVector() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_corePortIndexMap;
+}
+
+std::string CorePortIndexMap::getInterfaceFromCorePortIndex(
+        _In_ std::vector<uint32_t> corePortIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_coreportindex_to_ifname.find(corePortIndex);
+
+    if (it == m_coreportindex_to_ifname.end())
+    {
+        SWSS_LOG_WARN("Core port index (%d, %d) not found on index %u", corePortIndex[0], corePortIndex[1], m_switchIndex);
+
+        return "";
+    }
+
+    return it->second;
+}

--- a/vslib/src/CorePortIndexMapContainer.cpp
+++ b/vslib/src/CorePortIndexMapContainer.cpp
@@ -1,0 +1,80 @@
+#include "CorePortIndexMapContainer.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+void CorePortIndexMapContainer::insert(
+        _In_ std::shared_ptr<CorePortIndexMap> corePortIndexMap)
+{
+    SWSS_LOG_ENTER();
+
+    m_map[corePortIndexMap->getSwitchIndex()] = corePortIndexMap;
+}
+
+void CorePortIndexMapContainer::remove(
+        _In_ uint32_t switchIndex)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_map.find(switchIndex);
+
+    if (it != m_map.end())
+    {
+        m_map.erase(it);
+    }
+}
+
+std::shared_ptr<CorePortIndexMap> CorePortIndexMapContainer::getCorePortIndexMap(
+        _In_ uint32_t switchIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_map.find(switchIndex);
+
+    if (it == m_map.end())
+    {
+        return nullptr;
+    }
+
+    return it->second;
+}
+
+void CorePortIndexMapContainer::clear()
+{
+    SWSS_LOG_ENTER();
+
+    m_map.clear();
+}
+
+bool CorePortIndexMapContainer::hasCorePortIndexMap(
+        _In_ uint32_t switchIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    return m_map.find(switchIndex) != m_map.end();
+}
+
+size_t CorePortIndexMapContainer::size() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_map.size();
+}
+
+void CorePortIndexMapContainer::removeEmptyCorePortIndexMaps()
+{
+    SWSS_LOG_ENTER();
+
+    for(auto it = m_map.begin(); it != m_map.end();)
+    {
+        if (it->second->isEmpty())
+        {
+            it = m_map.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}

--- a/vslib/src/CorePortIndexMapFileParser.cpp
+++ b/vslib/src/CorePortIndexMapFileParser.cpp
@@ -1,0 +1,230 @@
+#include "CorePortIndexMapFileParser.h"
+
+#include "swss/logger.h"
+#include "swss/tokenize.h"
+
+#include <net/if.h>
+
+#include <fstream>
+
+using namespace saivs;
+
+// must be the same or less as SAI_VS_SWITCH_INDEX_MAX
+#define MAX_SWITCH_INDEX (255)
+
+bool CorePortIndexMapFileParser::isInterfaceNameValid(
+        _In_ const std::string& name)
+{
+    SWSS_LOG_ENTER();
+
+    size_t size = name.size();
+
+    if (size == 0 || size > IFNAMSIZ)
+    {
+        SWSS_LOG_ERROR("invalid interface name %s or length: %zu", name.c_str(), size);
+        return false;
+    }
+
+    for (size_t i = 0; i < size; i++)
+    {
+        char c = name[i];
+
+        if (c >= '0' && c <= '9')
+            continue;
+
+        if (c >= 'a' && c <= 'z')
+            continue;
+
+        if (c >= 'A' && c <= 'Z')
+            continue;
+
+        SWSS_LOG_ERROR("invalid character '%c' in interface name %s", c, name.c_str());
+        return false;
+    }
+
+    // interface name is valid
+    return true;
+}
+
+void CorePortIndexMapFileParser::parse(
+        _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+        _In_ uint32_t switchIndex,
+        _In_ const std::string& ifname,
+        _In_ const std::string& scpidx)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isInterfaceNameValid(ifname))
+    {
+        SWSS_LOG_ERROR("interface name '%s' is invalid", ifname.c_str());
+        return;
+    }
+
+    auto tokens = swss::tokenize(scpidx,',');
+
+    size_t n = tokens.size();
+
+    if (n != 2)
+    {
+        SWSS_LOG_ERROR("Invalid core port index map %s assigned to interface %s", scpidx.c_str(), ifname.c_str());
+        return;
+    }
+
+    std::vector<uint32_t> cpidx;
+
+    for (auto c: tokens)
+    {
+        uint32_t c_or_pidx;
+        if (sscanf(c.c_str(), "%u", &c_or_pidx) != 1)
+        {
+            SWSS_LOG_ERROR("failed to parse core or port index: %s", c.c_str());
+            continue;
+        }
+
+        cpidx.push_back(c_or_pidx);
+    }
+
+    auto corePortIndexMap = container->getCorePortIndexMap(switchIndex);
+
+    if (!corePortIndexMap)
+    {
+        corePortIndexMap = std::make_shared<CorePortIndexMap>(switchIndex);
+
+        container->insert(corePortIndexMap);
+    }
+
+    corePortIndexMap->add(ifname, cpidx);
+}
+
+void CorePortIndexMapFileParser::parseLineWithNoIndex(
+        _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+        _In_ const std::vector<std::string>& tokens)
+{
+    SWSS_LOG_ENTER();
+
+    auto ifname = tokens.at(0);
+    auto scpidx = tokens.at(1);
+
+    parse(container, CorePortIndexMap::DEFAULT_SWITCH_INDEX, ifname, scpidx);
+}
+
+void CorePortIndexMapFileParser::parseLineWithIndex(
+        _In_ std::shared_ptr<CorePortIndexMapContainer> container,
+        _In_ const std::vector<std::string>& tokens)
+{
+    SWSS_LOG_ENTER();
+
+    auto swidx  = tokens.at(0);
+    auto ifname = tokens.at(1);
+    auto scpidx = tokens.at(2);
+
+    uint32_t switchIndex;
+
+    if (sscanf(swidx.c_str(), "%u", & switchIndex) != 1)
+    {
+        SWSS_LOG_ERROR("failed to parse switchIndex: %s", swidx.c_str());
+        return;
+    }
+
+    parse(container, switchIndex, ifname, scpidx);
+}
+
+std::shared_ptr<CorePortIndexMapContainer> CorePortIndexMapFileParser::parseCorePortIndexMapFile(
+        _In_ const std::string& file)
+{
+    SWSS_LOG_ENTER();
+
+    auto container = std::make_shared<CorePortIndexMapContainer>();
+
+    std::ifstream ifs(file);
+
+    if (!ifs.is_open())
+    {
+        SWSS_LOG_WARN("failed to open core port index map file: %s, using default", file.c_str());
+
+        auto def = CorePortIndexMap::getDefaultCorePortIndexMap();
+
+        container->insert(def);
+
+        return container;
+    }
+
+    SWSS_LOG_NOTICE("loading core port index map from: %s", file.c_str());
+
+    std::string line;
+
+    while(getline(ifs, line))
+    {
+        /*
+         * line can be in 2 forms:
+         * ethX:core, core port index
+         * N:ethX:core, core port index
+         *
+         * where N is switchIndex (0..255) - SAI_VS_SWITCH_INDEX_MAX
+         * if N is not specified then zero (0) is assumed
+         */
+
+        if (line.size() > 0 && (line[0] == '#' || line[0] == ';'))
+        {
+            continue;
+        }
+
+        SWSS_LOG_INFO("core port index line: %s", line.c_str());
+
+        auto tokens = swss::tokenize(line, ':');
+
+        if (tokens.size() == 3)
+        {
+            parseLineWithIndex(container, tokens);
+        }
+        else if (tokens.size() == 2)
+        {
+            parseLineWithNoIndex(container, tokens);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("expected 2 or 3 tokens in line %s, got %zu", line.c_str(), tokens.size());
+        }
+    }
+
+    container->removeEmptyCorePortIndexMaps();
+
+    if (container->size() == 0)
+    {
+        SWSS_LOG_WARN("no core port index map loaded, returning default core port index map");
+
+        auto def = CorePortIndexMap::getDefaultCorePortIndexMap();
+
+        container->insert(def);
+
+        return container;
+    }
+
+    SWSS_LOG_NOTICE("loaded %zu core port index maps to container", container->size());
+
+    return container;
+}
+
+std::shared_ptr<CorePortIndexMapContainer> CorePortIndexMapFileParser::parseCorePortIndexMapFile(
+        _In_ const char* file)
+{
+    SWSS_LOG_ENTER();
+
+    if (file == nullptr)
+    {
+        auto container = std::make_shared<CorePortIndexMapContainer>();
+
+        SWSS_LOG_NOTICE("no file map file specified, loading default");
+
+        auto def = CorePortIndexMap::getDefaultCorePortIndexMap();
+
+        container->insert(def);
+
+        return container;
+    }
+
+    std::string name(file);
+
+    return parseCorePortIndexMapFile(name);
+}
+

--- a/vslib/src/Makefile.am
+++ b/vslib/src/Makefile.am
@@ -50,7 +50,10 @@ libSaiVS_a_SOURCES = \
 					  SwitchState.cpp \
 					  SwitchBCM56850.cpp \
 					  SwitchBCM81724.cpp \
-					  SwitchMLNX2700.cpp
+					  SwitchMLNX2700.cpp \
+					  CorePortIndexMap.cpp \
+					  CorePortIndexMapContainer.cpp \
+					  CorePortIndexMapFileParser.cpp
 
 libsaivs_la_SOURCES = \
 					  sai_vs_fdb.cpp \

--- a/vslib/src/Sai.cpp
+++ b/vslib/src/Sai.cpp
@@ -7,6 +7,7 @@
 #include "HostInterfaceInfo.h"
 #include "SwitchConfigContainer.h"
 #include "ResourceLimiterParser.h"
+#include "CorePortIndexMapFileParser.h"
 
 #include "swss/logger.h"
 
@@ -112,6 +113,10 @@ sai_status_t Sai::initialize(
 
     m_laneMapContainer = LaneMapFileParser::parseLaneMapFile(laneMapFile);
 
+    auto *corePortIndexMapFile = service_method_table->profile_get_value(0, SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE);
+
+    m_corePortIndexMapContainer = CorePortIndexMapFileParser::parseCorePortIndexMapFile(corePortIndexMapFile);
+
     auto *resourceLimiterFile = service_method_table->profile_get_value(0, SAI_KEY_VS_RESOURCE_LIMITER_FILE);
 
     m_resourceLimiterContainer = ResourceLimiterParser::parseFromFile(resourceLimiterFile);
@@ -154,6 +159,7 @@ sai_status_t Sai::initialize(
     sc->m_laneMap = m_laneMapContainer->getLaneMap(sc->m_switchIndex);
     sc->m_eventQueue = m_eventQueue;
     sc->m_resourceLimiter = m_resourceLimiterContainer->getResourceLimiter(sc->m_switchIndex);
+    sc->m_corePortIndexMap = m_corePortIndexMapContainer->getCorePortIndexMap(sc->m_switchIndex);
 
     auto scc = std::make_shared<SwitchConfigContainer>();
 

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1783,6 +1783,10 @@ sai_status_t SwitchStateBase::refresh_read_only(
             case SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY:
             case SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY:
                 return SAI_STATUS_SUCCESS;
+
+            case SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS:
+            case SAI_SWITCH_ATTR_SYSTEM_PORT_LIST:
+                return SAI_STATUS_SUCCESS;
         }
     }
 
@@ -1807,6 +1811,17 @@ sai_status_t SwitchStateBase::refresh_read_only(
                  */
 
             case SAI_PORT_ATTR_OPER_STATUS:
+                return SAI_STATUS_SUCCESS;
+        }
+    }
+
+    if (meta->objecttype == SAI_OBJECT_TYPE_SYSTEM_PORT)
+    {
+        switch (meta->attrid)
+        {
+            case SAI_SYSTEM_PORT_ATTR_TYPE:
+            case SAI_SYSTEM_PORT_ATTR_CONFIG_INFO:
+            case SAI_SYSTEM_PORT_ATTR_PORT:
                 return SAI_STATUS_SUCCESS;
         }
     }
@@ -2423,4 +2438,192 @@ void SwitchStateBase::debugSetStats(
     {
         m_countersMap[key][kvp.first] = kvp.second;
     }
+}
+
+sai_status_t SwitchStateBase::initialize_voq_switch_objects(
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    bool voq_switch = false;
+    int32_t voq_switch_id = -1;
+    uint32_t voq_max_cores = 0;
+    uint32_t sys_port_count = 0;
+    sai_system_port_config_t *sys_port_cfg_list = NULL;
+    for (uint32_t i = 0; i < attr_count; i++)
+    {
+        switch (attr_list[i].id)
+        {
+            case SAI_SWITCH_ATTR_TYPE:
+                if (attr_list[i].value.u32 != SAI_SWITCH_TYPE_VOQ)
+                {
+                    //Switch is not being set as VOQ type.
+                    return SAI_STATUS_SUCCESS;
+                }
+                else
+                {
+                    voq_switch = true;
+                }
+                break;
+
+            case SAI_SWITCH_ATTR_SWITCH_ID:
+                voq_switch_id = (int32_t) attr_list[i].value.u32;
+                if (voq_switch_id < 0)
+                {
+                    SWSS_LOG_ERROR("Invalid VOQ switch id %d", voq_switch_id);
+                    return (int32_t)SAI_STATUS_INVALID_ATTR_VALUE_0 + (int32_t)i;
+                }
+                break;
+
+            case SAI_SWITCH_ATTR_MAX_SYSTEM_CORES:
+                voq_max_cores = attr_list[i].value.u32;
+                if (voq_max_cores < 1)
+                {
+                    SWSS_LOG_ERROR("Invalid VOQ max system cores %d", voq_max_cores);
+                    return (int32_t)SAI_STATUS_INVALID_ATTR_VALUE_0 + (int32_t)i;
+                }
+                break;
+
+            case SAI_SWITCH_ATTR_SYSTEM_PORT_CONFIG_LIST:
+                sys_port_count = attr_list[i].value.sysportconfiglist.count;
+                sys_port_cfg_list = attr_list[i].value.sysportconfiglist.list;
+                if (sys_port_count < 1 || !sys_port_cfg_list)
+                {
+                    SWSS_LOG_ERROR("Invalid voq system port config info! sys port count %d, sys port list %p", sys_port_count, sys_port_cfg_list);
+                    return (int32_t)SAI_STATUS_INVALID_ATTR_VALUE_0 + (int32_t)i;
+                }
+                break;
+
+            default:
+                //Ignore other attributes. They are processed elsewhere.
+                break;
+        }
+    }
+
+    if (!voq_switch)
+    {
+        //No switch type attribute in the attribute list.
+        return SAI_STATUS_SUCCESS;
+    }
+
+    CHECK_STATUS(create_system_ports(voq_switch_id, sys_port_count, sys_port_cfg_list));
+    CHECK_STATUS(set_system_port_list());
+    CHECK_STATUS(set_voq_switch_attributes(voq_switch_id, voq_max_cores));
+
+    SWSS_LOG_NOTICE("Initialized VOQ switch.");
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::create_system_ports(int32_t voq_switch_id, uint32_t sys_port_count, sai_system_port_config_t *sys_port_cfg_list)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_INFO("create system ports");
+
+    m_system_port_list.clear();
+
+    for (uint32_t i = 0; i < sys_port_count; i++)
+    {
+        SWSS_LOG_DEBUG("create system port index %u", i);
+
+        sai_object_id_t system_port_id;
+
+        CHECK_STATUS(create(SAI_OBJECT_TYPE_SYSTEM_PORT, &system_port_id, m_switch_id, 0, NULL));
+        m_system_port_list.push_back(system_port_id);
+
+        sai_attribute_t attr;
+
+        attr.id = SAI_SYSTEM_PORT_ATTR_CONFIG_INFO;
+        attr.value.sysportconfig = sys_port_cfg_list[i];
+        CHECK_STATUS(set(SAI_OBJECT_TYPE_SYSTEM_PORT, system_port_id, &attr));
+
+        attr.id = SAI_SYSTEM_PORT_ATTR_TYPE;
+        attr.value.s32 = SAI_SYSTEM_PORT_TYPE_REMOTE;
+        if ((int32_t)sys_port_cfg_list[i].attached_switch_id == voq_switch_id)
+        {
+            attr.value.s32 = SAI_SYSTEM_PORT_TYPE_LOCAL;
+
+            //This is system port of local port. Set the oid of the local port corresponding to this system port
+            auto map = m_switchConfig->m_corePortIndexMap;
+            if (map)
+            {
+                auto& corePortIndexVector = map->getCorePortIndexVector();
+                size_t n_map = corePortIndexVector.size();
+                size_t idx;
+                for (idx = 0; idx < n_map; idx++)
+                {
+                    if (corePortIndexVector[idx][0] == sys_port_cfg_list[i].attached_core_index &&
+                            corePortIndexVector[idx][1] == sys_port_cfg_list[i].attached_core_port_index &&
+                            idx < m_port_list.size())
+                    {
+                        sai_attribute_t lp_attr;
+                        lp_attr.id = SAI_SYSTEM_PORT_ATTR_PORT;
+                        //m_port_list entries are in the same order as lane maps. The core port index maps are in the
+                        //same order as the lane maps. So m_port_list at the index corresponding to the core port index map
+                        //will be the port corresponding to the system port with core port index matching core port index map
+                        lp_attr.value.oid = m_port_list.at(idx);
+                        CHECK_STATUS(set(SAI_OBJECT_TYPE_SYSTEM_PORT, system_port_id, &lp_attr));
+                        break;
+                    }
+                }
+                if (idx >= n_map)
+                {
+                    SWSS_LOG_ERROR("Core port index not found for system port %d, System port's local port oid is not set!",
+                            sys_port_cfg_list[i].port_id, sai_serialize_object_id(m_switch_id).c_str());
+                }
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Core port index map for switch %s is NULL, Local port oid is not set for system port %d!",
+                        sai_serialize_object_id(m_switch_id).c_str(), sys_port_cfg_list[i].port_id);
+            }
+        }
+        CHECK_STATUS(set(SAI_OBJECT_TYPE_SYSTEM_PORT, system_port_id, &attr));
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::set_system_port_list()
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_INFO("set system port list");
+
+    // NOTE: this is static, but will be refreshed on read only get
+
+    sai_attribute_t attr;
+
+    uint32_t sys_port_count = (uint32_t)m_system_port_list.size();
+
+    attr.id = SAI_SWITCH_ATTR_SYSTEM_PORT_LIST;
+    attr.value.objlist.count = sys_port_count;
+    attr.value.objlist.list = m_system_port_list.data();
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    attr.id = SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS;
+    attr.value.u32 = sys_port_count;
+    return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
+}
+
+sai_status_t SwitchStateBase::set_voq_switch_attributes(int32_t voq_switch_id, uint32_t voq_max_cores)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_INFO("set voq switch attributes");
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_TYPE;
+    attr.value.s32 = SAI_SWITCH_TYPE_VOQ;
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_ID;
+    attr.value.u32 = voq_switch_id;
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    attr.id = SAI_SWITCH_ATTR_MAX_SYSTEM_CORES;
+    attr.value.u32 = voq_max_cores;
+    return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
 }

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -659,6 +659,12 @@ sai_status_t VirtualSwitchSaiInterface::create(
             return SAI_STATUS_FAILURE;
         }
 
+        //Initialize switch for VOQ attributes
+        if ((ss->initialize_voq_switch_objects(attr_count, attr_list)) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("VOQ switch initialization failed!");
+        }
+
         if (warmBootState != nullptr)
         {
             update_local_metadata(switchId);


### PR DESCRIPTION
Signed-off-by: vedganes <vedavinayagam.ganesan@nokia.com>

SAI emulation support added for VOQ system ports. The changes include:
(1) Switch create initialization for VOQ switch objects
(2) Associating local port id to sytems ports that correspond to the
local ports. In real SAI, mapping between system port and local port
is done by matching the system ports's <switch_id, core index, core port
index> tuple. In VOQ switches, each port blongs to a switch core and is
assigned an index. This mapping is done in hardware configurations. For
VS, the mapping is emulated via a new file coreportindexmap.ini. This
file is made available in /usr/share/sonic/hwsku in the same way how
lanemap.ini is made avaialble. The loading and parsing of
coreportindexmap.ini is done in similar way as it is done for
lanemap.ini. While emulating configuration system ports, if a system
port is found to be a local port (determined using its switch_id), the
local port oid corresponding system port is retrieved from m_port_list
and local port atribute is set in the system port object. This is used
by orchagent (portsorch) for system port initialization.