### PR TITLE
Remove gbsyncd_start.sh

### DIFF
--- a/syncd/scripts/gbsyncd_start.sh
+++ b/syncd/scripts/gbsyncd_start.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-#
-# Script to start syncd using supervisord
-#
-
-exec "/usr/bin/gbsyncd_startup.py"
-


### PR DESCRIPTION
`gbsyncd_start.sh` was a simple wrapper which only called `exec "/usr/bin/gbsyncd_startup.py"`. This causes unnecessary extra complexity and maintenance. It makes things simpler to run `/usr/bin/gbsyncd_startup.py` directly, which is being done by https://github.com/Azure/sonic-buildimage/pull/7084. That PR has merged, so we can now merge this.