### PR TITLE
[vs] Initialization of VOQ switch objects

### DIFF
--- a/vslib/inc/SwitchBCM81724.h
+++ b/vslib/inc/SwitchBCM81724.h
@@ -97,8 +97,14 @@ namespace saivs
 
         protected:
 
-            virtual sai_status_t refresh_read_only( _In_ const sai_attr_metadata_t *meta, _In_ sai_object_id_t object_id) override;
+            virtual sai_status_t refresh_read_only(
+                    _In_ const sai_attr_metadata_t *meta,
+                    _In_ sai_object_id_t object_id) override;
+
             virtual sai_status_t set_switch_default_attributes();
-            virtual sai_status_t initialize_default_objects( _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list) override;
+
+            virtual sai_status_t initialize_default_objects(
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list) override;
     };
 }

--- a/vslib/inc/SwitchBCM81724.h
+++ b/vslib/inc/SwitchBCM81724.h
@@ -99,6 +99,6 @@ namespace saivs
 
             virtual sai_status_t refresh_read_only( _In_ const sai_attr_metadata_t *meta, _In_ sai_object_id_t object_id) override;
             virtual sai_status_t set_switch_default_attributes();
-            virtual sai_status_t initialize_default_objects() override;
+            virtual sai_status_t initialize_default_objects( _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list) override;
     };
 }

--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -98,7 +98,9 @@ namespace saivs
 
         public:
 
-            virtual sai_status_t initialize_default_objects();
+            virtual sai_status_t initialize_default_objects(
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
 
             virtual sai_status_t create_port_dependencies(
                     _In_ sai_object_id_t port_id);

--- a/vslib/inc/VirtualSwitchSaiInterface.h
+++ b/vslib/inc/VirtualSwitchSaiInterface.h
@@ -339,7 +339,10 @@ namespace saivs
                     _In_ sai_object_id_t switch_id,
                     _In_ std::shared_ptr<SwitchConfig> config,
                     _In_ std::shared_ptr<WarmBootState> warmBootState,
-                    _In_ std::weak_ptr<saimeta::Meta> meta);
+                    _In_ std::weak_ptr<saimeta::Meta> meta,
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
+
         private:
 
             static bool doesFdbEntryNotMatchFlushAttr(

--- a/vslib/src/SwitchBCM81724.cpp
+++ b/vslib/src/SwitchBCM81724.cpp
@@ -62,7 +62,9 @@ sai_status_t SwitchBCM81724::create_port_dependencies(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchBCM81724::initialize_default_objects()
+sai_status_t SwitchBCM81724::initialize_default_objects(
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1429,7 +1429,9 @@ sai_status_t SwitchStateBase::set_number_of_ecmp_groups()
     return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
 }
 
-sai_status_t SwitchStateBase::initialize_default_objects()
+sai_status_t SwitchStateBase::initialize_default_objects(
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
 {
     SWSS_LOG_ENTER();
 
@@ -1453,6 +1455,10 @@ sai_status_t SwitchStateBase::initialize_default_objects()
     CHECK_STATUS(set_switch_default_attributes());
     CHECK_STATUS(create_scheduler_groups());
     CHECK_STATUS(set_static_crm_values());
+
+    // Initialize switch for VOQ attributes
+
+    CHECK_STATUS(initialize_voq_switch_objects(attr_count, attr_list));
 
     return SAI_STATUS_SUCCESS;
 }

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -597,20 +597,11 @@ std::shared_ptr<SwitchStateBase> VirtualSwitchSaiInterface::init_switch(
     }
     else
     {
-        sai_status_t status = ss->initialize_default_objects(); // TODO move to constructor
+        sai_status_t status = ss->initialize_default_objects(attr_count, attr_list); // TODO move to constructor
 
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_THROW("unable to init switch %s", sai_serialize_status(status).c_str());
-        }
-
-        // Initialize switch for VOQ attributes
-
-        status = ss->initialize_voq_switch_objects(attr_count, attr_list);
-
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_THROW("VOQ switch initialization failed!");
         }
 
         SWSS_LOG_NOTICE("initialized switch %s", sai_serialize_object_id(switch_id).c_str());

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -659,6 +659,12 @@ sai_status_t VirtualSwitchSaiInterface::create(
             return SAI_STATUS_FAILURE;
         }
 
+        // Initialize switch for VOQ attributes
+        if ((ss->initialize_voq_switch_objects(attr_count, attr_list)) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_THROW("VOQ switch initialization failed!");
+        }
+
         if (warmBootState != nullptr)
         {
             update_local_metadata(switchId);


### PR DESCRIPTION
VOQ switch objects are initialized during swich create. This VOQ objects
are initialized after regular switch objects are initialized. This PR depends on https://github.com/Azure/sonic-sairedis/pull/701
for switch state initialization