### PR TITLE
[vslib]Add MACsec Filters

### DIFF
--- a/vslib/inc/MACsecEgressFilter.h
+++ b/vslib/inc/MACsecEgressFilter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "MACsecFilter.h"
+
+namespace saivs
+{
+    class MACsecEgressFilter : public MACsecFilter
+    {
+    public:
+        MACsecEgressFilter(_In_ const std::string &macsecInterfaceName);
+
+        virtual ~MACsecEgressFilter() = default;
+
+    protected:
+        virtual FilterStatus forward(
+            _In_ const void *buffer,
+            _In_ ssize_t length) override;
+    };
+}

--- a/vslib/inc/MACsecEgressFilter.h
+++ b/vslib/inc/MACsecEgressFilter.h
@@ -15,6 +15,6 @@ namespace saivs
     protected:
         virtual FilterStatus forward(
             _In_ const void *buffer,
-            _In_ ssize_t length) override;
+            _In_ size_t length) override;
     };
 }

--- a/vslib/inc/MACsecEgressFilter.h
+++ b/vslib/inc/MACsecEgressFilter.h
@@ -7,7 +7,8 @@ namespace saivs
     class MACsecEgressFilter : public MACsecFilter
     {
     public:
-        MACsecEgressFilter(_In_ const std::string &macsecInterfaceName);
+        MACsecEgressFilter(
+            _In_ const std::string &macsecInterfaceName);
 
         virtual ~MACsecEgressFilter() = default;
 

--- a/vslib/inc/MACsecFilter.h
+++ b/vslib/inc/MACsecFilter.h
@@ -17,7 +17,7 @@ namespace saivs
 
         virtual FilterStatus execute(
             _Inout_ void *buffer,
-            _Inout_ ssize_t &length) override;
+            _Inout_ size_t &length) override;
 
         void enable_macsec_device(
             _In_ bool enable);
@@ -28,7 +28,7 @@ namespace saivs
     protected:
         virtual FilterStatus forward(
             _In_ const void *buffer,
-            _In_ ssize_t length) = 0;
+            _In_ size_t length) = 0;
 
         bool m_macsec_device_enable;
 

--- a/vslib/inc/MACsecFilter.h
+++ b/vslib/inc/MACsecFilter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "TrafficFilter.h"
+
+#include <string>
+
+namespace saivs
+{
+    class MACsecFilter : public TrafficFilter
+    {
+    public:
+        MACsecFilter(
+            _In_ const std::string &macsec_interface_name);
+
+        virtual ~MACsecFilter() = default;
+
+        virtual FilterStatus execute(
+            _Inout_ void *buffer,
+            _Inout_ ssize_t &length) override;
+
+        void enable_macsec_device(bool enable);
+
+        void set_macsec_fd(int macsecfd);
+
+    protected:
+        virtual FilterStatus forward(
+            _In_ const void *buffer,
+            _In_ ssize_t length) = 0;
+
+        bool m_macsec_device_enable;
+
+        int m_macsecfd;
+
+        const std::string m_macsec_interface_name;
+    };
+}

--- a/vslib/inc/MACsecFilter.h
+++ b/vslib/inc/MACsecFilter.h
@@ -6,11 +6,12 @@
 
 namespace saivs
 {
-    class MACsecFilter : public TrafficFilter
+    class MACsecFilter :
+        public TrafficFilter
     {
     public:
         MACsecFilter(
-            _In_ const std::string &macsec_interface_name);
+            _In_ const std::string &macsecInterfaceName);
 
         virtual ~MACsecFilter() = default;
 
@@ -18,9 +19,11 @@ namespace saivs
             _Inout_ void *buffer,
             _Inout_ ssize_t &length) override;
 
-        void enable_macsec_device(bool enable);
+        void enable_macsec_device(
+            _In_ bool enable);
 
-        void set_macsec_fd(int macsecfd);
+        void set_macsec_fd(
+            _In_ int macsecfd);
 
     protected:
         virtual FilterStatus forward(

--- a/vslib/inc/MACsecIngressFilter.h
+++ b/vslib/inc/MACsecIngressFilter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "MACsecFilter.h"
+
+namespace saivs
+{
+    class MACsecIngressFilter : public MACsecFilter
+    {
+    public:
+        MACsecIngressFilter(_In_ const std::string &macsec_interface_name);
+
+        virtual ~MACsecIngressFilter() = default;
+
+    protected:
+        virtual FilterStatus forward(
+            _In_ const void *buffer,
+            _In_ ssize_t length) override;
+    };
+}

--- a/vslib/inc/MACsecIngressFilter.h
+++ b/vslib/inc/MACsecIngressFilter.h
@@ -16,6 +16,6 @@ namespace saivs
     protected:
         virtual FilterStatus forward(
             _In_ const void *buffer,
-            _In_ ssize_t length) override;
+            _In_ size_t length) override;
     };
 }

--- a/vslib/inc/MACsecIngressFilter.h
+++ b/vslib/inc/MACsecIngressFilter.h
@@ -4,10 +4,12 @@
 
 namespace saivs
 {
-    class MACsecIngressFilter : public MACsecFilter
+    class MACsecIngressFilter :
+        public MACsecFilter
     {
     public:
-        MACsecIngressFilter(_In_ const std::string &macsec_interface_name);
+        MACsecIngressFilter(
+            _In_ const std::string &macsecInterfaceName);
 
         virtual ~MACsecIngressFilter() = default;
 

--- a/vslib/inc/TrafficFilter.h
+++ b/vslib/inc/TrafficFilter.h
@@ -27,6 +27,6 @@ namespace saivs
 
         virtual FilterStatus execute(
             _Inout_ void *buffer,
-            _Inout_ ssize_t &length) = 0;
+            _Inout_ size_t &length) = 0;
     };
 }

--- a/vslib/inc/TrafficFilter.h
+++ b/vslib/inc/TrafficFilter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "swss/sal.h"
+
+#include <sys/types.h>
+
+namespace saivs
+{
+    enum FilterPriority
+    {
+        MACSEC_FILTER,
+    };
+
+    class TrafficFilter
+    {
+    public:
+        enum FilterStatus
+        {
+            CONTINUE,
+            TERMINATE,
+            ERROR,
+        };
+
+        TrafficFilter() = default;
+
+        virtual ~TrafficFilter() = default;
+
+        virtual FilterStatus execute(
+            _Inout_ void *buffer,
+            _Inout_ ssize_t &length) = 0;
+    };
+}

--- a/vslib/inc/TrafficFilterPipes.h
+++ b/vslib/inc/TrafficFilterPipes.h
@@ -24,7 +24,7 @@ namespace saivs
 
         TrafficFilter::FilterStatus execute(
             _Inout_ void *buffer,
-            _Inout_ ssize_t &length);
+            _Inout_ size_t &length);
 
     private:
         typedef std::map<int, std::shared_ptr<TrafficFilter> > FilterPriorityQueue;

--- a/vslib/inc/TrafficFilterPipes.h
+++ b/vslib/inc/TrafficFilterPipes.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "TrafficFilter.h"
+
+#include <memory>
+#include <map>
+#include <mutex>
+
+namespace saivs
+{
+    class TrafficFilterPipes
+    {
+    public:
+        TrafficFilterPipes() = default;
+
+        virtual ~TrafficFilterPipes() = default;
+
+        bool installFilter(
+            _In_ int priority,
+            _In_ std::shared_ptr<TrafficFilter> filter);
+
+        bool uninstallFilter(
+            _In_ std::shared_ptr<TrafficFilter> filter);
+
+        TrafficFilter::FilterStatus execute(
+            _Inout_ void *buffer,
+            _Inout_ ssize_t &length);
+
+    private:
+        typedef std::map<int, std::shared_ptr<TrafficFilter> > FilterPriorityQueue;
+
+        std::mutex m_mutex;
+        FilterPriorityQueue m_filters;
+    };
+}

--- a/vslib/src/MACsecEgressFilter.cpp
+++ b/vslib/src/MACsecEgressFilter.cpp
@@ -18,7 +18,7 @@ MACsecEgressFilter::MACsecEgressFilter(
 
 TrafficFilter::FilterStatus MACsecEgressFilter::forward(
     _In_ const void *buffer,
-    _In_ ssize_t length)
+    _In_ size_t length)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/MACsecEgressFilter.cpp
+++ b/vslib/src/MACsecEgressFilter.cpp
@@ -7,7 +7,8 @@
 
 using namespace saivs;
 
-MACsecEgressFilter::MACsecEgressFilter(_In_ const std::string &macsecInterfaceName):
+MACsecEgressFilter::MACsecEgressFilter(
+    _In_ const std::string &macsecInterfaceName):
     MACsecFilter(macsecInterfaceName)
 {
     SWSS_LOG_ENTER();

--- a/vslib/src/MACsecEgressFilter.cpp
+++ b/vslib/src/MACsecEgressFilter.cpp
@@ -1,0 +1,48 @@
+#include "MACsecEgressFilter.h"
+
+#include <swss/logger.h>
+
+#include <unistd.h>
+#include <string.h>
+
+using namespace saivs;
+
+MACsecEgressFilter::MACsecEgressFilter(_In_ const std::string &macsecInterfaceName):
+    MACsecFilter(macsecInterfaceName)
+{
+    SWSS_LOG_ENTER();
+
+    // empty intentionally
+}
+
+TrafficFilter::FilterStatus MACsecEgressFilter::forward(
+    _In_ const void *buffer,
+    _In_ ssize_t length)
+{
+    SWSS_LOG_ENTER();
+
+    if (write(m_macsecfd, buffer, length) < 0)
+    {
+        if (errno != ENETDOWN && errno != EIO)
+        {
+            SWSS_LOG_ERROR(
+                "failed to write to macsec device %s fd %d, errno(%d): %s",
+                m_macsec_interface_name.c_str(),
+                m_macsecfd,
+                errno,
+                strerror(errno));
+        }
+
+        if (errno == EBADF)
+        {
+            SWSS_LOG_ERROR(
+                "ending thread for macsec device %s fd %d",
+                m_macsec_interface_name.c_str(),
+                m_macsecfd);
+
+            return TrafficFilter::ERROR;
+        }
+    }
+
+    return TrafficFilter::TERMINATE;
+}

--- a/vslib/src/MACsecEgressFilter.cpp
+++ b/vslib/src/MACsecEgressFilter.cpp
@@ -28,7 +28,7 @@ TrafficFilter::FilterStatus MACsecEgressFilter::forward(
         {
             SWSS_LOG_ERROR(
                 "failed to write to macsec device %s fd %d, errno(%d): %s",
-                m_macsec_interface_name.c_str(),
+                m_macsecInterfaceName.c_str(),
                 m_macsecfd,
                 errno,
                 strerror(errno));
@@ -38,7 +38,7 @@ TrafficFilter::FilterStatus MACsecEgressFilter::forward(
         {
             SWSS_LOG_ERROR(
                 "ending thread for macsec device %s fd %d",
-                m_macsec_interface_name.c_str(),
+                m_macsecInterfaceName.c_str(),
                 m_macsecfd);
 
             return TrafficFilter::ERROR;

--- a/vslib/src/MACsecFilter.cpp
+++ b/vslib/src/MACsecFilter.cpp
@@ -42,7 +42,7 @@ void MACsecFilter::set_macsec_fd(
 
 TrafficFilter::FilterStatus MACsecFilter::execute(
     _Inout_ void *buffer,
-    _Inout_ ssize_t &length)
+    _Inout_ size_t &length)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/MACsecFilter.cpp
+++ b/vslib/src/MACsecFilter.cpp
@@ -15,9 +15,9 @@ using namespace saivs;
 
 MACsecFilter::MACsecFilter(
     _In_ const std::string &macsecInterfaceName):
-    m_macsec_device_enable(false),
+    m_macsecDeviceEnable(false),
     m_macsecfd(0),
-    m_macsec_interface_name(macsecInterfaceName)
+    m_macsecInterfaceName(macsecInterfaceName)
 {
     SWSS_LOG_ENTER();
 
@@ -29,7 +29,7 @@ void MACsecFilter::enable_macsec_device(
 {
     SWSS_LOG_ENTER();
 
-    m_macsec_device_enable = enable;
+    m_macsecDeviceEnable = enable;
 }
 
 void MACsecFilter::set_macsec_fd(
@@ -54,7 +54,7 @@ TrafficFilter::FilterStatus MACsecFilter::execute(
         return TrafficFilter::CONTINUE;
     }
 
-    if (m_macsec_device_enable)
+    if (m_macsecDeviceEnable)
     {
         return forward(buffer, length);
     }

--- a/vslib/src/MACsecFilter.cpp
+++ b/vslib/src/MACsecFilter.cpp
@@ -14,23 +14,29 @@ using namespace saivs;
 #define EAPOL_ETHER_TYPE (0x888e)
 
 MACsecFilter::MACsecFilter(
-    _In_ const std::string &macsec_interface_name):
+    _In_ const std::string &macsecInterfaceName):
     m_macsec_device_enable(false),
     m_macsecfd(0),
-    m_macsec_interface_name(macsec_interface_name)
+    m_macsec_interface_name(macsecInterfaceName)
 {
     SWSS_LOG_ENTER();
 
     // empty intentionally
 }
 
-void MACsecFilter::enable_macsec_device(bool enable)
+void MACsecFilter::enable_macsec_device(
+    _In_ bool enable)
 {
+    SWSS_LOG_ENTER();
+
     m_macsec_device_enable = enable;
 }
 
-void MACsecFilter::set_macsec_fd(int macsecfd)
+void MACsecFilter::set_macsec_fd(
+    _In_ int macsecfd)
 {
+    SWSS_LOG_ENTER();
+
     m_macsecfd = macsecfd;
 }
 

--- a/vslib/src/MACsecFilter.cpp
+++ b/vslib/src/MACsecFilter.cpp
@@ -1,0 +1,58 @@
+#include "MACsecFilter.h"
+
+#include "swss/logger.h"
+#include "swss/select.h"
+
+#include <sys/socket.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+
+using namespace saivs;
+
+#define EAPOL_ETHER_TYPE (0x888e)
+
+MACsecFilter::MACsecFilter(
+    _In_ const std::string &macsec_interface_name):
+    m_macsec_device_enable(false),
+    m_macsecfd(0),
+    m_macsec_interface_name(macsec_interface_name)
+{
+    SWSS_LOG_ENTER();
+
+    // empty intentionally
+}
+
+void MACsecFilter::enable_macsec_device(bool enable)
+{
+    m_macsec_device_enable = enable;
+}
+
+void MACsecFilter::set_macsec_fd(int macsecfd)
+{
+    m_macsecfd = macsecfd;
+}
+
+TrafficFilter::FilterStatus MACsecFilter::execute(
+    _Inout_ void *buffer,
+    _Inout_ ssize_t &length)
+{
+    SWSS_LOG_ENTER();
+
+    auto mac_hdr = static_cast<const ethhdr *>(buffer);
+
+    if (ntohs(mac_hdr->h_proto) == EAPOL_ETHER_TYPE)
+    {
+        // EAPOL traffic will never be delivered to MACsec device
+        return TrafficFilter::CONTINUE;
+    }
+
+    if (m_macsec_device_enable)
+    {
+        return forward(buffer, length);
+    }
+
+    // Drop all non-EAPOL packets if macsec device haven't been enable.
+    return TrafficFilter::TERMINATE;
+}

--- a/vslib/src/MACsecIngressFilter.cpp
+++ b/vslib/src/MACsecIngressFilter.cpp
@@ -18,7 +18,7 @@ MACsecIngressFilter::MACsecIngressFilter(
 
 TrafficFilter::FilterStatus MACsecIngressFilter::forward(
     _In_ const void *buffer,
-    _In_ ssize_t length)
+    _In_ size_t length)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/MACsecIngressFilter.cpp
+++ b/vslib/src/MACsecIngressFilter.cpp
@@ -8,8 +8,8 @@
 using namespace saivs;
 
 MACsecIngressFilter::MACsecIngressFilter(
-    _In_ const std::string &macsec_interface_name) :
-    MACsecFilter(macsec_interface_name)
+    _In_ const std::string &macsecInterfaceName) :
+    MACsecFilter(macsecInterfaceName)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/src/MACsecIngressFilter.cpp
+++ b/vslib/src/MACsecIngressFilter.cpp
@@ -1,0 +1,30 @@
+#include "MACsecIngressFilter.h"
+
+#include "swss/logger.h"
+
+#include <unistd.h>
+#include <string.h>
+
+using namespace saivs;
+
+MACsecIngressFilter::MACsecIngressFilter(
+    _In_ const std::string &macsec_interface_name) :
+    MACsecFilter(macsec_interface_name)
+{
+    SWSS_LOG_ENTER();
+
+    // empty intentionally
+}
+
+TrafficFilter::FilterStatus MACsecIngressFilter::forward(
+    _In_ const void *buffer,
+    _In_ ssize_t length)
+{
+    SWSS_LOG_ENTER();
+
+    // MACsec interface will automatically forward ingress MACsec traffic
+    // by Linux Kernel.
+    // So this filter just need to drop all ingress MACsec traffic directly
+
+    return TrafficFilter::TERMINATE;
+}

--- a/vslib/src/TrafficFilterPipes.cpp
+++ b/vslib/src/TrafficFilterPipes.cpp
@@ -52,9 +52,7 @@ TrafficFilter::FilterStatus TrafficFilterPipes::execute(
 
         if (filter)
         {
-            ret = filter->execute(
-                buffer,
-                length);
+            ret = filter->execute(buffer, length);
 
             if (ret == TrafficFilter::CONTINUE)
             {
@@ -69,7 +67,6 @@ TrafficFilter::FilterStatus TrafficFilterPipes::execute(
         {
             itr = m_filters.erase(itr);
         }
-
     }
 
     return ret;

--- a/vslib/src/TrafficFilterPipes.cpp
+++ b/vslib/src/TrafficFilterPipes.cpp
@@ -1,0 +1,76 @@
+#include "TrafficFilterPipes.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+bool TrafficFilterPipes::installFilter(
+    _In_ int priority,
+    _In_ std::shared_ptr<TrafficFilter> filter)
+{
+    SWSS_LOG_ENTER();
+
+    std::unique_lock<std::mutex> guard(m_mutex);
+
+    return m_filters.emplace(priority, filter).second;
+}
+
+bool TrafficFilterPipes::uninstallFilter(
+    _In_ std::shared_ptr<TrafficFilter> filter)
+{
+    SWSS_LOG_ENTER();
+
+    std::unique_lock<std::mutex> guard(m_mutex);
+
+    for (auto itr = m_filters.begin();
+        itr != m_filters.end();
+        itr ++)
+    {
+        if (itr->second == filter)
+        {
+            m_filters.erase(itr);
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+TrafficFilter::FilterStatus TrafficFilterPipes::execute(
+    _Inout_ void *buffer,
+    _Inout_ ssize_t &length)
+{
+    SWSS_LOG_ENTER();
+
+    std::unique_lock<std::mutex> guard(m_mutex);
+    TrafficFilter::FilterStatus ret = TrafficFilter::CONTINUE;
+
+    for (auto itr = m_filters.begin(); itr != m_filters.end();)
+    {
+        auto filter = itr->second;
+
+        if (filter)
+        {
+            ret = filter->execute(
+                buffer,
+                length);
+
+            if (ret == TrafficFilter::CONTINUE)
+            {
+                itr ++;
+            }
+            else
+            {
+                break;
+            }
+        }
+        else
+        {
+            itr = m_filters.erase(itr);
+        }
+
+    }
+
+    return ret;
+}

--- a/vslib/src/TrafficFilterPipes.cpp
+++ b/vslib/src/TrafficFilterPipes.cpp
@@ -39,7 +39,7 @@ bool TrafficFilterPipes::uninstallFilter(
 
 TrafficFilter::FilterStatus TrafficFilterPipes::execute(
     _Inout_ void *buffer,
-    _Inout_ ssize_t &length)
+    _Inout_ size_t &length)
 {
     SWSS_LOG_ENTER();
 


### PR DESCRIPTION
The document about MACsec Filters can be found at: https://github.com/Azure/SONiC/blob/88c7ada900051f73a29aaf4a28bcaf5062ae7305/doc/macsec/MACsec_hld.md#345-virtual-macsec-sai

All filters will be installed in `HostInterfaceInfo` to filter the EAPOL and data traffic.
The `MACsecEgressFilter` will forward EAPOL packets to eth device and forward data packets to MACsec device.
The `MACsecIngressFilter` will forward EAPOL packets to Ethernet device and drop all data packets. Because the data packets will be forwarded to MACsec device by Linux kernel.

The `TrafficFilterPipes` provides an interfaces to add more filters for future functions.

Signed-off-by: Ze Gan <ganze718@gmail.com>