### PR TITLE
[vslib]Add MACsec forward and filters to HostInterfaceInfo

### DIFF
--- a/vslib/inc/HostInterfaceInfo.h
+++ b/vslib/inc/HostInterfaceInfo.h
@@ -6,6 +6,7 @@ extern "C" {
 
 #include "EventQueue.h"
 #include "TrafficFilterPipes.h"
+#include "TrafficForwarder.h"
 
 #include "swss/selectableevent.h"
 
@@ -15,7 +16,8 @@ extern "C" {
 
 namespace saivs
 {
-    class HostInterfaceInfo
+    class HostInterfaceInfo :
+        public TrafficForwarder
     {
         private:
 

--- a/vslib/inc/HostInterfaceInfo.h
+++ b/vslib/inc/HostInterfaceInfo.h
@@ -5,6 +5,7 @@ extern "C" {
 }
 
 #include "EventQueue.h"
+#include "TrafficFilterPipes.h"
 
 #include "swss/selectableevent.h"
 
@@ -38,6 +39,20 @@ namespace saivs
                     _In_ const uint8_t *buffer,
                     _In_ size_t size) const;
 
+            bool installEth2TapFilter(
+                    _In_ int priority,
+                    _In_ std::shared_ptr<TrafficFilter> filter);
+
+            bool uninstallEth2TapFilter(
+                    _In_ std::shared_ptr<TrafficFilter> filter);
+
+            bool installTap2EthFilter(
+                    _In_ int priority,
+                    _In_ std::shared_ptr<TrafficFilter> filter);
+
+            bool uninstallTap2EthFilter(
+                    _In_ std::shared_ptr<TrafficFilter> filter);
+
         private:
 
             void veth2tap_fun();
@@ -58,12 +73,15 @@ namespace saivs
 
             std::shared_ptr<EventQueue> m_eventQueue;
 
-        private:
-
             int m_tapfd;
+
+        private:
 
             std::shared_ptr<std::thread> m_e2t;
             std::shared_ptr<std::thread> m_t2e;
+
+            TrafficFilterPipes m_e2tFilters;
+            TrafficFilterPipes m_t2eFilters;
 
             swss::SelectableEvent m_e2tEvent;
             swss::SelectableEvent m_t2eEvent;

--- a/vslib/inc/MACsecFilter.h
+++ b/vslib/inc/MACsecFilter.h
@@ -30,10 +30,10 @@ namespace saivs
             _In_ const void *buffer,
             _In_ size_t length) = 0;
 
-        bool m_macsec_device_enable;
+        bool m_macsecDeviceEnable;
 
         int m_macsecfd;
 
-        const std::string m_macsec_interface_name;
+        const std::string m_macsecInterfaceName;
     };
 }

--- a/vslib/inc/MACsecForwarder.h
+++ b/vslib/inc/MACsecForwarder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "HostInterfaceInfo.h"
+#include "TrafficForwarder.h"
 
 #include "swss/sal.h"
 #include "swss/selectableevent.h"
@@ -11,12 +12,12 @@
 
 namespace saivs
 {
-    class MACsecForwarder
+    class MACsecForwarder :
+        public TrafficForwarder
     {
     public:
         MACsecForwarder(
             _In_ const std::string &macsecInterfaceName,
-            _In_ int tapfd,
             _In_ std::shared_ptr<HostInterfaceInfo> info);
 
         virtual ~MACsecForwarder();
@@ -26,7 +27,6 @@ namespace saivs
         void forward();
 
     private:
-        int m_tapfd;
         int m_macsecfd;
 
         const std::string m_macsecInterfaceName;

--- a/vslib/inc/MACsecForwarder.h
+++ b/vslib/inc/MACsecForwarder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "HostInterfaceInfo.h"
+
 #include "swss/sal.h"
 #include "swss/selectableevent.h"
 
@@ -14,7 +16,8 @@ namespace saivs
     public:
         MACsecForwarder(
             _In_ const std::string &macsecInterfaceName,
-            _In_ int tapfd);
+            _In_ int tapfd,
+            _In_ std::shared_ptr<HostInterfaceInfo> info);
 
         virtual ~MACsecForwarder();
 
@@ -33,5 +36,7 @@ namespace saivs
         swss::SelectableEvent m_exitEvent;
 
         std::shared_ptr<std::thread> m_forwardThread;
+
+        std::shared_ptr<HostInterfaceInfo> m_info;
     };
 }

--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -363,6 +363,11 @@ namespace saivs
             sai_status_t removeDebugCounter(
                     _In_ sai_object_id_t objectId);
 
+        public:
+
+            static int promisc(
+                    _In_ const char *dev);
+
         protected: // custom hostif
 
             sai_status_t createHostif(
@@ -393,9 +398,6 @@ namespace saivs
             static int vs_set_dev_mac_address(
                     _In_ const char *dev,
                     _In_ const sai_mac_t& mac);
-
-            static int promisc(
-                    _In_ const char *dev);
 
             static int get_default_gw_mac_address(
                     _Out_ sai_mac_t& mac);

--- a/vslib/inc/TrafficForwarder.h
+++ b/vslib/inc/TrafficForwarder.h
@@ -5,6 +5,9 @@
 #include <stddef.h>
 #include <sys/socket.h>
 
+static constexpr size_t ETH_FRAME_BUFFER_SIZE = 0x4000;
+static constexpr size_t CONTROL_MESSAGE_BUFFER_SIZE = 0x1000;
+
 namespace saivs
 {
     class TrafficForwarder
@@ -15,15 +18,15 @@ namespace saivs
     protected:
         TrafficForwarder() = default;
 
-        void add_vlan_tag(
+        static void addVlanTag(
             _Inout_ unsigned char *buffer,
             _Inout_ size_t &length,
-            _Inout_ struct msghdr &msg) const;
+            _Inout_ struct msghdr &msg);
 
-        bool send_to(
+        bool sendTo(
             _In_ int fd,
             _In_ const unsigned char *buffer,
-            _In_ size_t &length) const;
+            _In_ size_t length) const;
 
     };
 }

--- a/vslib/inc/TrafficForwarder.h
+++ b/vslib/inc/TrafficForwarder.h
@@ -5,11 +5,11 @@
 #include <stddef.h>
 #include <sys/socket.h>
 
-static constexpr size_t ETH_FRAME_BUFFER_SIZE = 0x4000;
-static constexpr size_t CONTROL_MESSAGE_BUFFER_SIZE = 0x1000;
-
 namespace saivs
 {
+    static constexpr size_t ETH_FRAME_BUFFER_SIZE = 0x4000;
+    static constexpr size_t CONTROL_MESSAGE_BUFFER_SIZE = 0x1000;
+
     class TrafficForwarder
     {
     public:

--- a/vslib/inc/TrafficForwarder.h
+++ b/vslib/inc/TrafficForwarder.h
@@ -23,7 +23,7 @@ namespace saivs
             _Inout_ size_t &length,
             _Inout_ struct msghdr &msg);
 
-        bool sendTo(
+        virtual bool sendTo(
             _In_ int fd,
             _In_ const unsigned char *buffer,
             _In_ size_t length) const;

--- a/vslib/inc/TrafficForwarder.h
+++ b/vslib/inc/TrafficForwarder.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "swss/sal.h"
+
+#include <stddef.h>
+#include <sys/socket.h>
+
+namespace saivs
+{
+    class TrafficForwarder
+    {
+    public:
+        virtual ~TrafficForwarder() = default;
+
+    protected:
+        TrafficForwarder() = default;
+
+        void add_vlan_tag(
+            _Inout_ unsigned char *buffer,
+            _Inout_ size_t &length,
+            _Inout_ struct msghdr &msg) const;
+
+        bool send_to(
+            _In_ int fd,
+            _In_ const unsigned char *buffer,
+            _In_ size_t &length) const;
+
+    };
+}

--- a/vslib/src/HostInterfaceInfo.cpp
+++ b/vslib/src/HostInterfaceInfo.cpp
@@ -124,12 +124,6 @@ bool HostInterfaceInfo::uninstallTap2EthFilter(
     return m_t2eFilters.uninstallFilter(filter);
 }
 
-#define ETH_FRAME_BUFFER_SIZE (0x4000)
-#define CONTROL_MESSAGE_BUFFER_SIZE (0x1000)
-#define IEEE_8021Q_ETHER_TYPE (0x8100)
-#define MAC_ADDRESS_SIZE (6)
-#define VLAN_TAG_SIZE (4)
-
 void HostInterfaceInfo::veth2tap_fun()
 {
     SWSS_LOG_ENTER();
@@ -210,11 +204,11 @@ void HostInterfaceInfo::veth2tap_fun()
             return;
         }
 
-        add_vlan_tag(buffer, length, msg);
+        addVlanTag(buffer, length, msg);
 
         async_process_packet_for_fdb_event(buffer, length);
 
-        if (!send_to(m_tapfd, buffer, length))
+        if (!sendTo(m_tapfd, buffer, length))
         {
             break;
         }

--- a/vslib/src/MACsecForwarder.cpp
+++ b/vslib/src/MACsecForwarder.cpp
@@ -15,13 +15,19 @@
 using namespace saivs;
 
 #define ETH_FRAME_BUFFER_SIZE (0x4000)
+#define CONTROL_MESSAGE_BUFFER_SIZE (0x1000)
+#define IEEE_8021Q_ETHER_TYPE (0x8100)
+#define MAC_ADDRESS_SIZE (6)
+#define VLAN_TAG_SIZE (4)
 
 MACsecForwarder::MACsecForwarder(
     _In_ const std::string &macsecInterfaceName,
-    _In_ int tapfd):
+    _In_ int tapfd,
+    _In_ std::shared_ptr<HostInterfaceInfo> info):
     m_tapfd(tapfd),
     m_macsecInterfaceName(macsecInterfaceName),
-    m_runThread(true)
+    m_runThread(true),
+    m_info(info)
 {
     SWSS_LOG_ENTER();
 
@@ -112,6 +118,25 @@ void MACsecForwarder::forward()
 
     while (m_runThread)
     {
+        struct msghdr  msg;
+        memset(&msg, 0, sizeof(struct msghdr));
+
+        struct sockaddr_storage srcAddr;
+
+        struct iovec iov[1];
+
+        iov[0].iov_base = buffer;       // buffer for message
+        iov[0].iov_len = sizeof(buffer);
+
+        char control[CONTROL_MESSAGE_BUFFER_SIZE];   // buffer for control messages
+
+        msg.msg_name = &srcAddr;
+        msg.msg_namelen = sizeof(srcAddr);
+        msg.msg_iov = iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = control;
+        msg.msg_controllen = sizeof(control);
+
         swss::Selectable *sel = NULL;
         int result = s.select(&sel);
 
@@ -128,7 +153,7 @@ void MACsecForwarder::forward()
         if (sel == &m_exitEvent) // thread end event
             break;
 
-        ssize_t size = read(m_macsecfd, buffer, sizeof(buffer));
+        ssize_t size = recvmsg(m_macsecfd, &msg, 0);
 
         if (size < 0)
         {
@@ -151,6 +176,55 @@ void MACsecForwarder::forward()
 
             continue;
         }
+        else if (size < (ssize_t)sizeof(ethhdr))
+        {
+            SWSS_LOG_ERROR("invalid ethernet frame length: %zu", msg.msg_controllen);
+
+            continue;
+        }
+
+        struct cmsghdr *cmsg;
+
+        for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg))
+        {
+            if (cmsg->cmsg_level != SOL_PACKET || cmsg->cmsg_type != PACKET_AUXDATA)
+                continue;
+
+            struct tpacket_auxdata* aux = (struct tpacket_auxdata*)CMSG_DATA(cmsg);
+
+            if ((aux->tp_status & TP_STATUS_VLAN_VALID) &&
+                    (aux->tp_status & TP_STATUS_VLAN_TPID_VALID))
+            {
+                SWSS_LOG_DEBUG("got vlan tci: 0x%x, vlanid: %d", aux->tp_vlan_tci, aux->tp_vlan_tci & 0xFFF);
+
+                // inject vlan tag into frame
+
+                // for overlapping buffers
+                memmove(buffer + 2 * MAC_ADDRESS_SIZE + VLAN_TAG_SIZE,
+                        buffer + 2 * MAC_ADDRESS_SIZE,
+                        size - (2 * MAC_ADDRESS_SIZE));
+
+                uint16_t tci = htons(aux->tp_vlan_tci);
+                uint16_t tpid = htons(IEEE_8021Q_ETHER_TYPE);
+
+                uint8_t* pvlan =  (uint8_t *)(buffer + 2 * MAC_ADDRESS_SIZE);
+                memcpy(pvlan, &tpid, sizeof(uint16_t));
+                memcpy(pvlan + sizeof(uint16_t), &tci, sizeof(uint16_t));
+
+                size += VLAN_TAG_SIZE;
+
+                break;
+            }
+        }
+
+        if (m_info == nullptr)
+        {
+            SWSS_LOG_ERROR("The HostInterfaceInfo on the MACsec port %s is empty", m_macsecInterfaceName.c_str());
+
+            break;
+        }
+
+        m_info->async_process_packet_for_fdb_event(buffer, size);
 
         if (write(m_tapfd, buffer, static_cast<int>(size)) < 0)
         {

--- a/vslib/src/MACsecForwarder.cpp
+++ b/vslib/src/MACsecForwarder.cpp
@@ -14,12 +14,6 @@
 
 using namespace saivs;
 
-#define ETH_FRAME_BUFFER_SIZE (0x4000)
-#define CONTROL_MESSAGE_BUFFER_SIZE (0x1000)
-#define IEEE_8021Q_ETHER_TYPE (0x8100)
-#define MAC_ADDRESS_SIZE (6)
-#define VLAN_TAG_SIZE (4)
-
 MACsecForwarder::MACsecForwarder(
     _In_ const std::string &macsecInterfaceName,
     _In_ std::shared_ptr<HostInterfaceInfo> info):
@@ -188,11 +182,11 @@ void MACsecForwarder::forward()
 
         size_t length = static_cast<size_t>(size);
 
-        add_vlan_tag(buffer, length, msg);
+        addVlanTag(buffer, length, msg);
 
         m_info->async_process_packet_for_fdb_event(buffer, length);
 
-        if (!send_to(m_info->m_tapfd, buffer, length))
+        if (!sendTo(m_info->m_tapfd, buffer, length))
         {
             break;
         }

--- a/vslib/src/MACsecManager.cpp
+++ b/vslib/src/MACsecManager.cpp
@@ -579,7 +579,7 @@ bool MACsecManager::add_macsec_forwarder(
 
     auto &manager = itr->second;
 
-    manager.m_forwarder = std::make_shared<MACsecForwarder>(macsecInterface, manager.m_info->m_tapfd, manager.m_info);
+    manager.m_forwarder = std::make_shared<MACsecForwarder>(macsecInterface, manager.m_info);
     return true;
 }
 

--- a/vslib/src/MACsecManager.cpp
+++ b/vslib/src/MACsecManager.cpp
@@ -579,7 +579,7 @@ bool MACsecManager::add_macsec_forwarder(
 
     auto &manager = itr->second;
 
-    manager.m_forwarder = std::make_shared<MACsecForwarder>(macsecInterface, manager.m_info->m_tapfd);
+    manager.m_forwarder = std::make_shared<MACsecForwarder>(macsecInterface, manager.m_info->m_tapfd, manager.m_info);
     return true;
 }
 

--- a/vslib/src/Makefile.am
+++ b/vslib/src/Makefile.am
@@ -57,6 +57,8 @@ libSaiVS_a_SOURCES = \
 					  MACsecFilter.cpp \
 					  MACsecEgressFilter.cpp \
 					  MACsecIngressFilter.cpp \
+					  TrafficForwarder.cpp \
+					  MACsecForwarder.cpp \
 					  TrafficFilterPipes.cpp
 
 libsaivs_la_SOURCES = \

--- a/vslib/src/Makefile.am
+++ b/vslib/src/Makefile.am
@@ -53,7 +53,11 @@ libSaiVS_a_SOURCES = \
 					  SwitchMLNX2700.cpp \
 					  CorePortIndexMap.cpp \
 					  CorePortIndexMapContainer.cpp \
-					  CorePortIndexMapFileParser.cpp
+					  CorePortIndexMapFileParser.cpp \
+					  MACsecFilter.cpp \
+					  MACsecEgressFilter.cpp \
+					  MACsecIngressFilter.cpp \
+					  TrafficFilterPipes.cpp
 
 libsaivs_la_SOURCES = \
 					  sai_vs_fdb.cpp \

--- a/vslib/src/TrafficForwarder.cpp
+++ b/vslib/src/TrafficForwarder.cpp
@@ -1,0 +1,100 @@
+#include "TrafficForwarder.h"
+
+#include "swss/logger.h"
+
+#include <memory.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <sys/ioctl.h>
+#include <net/if_arp.h>
+#include <unistd.h>
+#include <net/ethernet.h>
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+
+using namespace saivs;
+
+#define ETH_FRAME_BUFFER_SIZE (0x4000)
+#define CONTROL_MESSAGE_BUFFER_SIZE (0x1000)
+#define IEEE_8021Q_ETHER_TYPE (0x8100)
+#define MAC_ADDRESS_SIZE (6)
+#define VLAN_TAG_SIZE (4)
+
+void TrafficForwarder::add_vlan_tag(
+    _Inout_ unsigned char *buffer,
+    _Inout_ size_t &length,
+    _Inout_ struct msghdr &msg) const
+{
+    SWSS_LOG_ENTER();
+
+    struct cmsghdr *cmsg;
+
+    for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg))
+    {
+        if (cmsg->cmsg_level != SOL_PACKET || cmsg->cmsg_type != PACKET_AUXDATA)
+            continue;
+
+        struct tpacket_auxdata* aux = (struct tpacket_auxdata*)CMSG_DATA(cmsg);
+
+        if ((aux->tp_status & TP_STATUS_VLAN_VALID) &&
+                (aux->tp_status & TP_STATUS_VLAN_TPID_VALID))
+        {
+            SWSS_LOG_DEBUG("got vlan tci: 0x%x, vlanid: %d", aux->tp_vlan_tci, aux->tp_vlan_tci & 0xFFF);
+
+            // inject vlan tag into frame
+
+            // for overlapping buffers
+            memmove(buffer + 2 * MAC_ADDRESS_SIZE + VLAN_TAG_SIZE,
+                    buffer + 2 * MAC_ADDRESS_SIZE,
+                    length - (2 * MAC_ADDRESS_SIZE));
+
+            uint16_t tci = htons(aux->tp_vlan_tci);
+            uint16_t tpid = htons(IEEE_8021Q_ETHER_TYPE);
+
+            uint8_t* pvlan =  (uint8_t *)(buffer + 2 * MAC_ADDRESS_SIZE);
+            memcpy(pvlan, &tpid, sizeof(uint16_t));
+            memcpy(pvlan + sizeof(uint16_t), &tci, sizeof(uint16_t));
+
+            length += VLAN_TAG_SIZE;
+
+            break;
+        }
+    }
+}
+
+bool TrafficForwarder::send_to(
+    _In_ int fd,
+    _In_ const unsigned char *buffer,
+    _In_ size_t &length) const
+{
+    SWSS_LOG_ENTER();
+
+    if (write(fd, buffer, static_cast<int>(length)) < 0)
+    {
+        /*
+        * We filter out EIO because of this patch:
+        * https://github.com/torvalds/linux/commit/1bd4978a88ac2589f3105f599b1d404a312fb7f6
+        */
+
+        if (errno != ENETDOWN && errno != EIO)
+        {
+            SWSS_LOG_ERROR("failed to write to device fd %d, errno(%d): %s",
+                    fd, errno, strerror(errno));
+        }
+
+        if (errno == EBADF)
+        {
+            // bad file descriptor, just end thread
+            SWSS_LOG_NOTICE("ending forward for fd %d", fd);
+
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
Add MACsec filter before VLAN Tag and FDB event processing.

Refer: MACsec in VLAN-aware Bridges
![image](https://user-images.githubusercontent.com/18609639/99933377-d7de9e00-2d95-11eb-90d7-46f9e96d89c4.png)

Signed-off-by: Ze Gan <ganze718@gmail.com>