### PR TITLE
Query counters capabilities with new SAI API

### DIFF
--- a/lib/inc/SaiInterface.h
+++ b/lib/inc/SaiInterface.h
@@ -254,6 +254,11 @@ namespace sairedis
                     _In_ sai_attr_id_t attr_id,
                     _Inout_ sai_s32_list_t *enum_values_capability) = 0;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) = 0;
+
             virtual sai_object_type_t objectTypeQuery(
                     _In_ sai_object_id_t objectId) = 0;
 

--- a/syncd/FlexCounterManager.cpp
+++ b/syncd/FlexCounterManager.cpp
@@ -86,7 +86,7 @@ void FlexCounterManager::addCounter(
         _In_ const std::vector<swss::FieldValueTuple>& values)
 {
     SWSS_LOG_ENTER();
-
+    SWSS_LOG_INFO("SHLOMI FlexCounterManager instanceId: %s", instanceId);
     auto fc = getInstance(instanceId);
 
     fc->addCounter(vid, rid, values);

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1892,6 +1892,7 @@ void Syncd::processFlexCounterEvent( // TODO must be moved to go via ASIC channe
         _In_ swss::ConsumerTable& consumer)
 {
     SWSS_LOG_ENTER();
+    SWSS_LOG_INFO("SHLOMI inside processFlexCounterEvent");
 
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -1901,6 +1902,8 @@ void Syncd::processFlexCounterEvent( // TODO must be moved to go via ASIC channe
 
     auto& key = kfvKey(kco);
     auto& op = kfvOp(kco);
+    SWSS_LOG_INFO("SHLOMI key = %s", key.c_str());
+    SWSS_LOG_INFO("SHLOMI op = %s", op.c_str());
 
     auto delimiter = key.find_first_of(":");
 
@@ -4348,6 +4351,7 @@ void Syncd::run()
             }
             else if (sel == m_flexCounter.get())
             {
+                SWSS_LOG_INFO("SHLOMI geting an event of flex counters");
                 processFlexCounterEvent(*(swss::ConsumerTable*)sel);
             }
             else if (sel == m_flexCounterGroup.get())

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1052,6 +1052,21 @@ sai_status_t VendorSai::queryAattributeEnumValuesCapability(
             enum_values_capability);
 }
 
+sai_status_t VendorSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    return sai_query_stats_capability(
+            switchId,
+            objectType,
+            stats_capability);
+}
+
 sai_object_type_t VendorSai::objectTypeQuery(
         _In_ sai_object_id_t objectId)
 {

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -239,6 +239,11 @@ namespace syncd
                     _In_ sai_attr_id_t attr_id,
                     _Inout_ sai_s32_list_t *enum_values_capability) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_object_type_t objectTypeQuery(
                     _In_ sai_object_id_t objectId) override;
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

Implement new SAI API to query counters capabilities.
This API is used to get the capabilities in a way which is not accessing the HW and performs much quicker.
New API introduced on this PR: https://github.com/opencomputeproject/SAI/pull/1148