### PR TITLE
[configure] Add -Wno-psabi to remove "passing argument changed" logs note on arm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,7 @@ CFLAGS_COMMON+=" -Wvariadic-macros"
 CFLAGS_COMMON+=" -Wwrite-strings"
 CFLAGS_COMMON+=" -Wno-switch-default"
 CFLAGS_COMMON+=" -Wconversion"
+CFLAGS_COMMON+=" -Wno-psabi"
 
 SAVED_FLAGS="$CXXFLAGS"
 CXXFLAGS="-Wcast-align=strict"


### PR DESCRIPTION
When arm platform is compiled, because of ABI warning we get a ton of logs notes:
```
note: parameter passing for argument of type XXX changed in GCC 7.1
```

which pollutes log to a level when it's hard to spot actual error

Signed-off-by: kcudnik <kcudnik@gmail.com>