### PR TITLE
syncd: Fix profile iterator bug

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -95,9 +95,9 @@ Syncd::Syncd(
 
     m_manager = std::make_shared<FlexCounterManager>(m_vendorSai, m_contextConfig->m_dbCounters);
 
-    m_profileIter = m_profileMap.begin();
-
     loadProfileMap();
+
+    m_profileIter = m_profileMap.begin();
 
     // we need STATE_DB ASIC_DB and COUNTERS_DB
 


### PR DESCRIPTION
As I didn't see SAI specifying that the user of the service table should reset the iterator before iterating over the values, I think this would come as a surprise to most vendors implementing SAI. Because the iterator was first stored before adding any values to the map, it would be pointing to the profile's .end(), thus if a SAI implementation would try iterating over the values,  it'd get none until it'd reset the iterator.