### PR TITLE
[vs] Add special warm boot logic to populate default attributes

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -241,6 +241,8 @@ void ComparisonLogic::checkInternalObjects(
 {
     SWSS_LOG_ENTER();
 
+    SWSS_LOG_NOTICE("check internal objects");
+
     std::vector<sai_object_type_t> ots =
     {
         SAI_OBJECT_TYPE_QUEUE,
@@ -2220,6 +2222,8 @@ void ComparisonLogic::populateExistingObjects(
         _In_ AsicView &temporaryView)
 {
     SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("populate existing objects");
 
     auto rids = m_switch->getDiscoveredRids();
 

--- a/syncd/SaiSwitchInterface.cpp
+++ b/syncd/SaiSwitchInterface.cpp
@@ -47,3 +47,11 @@ sai_object_id_t SaiSwitchInterface::getSwitchDefaultAttrOid(
 
     return it->second;
 }
+
+std::set<sai_object_id_t> SaiSwitchInterface::getWarmBootNewDiscoveredVids()
+{
+    SWSS_LOG_ENTER();
+
+    return m_warmBootNewDiscoveredVids;
+}
+

--- a/syncd/SaiSwitchInterface.h
+++ b/syncd/SaiSwitchInterface.h
@@ -85,6 +85,8 @@ namespace syncd
 
             virtual std::set<sai_object_id_t> getWarmBootDiscoveredVids() const = 0;
 
+            virtual std::set<sai_object_id_t> getWarmBootNewDiscoveredVids();
+
             virtual void onPostPortCreate(
                     _In_ sai_object_id_t port_rid,
                     _In_ sai_object_id_t port_vid) = 0;
@@ -119,5 +121,7 @@ namespace syncd
             std::set<sai_object_id_t> m_coldBootDiscoveredVids;
 
             std::set<sai_object_id_t> m_warmBootDiscoveredVids;
+
+            std::set<sai_object_id_t> m_warmBootNewDiscoveredVids;
     };
 }

--- a/vslib/inc/SwitchBCM56850.h
+++ b/vslib/inc/SwitchBCM56850.h
@@ -44,5 +44,7 @@ namespace saivs
             virtual sai_status_t refresh_bridge_port_list(
                     _In_ const sai_attr_metadata_t *meta,
                     _In_ sai_object_id_t bridge_id) override;
+
+            virtual sai_status_t warm_update_queues() override;
     };
 }

--- a/vslib/inc/SwitchMLNX2700.h
+++ b/vslib/inc/SwitchMLNX2700.h
@@ -41,6 +41,8 @@ namespace saivs
             virtual sai_status_t refresh_bridge_port_list(
                     _In_ const sai_attr_metadata_t *meta,
                     _In_ sai_object_id_t bridge_id) override;
+
+            virtual sai_status_t warm_update_queues() override;
     };
 }
 

--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -17,6 +17,8 @@
 
 #define DEFAULT_VLAN_NUMBER 1
 
+#define MAX_OBJLIST_LEN 128
+
 #define CHECK_STATUS(status) {                                  \
     sai_status_t _status = (status);                            \
     if (_status != SAI_STATUS_SUCCESS) { return _status; } }
@@ -48,6 +50,8 @@ namespace saivs
         protected:
 
             virtual sai_status_t set_switch_mac_address();
+
+            virtual sai_status_t set_switch_supported_object_types();
 
             virtual sai_status_t set_switch_default_attributes();
 
@@ -152,6 +156,18 @@ namespace saivs
             virtual sai_status_t refresh_read_only(
                     _In_ const sai_attr_metadata_t *meta,
                     _In_ sai_object_id_t object_id);
+
+        protected:
+
+            virtual sai_status_t warm_update_queues();
+
+            virtual sai_status_t warm_update_scheduler_groups();
+
+            virtual sai_status_t warm_update_ingress_priority_groups();
+
+            virtual sai_status_t warm_update_switch();
+
+            virtual sai_status_t warm_update_cpu_queues();
 
         protected: // TODO should be pure
 

--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -1334,6 +1334,11 @@ bool VirtualSwitchSaiInterface::writeWarmBootFile(
             return false;
         }
 
+        if (m_warmBootData.size() == 0)
+        {
+            SWSS_LOG_WARN("warm boot data is empty, is that what you want?");
+        }
+
         for (auto& kvp: m_warmBootData)
         {
             ofs << kvp.second;


### PR DESCRIPTION
When doing warm boot from older SAI (201811) to master some attributes
maybe not implemented in previous version, but they are expected to be
present on new version. Special logic is required to populate those
default attributes after warm boot.