### PR TITLE
Dynamic Port breakout fix the crash, port down event processing after…

### DIFF
--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -387,6 +387,7 @@ void NotificationProcessor::process_on_port_state_change(
     for (uint32_t i = 0; i < count; i++)
     {
         sai_port_oper_status_notification_t *oper_stat = &data[i];
+        sai_object_id_t rid = oper_stat->port_id;
 
         /*
          * We are using switch_rid as null, since port should be already
@@ -398,14 +399,11 @@ void NotificationProcessor::process_on_port_state_change(
          */
 
         SWSS_LOG_DEBUG("Port RID %s state change notification", 
-                sai_serialize_object_id(oper_stat->port_id).c_str());
+                sai_serialize_object_id(rid).c_str());
 
-        if (false == m_translator->tryTranslateRidToVid(oper_stat->port_id, oper_stat->port_id))
+        if (false == m_translator->tryTranslateRidToVid(rid, oper_stat->port_id))
         {
-            oper_stat->port_id = SAI_NULL_OBJECT_ID;
-
-            SWSS_LOG_WARN("Port RID transalted to null VID!!!");
-
+            SWSS_LOG_WARN("Port RID %s transalted to null VID!!!", sai_serialize_object_id(rid).c_str());
         }
 
         /*

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -400,14 +400,16 @@ void NotificationProcessor::process_on_port_state_change(
         SWSS_LOG_DEBUG("Port RID %s state change notification", 
                 sai_serialize_object_id(oper_stat->port_id).c_str());
 
-        oper_stat->port_id = m_translator->tryTranslateRidToVid(oper_stat->port_id, SAI_NULL_OBJECT_ID);
-
+        if (false == m_translator->tryTranslateRidToVid(oper_stat->port_id, oper_stat->port_id))
+        {
+            oper_stat->port_id = SAI_NULL_OBJECT_ID;
+        }
         /*
          * port may be in process of removal. OA may recieve notification for VID either
          * SAI_NULL_OBJECT_ID or non exist at time of processing 
          */
 
-        SWSS_LOG_DEBUG("Port VID %s state change notification", 
+        SWSS_LOG_INFO("Port VID %s state change notification", 
                 sai_serialize_object_id(oper_stat->port_id).c_str());
     }
 

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -398,7 +398,7 @@ void NotificationProcessor::process_on_port_state_change(
          * switch vid.
          */
 
-        SWSS_LOG_DEBUG("Port RID %s state change notification", 
+        SWSS_LOG_INFO("Port RID %s state change notification", 
                 sai_serialize_object_id(rid).c_str());
 
         if (false == m_translator->tryTranslateRidToVid(rid, oper_stat->port_id))

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -403,9 +403,13 @@ void NotificationProcessor::process_on_port_state_change(
         if (false == m_translator->tryTranslateRidToVid(oper_stat->port_id, oper_stat->port_id))
         {
             oper_stat->port_id = SAI_NULL_OBJECT_ID;
+
+            SWSS_LOG_WARN("Port RID transalted to null VID!!!");
+
         }
+
         /*
-         * port may be in process of removal. OA may recieve notification for VID either
+         * Port may be in process of removal. OA may recieve notification for VID either
          * SAI_NULL_OBJECT_ID or non exist at time of processing 
          */
 

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -31,15 +31,28 @@ bool VirtualOidTranslator::tryTranslateRidToVid(
     std::lock_guard<std::mutex> lock(m_mutex);
 
     if (rid == SAI_NULL_OBJECT_ID)
-        return false;
+    {
+        SWSS_LOG_DEBUG("translated RID null to VID null");
 
-    if (m_rid2vid.find(rid) == m_rid2vid.end())
-        return false;
+        vid = SAI_NULL_OBJECT_ID;
+        return true;
+    }
+
+    auto it = m_rid2vid.find(vid);
+
+    if (it != m_rid2vid.end())
+    {
+        vid = it->second;
+        return true;
+    }
 
     vid = m_client->getVidForRid(rid);
 
-    SWSS_LOG_DEBUG("translated RID %s to VID %s",
-            sai_serialize_object_id(rid).c_str(), sai_serialize_object_id(vid).c_str());
+    if(vid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_DEBUG("translated RID %s to VID null", sai_serialize_object_id(rid).c_str());
+        return false;
+    }
 
     return true;
 }

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -48,7 +48,7 @@ bool VirtualOidTranslator::tryTranslateRidToVid(
 
     vid = m_client->getVidForRid(rid);
 
-    if(vid == SAI_NULL_OBJECT_ID)
+    if (vid == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_DEBUG("translated RID %s to VID null", sai_serialize_object_id(rid).c_str());
         return false;

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -83,6 +83,16 @@ sai_object_id_t VirtualOidTranslator::translateRidToVid(
         SWSS_LOG_THROW("RID 0x%" PRIx64 " is switch object, but not in local or redis db, bug!", rid);
     }
 
+    if((object_type == SAI_OBJECT_TYPE_PORT) && (switchVid == SAI_NULL_OBJECT_ID))
+    {
+        /* Port might have been removed. Dont create new object from 
+           notification handler. switchVid == NULL is right check? TODO
+         */
+        SWSS_LOG_NOTICE("Port RID %s VID %s ignore allocation (from notify)!", 
+                sai_serialize_object_id(rid).c_str(), sai_serialize_object_id(vid).c_str());
+        return SAI_NULL_OBJECT_ID;
+    }
+
     vid = m_virtualObjectIdManager->allocateNewObjectId(object_type, switchVid); // TODO to std::function or separate object
 
     SWSS_LOG_DEBUG("translated RID %s to VID %s",

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -22,6 +22,28 @@ VirtualOidTranslator::VirtualOidTranslator(
     // empty
 }
 
+sai_object_id_t VirtualOidTranslator::tryTranslateRidToVid(
+        _In_ sai_object_id_t rid,
+        _In_ sai_object_id_t switchVid)
+{
+    SWSS_LOG_ENTER();
+
+    /*
+     * NOTE: switch_vid here is Virtual ID of switch for which we need
+     *  get VID for given RID. No check now! 
+     */
+
+    if(false == checkRidExists(rid))
+    {
+        SWSS_LOG_NOTICE("translated RID %s to VID null", sai_serialize_object_id(rid).c_str());
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    auto vid = m_client->getVidForRid(rid);
+
+    return vid;
+}
+
 sai_object_id_t VirtualOidTranslator::translateRidToVid(
         _In_ sai_object_id_t rid,
         _In_ sai_object_id_t switchVid)

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -118,16 +118,6 @@ sai_object_id_t VirtualOidTranslator::translateRidToVid(
         SWSS_LOG_THROW("RID 0x%" PRIx64 " is switch object, but not in local or redis db, bug!", rid);
     }
 
-    if((object_type == SAI_OBJECT_TYPE_PORT) && (switchVid == SAI_NULL_OBJECT_ID))
-    {
-        /* Port might have been removed. Dont create new object from 
-           notification handler. switchVid == NULL is right check? TODO
-         */
-        SWSS_LOG_NOTICE("Port RID %s VID %s ignore allocation (from notify)!", 
-                sai_serialize_object_id(rid).c_str(), sai_serialize_object_id(vid).c_str());
-        return SAI_NULL_OBJECT_ID;
-    }
-
     vid = m_virtualObjectIdManager->allocateNewObjectId(object_type, switchVid); // TODO to std::function or separate object
 
     SWSS_LOG_DEBUG("translated RID %s to VID %s",

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -42,6 +42,15 @@ namespace syncd
                     _In_ sai_object_id_t rid,
                     _In_ sai_object_id_t switchVid);
 
+            /*
+             * This method will try get VID for given RID.
+             * switch instance check not yet ready
+             * returns SAI_NULL_OBJECT_ID if not exists.
+             */
+            sai_object_id_t tryTranslateRidToVid(
+                    _In_ sai_object_id_t rid,
+                    _In_ sai_object_id_t switchVid);
+
             void translateRidToVid(
                     _Inout_ sai_object_list_t& objectList,
                     _In_ sai_object_id_t switchVid);

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -44,9 +44,9 @@ namespace syncd
 
             /*
              * This method will try get VID for given RID.
-             * returns true if input RID is null object and out VID is null object
-             * returns true if able to find VID and out VID object.
-             * returns false if not able to find VID and out VID is null object.
+             * Returns true if input RID is null object and out VID is null object.
+             * Returns true if able to find RID and out VID object.
+             * Returns false if not able to find RID and out VID is null object.
              */
             bool tryTranslateRidToVid(
                     _In_ sai_object_id_t rid,

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -44,12 +44,12 @@ namespace syncd
 
             /*
              * This method will try get VID for given RID.
-             * switch instance check not yet ready
-             * returns SAI_NULL_OBJECT_ID if not exists.
+             * returns false if vid doesn't exists.
+             * returns true if exists and vid.
              */
-            sai_object_id_t tryTranslateRidToVid(
+            bool tryTranslateRidToVid(
                     _In_ sai_object_id_t rid,
-                    _In_ sai_object_id_t switchVid);
+                    _Out_ sai_object_id_t &vid);
 
             void translateRidToVid(
                     _Inout_ sai_object_list_t& objectList,

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -44,8 +44,9 @@ namespace syncd
 
             /*
              * This method will try get VID for given RID.
-             * returns false if vid doesn't exists.
-             * returns true if exists and vid.
+             * returns true if input RID is null object and out VID is null object
+             * returns true if able to find VID and out VID object.
+             * returns false if not able to find VID and out VID is null object.
              */
             bool tryTranslateRidToVid(
                     _In_ sai_object_id_t rid,


### PR DESCRIPTION
Fix the syncd crash during Dynamic Port Breakout (DPB).  The syncd is processing in-transit port events after port has been removed. Add check to avoid it. Please refer the inline comments for enhancement required in this area.

Nov 23 03:26:21.607291 sonic ERR syncd#syncd: :- allocateNewObjectId: object type of switch oid:0x0 is SAI_OBJECT_TYPE_NULL, should be SWITCH
