### PR TITLE
[saidiscovery] Update saidiscovery to use VendorSai object and metadata

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -55,14 +55,14 @@ sai_status_t Meta::initialize(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_SUCCESS;
+    return m_implementation->initialize(flags, service_method_table);
 }
 
 sai_status_t Meta::uninitialize(void)
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_SUCCESS;
+    return m_implementation->uninitialize();
 }
 
 void Meta::meta_warm_boot_notify()

--- a/saidiscovery/Makefile.am
+++ b/saidiscovery/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(top_srcdir)/vslib/inc -I$(top_srcdir)/lib/inc -I$(top_srcdir)/SAI/inc -I$(top_srcdir)/SAI/meta -I$(top_srcdir)/SAI/experimental
+AM_CPPFLAGS = -I$(top_srcdir)/vslib/inc -I$(top_srcdir)/lib/inc -I$(top_srcdir)/SAI/inc -I$(top_srcdir)/SAI/meta -I$(top_srcdir)/SAI/experimental -I${top_srcdir}/meta -I${top_srcdir}/syncd
 
 bin_PROGRAMS = saidiscovery
 
@@ -17,4 +17,4 @@ endif
 saidiscovery_SOURCES = saidiscovery.cpp
 
 saidiscovery_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(SAIFLAGS)
-saidiscovery_LDADD = -lhiredis -lswsscommon $(SAILIB) -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta
+saidiscovery_LDADD = -lhiredis -lswsscommon $(SAILIB) -lpthread $(top_srcdir)/syncd/libSyncd.a -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta

--- a/saidiscovery/Makefile.am
+++ b/saidiscovery/Makefile.am
@@ -17,4 +17,4 @@ endif
 saidiscovery_SOURCES = saidiscovery.cpp
 
 saidiscovery_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(SAIFLAGS)
-saidiscovery_LDADD = -lhiredis -lswsscommon $(SAILIB) -lpthread $(top_srcdir)/syncd/libSyncd.a -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta
+saidiscovery_LDADD = -lhiredis -lswsscommon $(top_srcdir)/syncd/libSyncd.a $(SAILIB) -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta


### PR DESCRIPTION
Replace static check_mandatory_attributes with Meta object, which automatically checks for mandatory objects on create switch. Previous function was incorrectly demanding mandatory objects which are on condition.