### PR TITLE
[debian/control] libsairedis-dev depends on libzmq5-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic
 Maintainer: Kamil Cudnik <kcudnik@microsoft.com>
 Section: net
 Priority: optional
-Build-Depends: debhelper (>=9), autotools-dev
+Build-Depends: debhelper (>=9), autotools-dev, libzmq5-dev
 Standards-Version: 1.0.0
 
 Package: syncd
@@ -26,12 +26,13 @@ Description: This package contains sync daemon for SONiC project linked with vir
 
 Package: libsairedis
 Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Pre-Depends}
 Section: libs
 Description: This package contains SAI-Redis implementation for SONiC project.
 
 Package: libsairedis-dev
 Architecture: any
-Depends: libsairedis (= ${binary:Version})
+Depends: libsairedis (= ${binary:Version}), libzmq5-dev
 Section: libdevel
 Description: This package contains development files for SAI-Redis.
 


### PR DESCRIPTION
libsairedis-dev is not usable without libzmq5-dev package, meaning I cannot link my binary without a symlink to .so file provided by dev package. Make it implicitly install by apt-get install -f

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>