### PR TITLE
Update FlexCounter.cpp, use m_pollInterval in MUTEX lock

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1694,7 +1694,7 @@ void FlexCounter::flexCounterThreadRunFunction()
                     std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count());
 
             uint32_t correction = delay % m_pollInterval;
-            correction = m_pollInterval - correction；
+            correction = m_pollInterval - correction;
             MUTEX_UNLOCK; // explicit unlock
 
             SWSS_LOG_DEBUG("End of flex counter thread FC %s, took %d ms", m_instanceId.c_str(), delay);

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1694,14 +1694,14 @@ void FlexCounter::flexCounterThreadRunFunction()
                     std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count());
 
             uint32_t correction = delay % m_pollInterval;
-
+            correction = m_pollInterval - correction；
             MUTEX_UNLOCK; // explicit unlock
 
             SWSS_LOG_DEBUG("End of flex counter thread FC %s, took %d ms", m_instanceId.c_str(), delay);
 
             std::unique_lock<std::mutex> lk(m_mtxSleep);
 
-            m_cvSleep.wait_for(lk, std::chrono::milliseconds(m_pollInterval - correction));
+            m_cvSleep.wait_for(lk, std::chrono::milliseconds(correction));
 
             continue;
         }


### PR DESCRIPTION
m_pollInterval is used out of the MUTEX lock，when set to a smaller value, it may result of wait for a very long time.