### PR TITLE
[vs] SAI support for VoQ switch - Core Port Index Map Container

### DIFF
--- a/vslib/inc/CorePortIndexMapContainer.h
+++ b/vslib/inc/CorePortIndexMapContainer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CorePortIndexMap.h"
+
+#include <memory>
+#include <map>
+
+namespace saivs
+{
+    class CorePortIndexMapContainer
+    {
+        public:
+
+            CorePortIndexMapContainer() = default;
+
+            virtual ~CorePortIndexMapContainer() = default;
+
+        public:
+
+            void insert(
+                    _In_ std::shared_ptr<CorePortIndexMap> corePortIndexMap);
+
+            void remove(
+                    _In_ uint32_t switchIndex);
+
+            std::shared_ptr<CorePortIndexMap> getCorePortIndexMap(
+                    _In_ uint32_t switchIndex) const;
+
+            void clear();
+
+            bool hasCorePortIndexMap(
+                    _In_ uint32_t switchIndex) const;
+
+            size_t size() const;
+
+            void removeEmptyCorePortIndexMaps();
+
+        private:
+
+            std::map<uint32_t, std::shared_ptr<CorePortIndexMap>> m_map;
+    };
+}
+

--- a/vslib/src/CorePortIndexMapContainer.cpp
+++ b/vslib/src/CorePortIndexMapContainer.cpp
@@ -1,0 +1,80 @@
+#include "CorePortIndexMapContainer.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+void CorePortIndexMapContainer::insert(
+        _In_ std::shared_ptr<CorePortIndexMap> corePortIndexMap)
+{
+    SWSS_LOG_ENTER();
+
+    m_map[corePortIndexMap->getSwitchIndex()] = corePortIndexMap;
+}
+
+void CorePortIndexMapContainer::remove(
+        _In_ uint32_t switchIndex)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_map.find(switchIndex);
+
+    if (it != m_map.end())
+    {
+        m_map.erase(it);
+    }
+}
+
+std::shared_ptr<CorePortIndexMap> CorePortIndexMapContainer::getCorePortIndexMap(
+        _In_ uint32_t switchIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_map.find(switchIndex);
+
+    if (it == m_map.end())
+    {
+        return nullptr;
+    }
+
+    return it->second;
+}
+
+void CorePortIndexMapContainer::clear()
+{
+    SWSS_LOG_ENTER();
+
+    m_map.clear();
+}
+
+bool CorePortIndexMapContainer::hasCorePortIndexMap(
+        _In_ uint32_t switchIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    return m_map.find(switchIndex) != m_map.end();
+}
+
+size_t CorePortIndexMapContainer::size() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_map.size();
+}
+
+void CorePortIndexMapContainer::removeEmptyCorePortIndexMaps()
+{
+    SWSS_LOG_ENTER();
+
+    for(auto it = m_map.begin(); it != m_map.end();)
+    {
+        if (it->second->isEmpty())
+        {
+            it = m_map.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: vedganes <vedavinayagam.ganesan@nokia.com>

Core Port-Index Map support for VOQ system ports. This is part of SAI support of VOQ VS testing. This PR has container class for Voq Core port index map.