### PR TITLE
[gbsyncd] Fix shebang in gbsyncd_startup.py; Make script executable

### DIFF
--- a/syncd/scripts/gbsyncd_startup.py
+++ b/syncd/scripts/gbsyncd_startup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 '''
 Copyright 2019 Broadcom. The term "Broadcom" refers to Broadcom Inc.


### PR DESCRIPTION
According to the Python community, `#!/usr/bin/python` is not a portable shebang and is discouraged in favor of `#!/usr/bin/env python[x]`.

The former shebang worked with Python 2, but with the recent migration to Python 3, the Python 3 package installed in SONiC does not install an executable or symlink at `/usr/bin/python`, thus generating the following error:

```
Mar 17 07:32:19.743425 vlab-01 INFO gbsyncd#/supervisord: syncd /usr/bin/gbsyncd_start.sh: /usr/bin/gbsyncd_startup.py: /usr/bin/python: bad interpreter: No such file or directory
```

This patch updates the shebang to `#!/usr/bin/env python3` and also makes the script executable, however that did not pose an issue because the script appears to get executable permissions when it is installed, but it can't hurt.