### PR TITLE
Remove unregisterMessageHandler from NetMsgRegistrar thread

### DIFF
--- a/vslib/src/NetMsgRegistrar.cpp
+++ b/vslib/src/NetMsgRegistrar.cpp
@@ -134,9 +134,6 @@ void NetMsgRegistrar::run()
         }
     }
 
-    swss::NetDispatcher::getInstance().unregisterMessageHandler(RTM_NEWLINK);
-    swss::NetDispatcher::getInstance().unregisterMessageHandler(RTM_DELLINK);
-
     SWSS_LOG_NOTICE("netlink msg listener ended");
 }
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/sonic-buildimage/issues/6466

This is a temporary fix to avoid double-free memory corruption (and core) that is consistently seen in syncd shutdown in KVM switch.
The call made to unregisterMessageHandler as part of NetMsgRegistrar thread causes, double-free memory corruption in one of the executing threads.