### PR TITLE
[ci]: use publish pipeline artifacts to publish syslog

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,12 +91,10 @@ jobs:
     inputs:
         contents: 'syslog-all.tgz'
         targetFolder: $(Build.ArtifactStagingDirectory)
-  - task: PublishBuildArtifacts@1
+  - publish: $(Build.ArtifactStagingDirectory)/
+    artifact: sonic-sairedis.syslog.amd64
     displayName: "Publish syslog artifacts"
     condition: always()
-    inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: sonic-sairedis.syslog.amd64
 
 - job:
   timeoutInMinutes: 180
@@ -178,12 +176,10 @@ jobs:
     inputs:
         contents: 'syslog-all.tgz'
         targetFolder: $(Build.ArtifactStagingDirectory)
-  - task: PublishBuildArtifacts@1
+  - publish: $(Build.ArtifactStagingDirectory)/
+    artifact: sonic-sairedis.syslog.arm64
     displayName: "Publish syslog artifacts"
     condition: always()
-    inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: sonic-sairedis.syslog.arm64
 
 - job:
   timeoutInMinutes: 180
@@ -265,9 +261,7 @@ jobs:
     inputs:
         contents: 'syslog-all.tgz'
         targetFolder: $(Build.ArtifactStagingDirectory)
-  - task: PublishBuildArtifacts@1
+  - publish: $(Build.ArtifactStagingDirectory)/
+    artifact: sonic-sairedis.syslog.armhf
     displayName: "Publish syslog artifacts"
     condition: always()
-    inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: sonic-sairedis.syslog.armhf


### PR DESCRIPTION
avoid to use publish build artifacts and pipeline artifacts
at the same time.

Signed-off-by: Guohan Lu <lguohan@gmail.com>