### PR TITLE
[build-vm] Don't Install Lib Boost 1.67

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,8 +35,7 @@ jobs:
         libnl-cli-3-dev \
         swig3.0 \
         libpython2.7-dev \
-        libzmq5 libzmq3-dev \
-        libboost1.71-dev
+        libzmq5 libzmq3-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
@@ -126,8 +125,7 @@ jobs:
         libnl-cli-3-dev \
         swig3.0 \
         libpython2.7-dev \
-        libzmq5 libzmq3-dev \
-        libboost1.71-dev
+        libzmq5 libzmq3-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
@@ -214,8 +212,7 @@ jobs:
         libnl-cli-3-dev \
         swig3.0 \
         libpython2.7-dev \
-        libzmq5 libzmq3-dev \
-        libboost1.71-dev
+        libzmq5 libzmq3-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
         swig3.0 \
         libpython2.7-dev \
         libzmq5 libzmq3-dev \
-        libboost-all-dev
+        libboost1.71-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
@@ -127,7 +127,7 @@ jobs:
         swig3.0 \
         libpython2.7-dev \
         libzmq5 libzmq3-dev \
-        libboost-all-dev
+        libboost1.71-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
@@ -215,7 +215,7 @@ jobs:
         swig3.0 \
         libpython2.7-dev \
         libzmq5 libzmq3-dev \
-        libboost-all-dev
+        libboost1.71-dev
 
       sudo apt-get install -y redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf


### PR DESCRIPTION
Libboost 1.71 is already installed in slave buster. Do not install v1.67 on top of it.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>