### PR TITLE
[sairedis] Add sai_dbg_generate_dump api to redis interface

### DIFF
--- a/lib/src/sai_redis_interfacequery.cpp
+++ b/lib/src/sai_redis_interfacequery.cpp
@@ -167,3 +167,11 @@ sai_object_id_t sai_switch_id_query(
 
     return redis_sai->switchIdQuery(objectId);
 }
+
+sai_status_t sai_dbg_generate_dump(
+        _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
All apis needs to be implemented when using pyext module.