### PR TITLE
[syncd armhf] Fix syncd crash when running community test suites

### DIFF
--- a/lib/src/PerformanceIntervalTimer.cpp
+++ b/lib/src/PerformanceIntervalTimer.cpp
@@ -1,6 +1,7 @@
 #include "PerformanceIntervalTimer.h"
 
 #include "swss/logger.h"
+#include <inttypes.h>
 
 using namespace sairediscommon;
 
@@ -46,7 +47,7 @@ void PerformanceIntervalTimer::inc(
     {
         if (m_enable)
         {
-            SWSS_LOG_NOTICE("%zu (calls %zu) %s op took: %zu ms", m_count, m_calls, m_msg.c_str(), m_total/1000000);
+            SWSS_LOG_NOTICE("%" PRIu64 " (calls %" PRIu64 ") %s op took: %" PRIu64 " ms", m_count, m_calls, m_msg.c_str(), m_total/1000000);
         }
 
         reset();

--- a/lib/src/VirtualObjectIdManager.cpp
+++ b/lib/src/VirtualObjectIdManager.cpp
@@ -2,6 +2,7 @@
 
 #include "meta/sai_serialize.h"
 #include "swss/logger.h"
+#include <inttypes.h>
 
 extern "C" {
 #include "saimetadata.h"
@@ -242,7 +243,7 @@ sai_object_id_t VirtualObjectIdManager::allocateNewObjectId(
 
     if (objectIndex > SAI_REDIS_OBJECT_INDEX_MAX)
     {
-        SWSS_LOG_THROW("no more object indexes available, given: 0x%lx but limit is 0x%llx",
+        SWSS_LOG_THROW("no more object indexes available, given: 0x%" PRIu64 " but limit is 0x%" PRIu64 " ",
                 objectIndex,
                 SAI_REDIS_OBJECT_INDEX_MAX);
     }


### PR DESCRIPTION
This commit fixes a syncd crash seen when running the sonic-mgmt comunity test
suites against the Marvell armhf platform. Analysis of the generated core file
points to improper format specifiers used when writing SWSS log entries. This
commit fixes that.