### PR TITLE
[sairedis] Add get response timeout knob

### DIFF
--- a/lib/inc/Channel.h
+++ b/lib/inc/Channel.h
@@ -30,6 +30,13 @@ namespace sairedis
 
         public:
 
+            void setResponseTimeout(
+                    _In_ uint64_t responseTimeout);
+
+            uint64_t getResponseTimeout() const;
+
+        public:
+
             virtual void setBuffered(
                     _In_ bool buffered) = 0;
 
@@ -55,6 +62,8 @@ namespace sairedis
         protected:
 
             Callback m_callback;
+
+            uint64_t m_responseTimeoutMs;
 
         protected: // notification
 

--- a/lib/inc/RedisRemoteSaiInterface.h
+++ b/lib/inc/RedisRemoteSaiInterface.h
@@ -465,6 +465,8 @@ namespace sairedis
 
             std::shared_ptr<Channel> m_communicationChannel;
 
+            uint64_t m_responseTimeoutMs;
+
             std::function<sai_switch_notifications_t(std::shared_ptr<Notification>)> m_notificationCallback;
 
             std::map<sai_object_id_t, swss::TableDump> m_tableDump;

--- a/lib/inc/sairedis.h
+++ b/lib/inc/sairedis.h
@@ -205,4 +205,15 @@ typedef enum _sai_redis_switch_attr_t
      */
     SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME,
 
+    /**
+     * @brief Get operation response timeout in milliseconds.
+     *
+     * Also used for every synchronous API call.
+     *
+     * @type sai_uint64_t
+     * @flgs CREATE_AND_SET
+     * @default 60000
+     */
+    SAI_REDIS_SWITCH_ATTR_GET_RESPONSE_TIMEOUT_MS,
+
 } sai_redis_switch_attr_t;

--- a/lib/inc/sairedis.h
+++ b/lib/inc/sairedis.h
@@ -13,6 +13,11 @@ extern "C" {
  */
 #define SAI_REDIS_KEY_CONTEXT_CONFIG              "SAI_REDIS_CONTEXT_CONFIG"
 
+/**
+ * @brief Default synchronous operation response timeout in milliseconds.
+ */
+#define SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT (60*1000)
+
 typedef enum _sai_redis_notify_syncd_t
 {
     SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW,
@@ -206,14 +211,15 @@ typedef enum _sai_redis_switch_attr_t
     SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME,
 
     /**
-     * @brief Get operation response timeout in milliseconds.
+     * @brief Synchronous operation response timeout in milliseconds.
      *
-     * Also used for every synchronous API call.
+     * Used for every synchronous API call. In asynchronous mode used for GET
+     * operation.
      *
      * @type sai_uint64_t
      * @flgs CREATE_AND_SET
      * @default 60000
      */
-    SAI_REDIS_SWITCH_ATTR_GET_RESPONSE_TIMEOUT_MS,
+    SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT,
 
 } sai_redis_switch_attr_t;

--- a/lib/inc/sairedis.h
+++ b/lib/inc/sairedis.h
@@ -217,7 +217,7 @@ typedef enum _sai_redis_switch_attr_t
      * operation.
      *
      * @type sai_uint64_t
-     * @flgs CREATE_AND_SET
+     * @flags CREATE_AND_SET
      * @default 60000
      */
     SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT,

--- a/lib/src/Channel.cpp
+++ b/lib/src/Channel.cpp
@@ -1,15 +1,15 @@
 #include "Channel.h"
 
+#include "sairedis.h"
+
 #include "swss/logger.h"
 
 using namespace sairedis;
 
-#define REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS (60*1000)
-
 Channel::Channel(
         _In_ Callback callback):
     m_callback(callback),
-    m_responseTimeoutMs(REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS)
+    m_responseTimeoutMs(SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT)
 {
     SWSS_LOG_ENTER();
 

--- a/lib/src/Channel.cpp
+++ b/lib/src/Channel.cpp
@@ -4,9 +4,12 @@
 
 using namespace sairedis;
 
+#define REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS (60*1000)
+
 Channel::Channel(
         _In_ Callback callback):
-    m_callback(callback)
+    m_callback(callback),
+    m_responseTimeoutMs(REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS)
 {
     SWSS_LOG_ENTER();
 
@@ -18,4 +21,19 @@ Channel::~Channel()
     SWSS_LOG_ENTER();
 
     // empty
+}
+
+void Channel::setResponseTimeout(
+        _In_ uint64_t responseTimeout)
+{
+    SWSS_LOG_ENTER();
+
+    m_responseTimeoutMs = responseTimeout;
+}
+
+uint64_t Channel::getResponseTimeout() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_responseTimeoutMs;
 }

--- a/lib/src/RedisChannel.cpp
+++ b/lib/src/RedisChannel.cpp
@@ -9,11 +9,6 @@
 
 using namespace sairedis;
 
-/**
- * @brief Get response timeout in milliseconds.
- */
-#define REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS (60*1000)
-
 RedisChannel::RedisChannel(
         _In_ const std::string& dbAsic,
         _In_ Channel::Callback callback):
@@ -179,7 +174,7 @@ sai_status_t RedisChannel::wait(
 
         swss::Selectable *sel;
 
-        int result = s.select(&sel, REDIS_ASIC_STATE_COMMAND_GETRESPONSE_TIMEOUT_MS);
+        int result = s.select(&sel, (int)m_responseTimeoutMs);
 
         if (result == swss::Select::OBJECT)
         {

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -357,7 +357,7 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
             return SAI_STATUS_SUCCESS;
 
-        case SAI_REDIS_SWITCH_ATTR_GET_RESPONSE_TIMEOUT_MS:
+        case SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT:
 
             m_responseTimeoutMs = attr->value.u64;
 

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -92,6 +92,8 @@ sai_status_t RedisRemoteSaiInterface::initialize(
                 std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
     }
 
+    m_responseTimeoutMs = m_communicationChannel->getResponseTimeout();
+
     m_db = std::make_shared<swss::DBConnector>(m_contextConfig->m_dbAsic, 0);
 
     m_redisVidIndexGenerator = std::make_shared<RedisVidIndexGenerator>(m_db, REDIS_KEY_VIDCOUNTER);
@@ -355,6 +357,16 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
             return SAI_STATUS_SUCCESS;
 
+        case SAI_REDIS_SWITCH_ATTR_GET_RESPONSE_TIMEOUT_MS:
+
+            m_responseTimeoutMs = attr->value.u64;
+
+            m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
+
+            SWSS_LOG_NOTICE("set response timeout to %lu ms", m_responseTimeoutMs);
+
+            return SAI_STATUS_SUCCESS;
+
         case SAI_REDIS_SWITCH_ATTR_SYNC_MODE:
 
             SWSS_LOG_WARN("sync mode is depreacated, use communication mode");
@@ -402,6 +414,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                             m_contextConfig->m_dbAsic,
                             std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
 
+                    m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
+
                     m_communicationChannel->setBuffered(true);
 
                     return SAI_STATUS_SUCCESS;
@@ -415,6 +429,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                     m_communicationChannel = std::make_shared<RedisChannel>(
                             m_contextConfig->m_dbAsic,
                             std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+
+                    m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
 
                     m_communicationChannel->setBuffered(false);
 
@@ -431,6 +447,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                             m_contextConfig->m_zmqEndpoint,
                             m_contextConfig->m_zmqNtfEndpoint,
                             std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+
+                    m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
 
                     SWSS_LOG_NOTICE("zmq enabled, forcing sync mode");
 

--- a/lib/src/ZeroMQChannel.cpp
+++ b/lib/src/ZeroMQChannel.cpp
@@ -268,7 +268,7 @@ sai_status_t ZeroMQChannel::wait(
     items[0].socket = m_socket;
     items[0].events = ZMQ_POLLIN;
 
-    int rc = zmq_poll(items, 1, m_responseTimeoutMs);
+    int rc = zmq_poll(items, 1, (int)m_responseTimeoutMs);
 
     if (rc == 0)
     {

--- a/lib/src/ZeroMQChannel.cpp
+++ b/lib/src/ZeroMQChannel.cpp
@@ -12,11 +12,6 @@
 
 using namespace sairedis;
 
-/**
- * @brief Get response timeout in milliseconds.
- */
-#define ZMQ_GETRESPONSE_TIMEOUT_MS (60*1000)
-
 #define ZMQ_RESPONSE_BUFFER_SIZE (4*1024*1024)
 
 ZeroMQChannel::ZeroMQChannel(
@@ -273,7 +268,7 @@ sai_status_t ZeroMQChannel::wait(
     items[0].socket = m_socket;
     items[0].events = ZMQ_POLLIN;
 
-    int rc = zmq_poll(items, 1, ZMQ_GETRESPONSE_TIMEOUT_MS);
+    int rc = zmq_poll(items, 1, m_responseTimeoutMs);
 
     if (rc == 0)
     {


### PR DESCRIPTION
Knob needed by mlnx when doing firmware update on some platforms, which can exceed default 1 min timeout.
Need to be set by orchagent.