### PR TITLE
[201911][logfile] sairedis record file handling

### DIFF
--- a/lib/inc/sai_redis.h
+++ b/lib/inc/sai_redis.h
@@ -50,6 +50,8 @@ extern void clear_local_state();
 extern void setRecording(bool record);
 extern sai_status_t setRecordingOutputDir(
         _In_ const sai_attribute_t &attr);
+extern sai_status_t setRecordingOutputFile(
+        _In_ const sai_attribute_t &attr);
 extern void recordLine(std::string s);
 extern std::string joinFieldValues(
         _In_ const std::vector<swss::FieldValueTuple> &values);

--- a/lib/inc/sairedis.h
+++ b/lib/inc/sairedis.h
@@ -123,6 +123,18 @@ typedef enum _sai_redis_switch_attr_t
      */
     SAI_REDIS_SWITCH_ATTR_SYNC_MODE,
 
+    /**
+     * @brief Recording log filename.
+     *
+     * Default valus is sairedis.rec
+     *
+     * @type sai_s8_list_t
+     * @flags CREATE_AND_SET
+     * @default sairedis.rec
+     */
+    SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME,
+
+
 } sai_redis_switch_attr_t;
 
 /*

--- a/lib/src/sai_redis_switch.cpp
+++ b/lib/src/sai_redis_switch.cpp
@@ -297,6 +297,8 @@ sai_status_t redis_set_switch_attribute(
             case SAI_REDIS_SWITCH_ATTR_RECORDING_OUTPUT_DIR:
                 return setRecordingOutputDir(*attr);
 
+            case SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME:
+                return setRecordingOutputFile(*attr);
             default:
                 break;
         }


### PR DESCRIPTION
The PR implements the handling of the sairedis rec filename passed to the orchagent.
This PR is porting changes done in https://github.com/Azure/sonic-sairedis/pull/747 to 201911
Corresponding swss pr : Azure/sonic-swss#1546
This change is mainly to be used for multi asic devices where each asic.

Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>