### PR TITLE
Check if libsaibcm is installed and install it dynamically on syncd docker start

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -87,6 +87,26 @@ function set_start_type()
 
 config_syncd_bcm()
 {
+    # Check if the libsaibcm package is installed.
+    if [ $(dpkg-query -W -f='${Status}' libsaibcm 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
+        if [ -d /usr/local/debs ]; then
+            env_file="/usr/share/sonic/platform/platform_env.conf"
+            [ -f $env_file ] && . $env_file
+
+            if [ $asic_type == bcm_dnx ]; then
+                gpl_dpkg="/usr/local/debs/libsaibcm-dnx_*.deb"
+            else
+                gpl_dpkg="/usr/local/debs/libsaibcm_*.deb"
+            fi
+
+            # Install the ASIC specific saibcm package.
+            dpkg -i $gpl_dpkg
+
+            # Delete the debian packages after installation.
+            rm -rf /usr/local/debs
+        fi
+    fi
+
     if [ -f "/etc/sai.d/sai.profile" ]; then
         CMD_ARGS+=" -p /etc/sai.d/sai.profile"
     else


### PR DESCRIPTION
This change is to support the support for DNX libsaibcm modules to be auto installed in docker based on the platform type. 
It checks first to see if libsaibcm package is installed and proceeds if not installed.
Ref PR : https://github.com/Azure/sonic-buildimage/pull/6882

With the approach in this PR, there will be an additional ~4 secs which syncd docker takes to install the saibcm DEB package. Since swss/syncd/teamd docker startup happens in parallel, this should not have a bigger impact ( not adding up the time it takes for control plane to be up ) in case of warm boot.  
