### PR TITLE
[SAI] Add PFC pause duration counters in microseconds

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -1017,7 +1017,7 @@ void FlexCounter::saiUpdateSupportedPortCounters(sai_object_id_t portId)
     SWSS_LOG_ENTER();
 
     uint64_t value;
-    for (int cntr_id = SAI_PORT_STAT_IF_IN_OCTETS; cntr_id <= SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS; ++cntr_id)
+    for (int cntr_id = SAI_PORT_STAT_IF_IN_OCTETS; cntr_id <= SAI_PORT_STAT_PFC_7_TX_PAUSE_DURATION_US; ++cntr_id)
     {
         sai_port_stat_t counter = static_cast<sai_port_stat_t>(cntr_id);
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

* Extended supported counters for "flex counter" logic in order to add support of PFC pause duration counters in microseconds.
* Updated SAI submodule in order to get headers with PFC pause duration counters in microseconds.
  * SAI submodule commit ID: ```8a88e31201bff375cadf7db4858735fc2c84571b```