### PR TITLE
[syncd] Translate depreacated attr enum values to new ones

### DIFF
--- a/meta/saiserialize.cpp
+++ b/meta/saiserialize.cpp
@@ -2143,11 +2143,21 @@ void sai_deserialize_enum(
         }
     }
 
-    // for backward compatibility from SAI v1.6
-    if (s == "SAI_NEXT_HOP_GROUP_TYPE_ECMP")
+    // check depreacated values if present
+    if (meta->ignorevaluesnames)
     {
-        value = SAI_NEXT_HOP_GROUP_TYPE_ECMP;
-        return;
+        // this can happen when we deserialize older SAI values
+
+        for (size_t i = 0; meta->ignorevaluesnames[i] != NULL; i++)
+        {
+            if (strcmp(s.c_str(), meta->ignorevaluesnames[i]) == 0)
+            {
+                SWSS_LOG_NOTICE("translating depreacated/ignored enum value: %s", s.c_str());
+
+                value = meta->ignorevalues[i];
+                return;
+            }
+        }
     }
 
     SWSS_LOG_WARN("enum %s not found in enum %s", s.c_str(), meta->name);

--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -1882,6 +1882,11 @@ void ComparisonLogic::processObjectForViewTransition(
         // No need to store VID since at this point we don't have RID yet, it will be
         // created on execute asic and RID will be saved to maps in both views.
 
+        SWSS_LOG_INFO("found best match, but set failed: %s: current: %s temporary: %s",
+                currentBestMatch->m_str_object_type.c_str(),
+                currentBestMatch->m_str_object_id.c_str(),
+                temporaryObj->m_str_object_id.c_str());
+
         createNewObjectFromTemporaryObject(currentView, temporaryView, temporaryObj);
 
         return;

--- a/syncd/SaiAttr.cpp
+++ b/syncd/SaiAttr.cpp
@@ -25,6 +25,22 @@ SaiAttr::SaiAttr(
     m_attr.id = m_meta->attrid;
 
     sai_deserialize_attr_value(str_attr_value, *m_meta, m_attr, false);
+
+    if (m_meta->isenum && m_meta->enummetadata->ignorevalues)
+    {
+        // if attribute is enum, and we are loading some older SAI values it
+        // may happen that we get depreacated/ignored value string and we need
+        // to update it to current one to not cause attribute compare confusion
+        // since they are compared by string value
+
+        auto val = sai_serialize_enum(m_attr.value.s32, m_meta->enummetadata);
+
+        SWSS_LOG_NOTICE("translating depreacated/ignore enum %s to %s",
+                m_str_attr_value.c_str(),
+                val.c_str());
+
+        m_str_attr_value = val;
+    }
 }
 
 SaiAttr::~SaiAttr()

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -147,7 +147,9 @@ sai_switch_type_t SaiSwitch::getSwitchType() const
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("failed to get switch type with status:0x%x. Assume default SAI_SWITCH_TYPE_NPU", status);
+        SWSS_LOG_WARN("failed to get switch type with status: %s, assume default SAI_SWITCH_TYPE_NPU",
+                sai_serialize_status(status).c_str());
+
         // Set to SAI_SWITCH_TYPE_NPU and move on
         attr.value.s32 = SAI_SWITCH_TYPE_NPU;
     }


### PR DESCRIPTION
If attribute is enum, and we are loading some older SAI values it may happen that we get deprecated/ignored value string and we need to update it to current one to not cause attribute compare confusion since they are compared by string value.

This fixes issues when warm shutdown on 201811 branch, and warm boot on master branch.