### PR TITLE
Switch Capability support

### DIFF
--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -864,6 +864,24 @@ sai_status_t SwitchStateBase::set_switch_default_attributes()
     attr.id = SAI_SWITCH_ATTR_WARM_RECOVER;
     attr.value.booldata = false;
 
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    // Fill this with supported SAI_OBJECT_TYPEs
+    sai_object_type_t supported_obj_list[] = {
+                                SAI_OBJECT_TYPE_PORT,
+                                SAI_OBJECT_TYPE_LAG,
+                                SAI_OBJECT_TYPE_TAM,
+                                SAI_OBJECT_TYPE_TAM_COLLECTOR,
+                                SAI_OBJECT_TYPE_TAM_REPORT,
+                                SAI_OBJECT_TYPE_TAM_TRANSPORT,
+                                SAI_OBJECT_TYPE_TAM_TELEMETRY,
+                                SAI_OBJECT_TYPE_TAM_EVENT_THRESHOLD
+                              };
+
+    attr.id = SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST;
+    attr.value.s32list.count = sizeof(supported_obj_list)/sizeof(sai_object_type_t);
+    attr.value.s32list.list = (int32_t *) supported_obj_list;
+
     return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
 }
 
@@ -1793,6 +1811,9 @@ sai_status_t SwitchStateBase::refresh_read_only(
             case SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS:
             case SAI_SWITCH_ATTR_SYSTEM_PORT_LIST:
                 return refresh_system_port_list(meta);
+
+            case SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST:
+                return SAI_STATUS_SUCCESS;
         }
     }
 

--- a/vslib/src/tests.cpp
+++ b/vslib/src/tests.cpp
@@ -779,6 +779,36 @@ void test_get_stats()
     ASSERT_TRUE(values[1] == 77);
 }
 
+void test_supported_obj_types()
+{
+    SWSS_LOG_ENTER();
+
+    sai_reinit();
+
+    uint32_t expected_num_attrs = 8;
+
+    sai_attribute_t attr;
+
+    sai_object_id_t switch_id;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    SUCCESS(sai_metadata_sai_switch_api->create_switch(&switch_id, 1, &attr));
+
+    std::vector<sai_object_type_t> supported_obj_list;
+    supported_obj_list.resize(expected_num_attrs);
+
+    attr.id = SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST;
+    attr.value.s32list.count = expected_num_attrs;
+    attr.value.s32list.list = (int32_t *) supported_obj_list.data();
+
+    SUCCESS(sai_metadata_sai_switch_api->get_switch_attribute(switch_id, 1, &attr));
+
+    ASSERT_TRUE(attr.value.objlist.count == expected_num_attrs);
+
+}
+
 int main()
 {
     swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_DEBUG);
@@ -802,6 +832,8 @@ int main()
     test_fdb_flush();
 
     test_get_stats();
+
+    test_supported_obj_types();
 
     test_set_stats_via_redis();
 


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>

Adds SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST to switch attributes.

Related PRs:
https://github.com/Azure/sonic-swss/pull/1525