### PR TITLE
[sairedis] Unlock api mutex for communication mode

### DIFF
--- a/lib/inc/SaiInternal.h
+++ b/lib/inc/SaiInternal.h
@@ -1,3 +1,4 @@
 #pragma once
 
 #define MUTEX() std::lock_guard<std::recursive_mutex> _lock(m_apimutex)
+#define MUTEX_UNLOCK() m_apimutex.unlock()

--- a/lib/src/Sai.cpp
+++ b/lib/src/Sai.cpp
@@ -196,6 +196,25 @@ sai_status_t Sai::set(
 
     if (RedisRemoteSaiInterface::isRedisAttribute(objectType, attr))
     {
+        if (attr->id == SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE)
+        {
+            // Since communication mode destroys current channel and creates
+            // new one, it may happen, that during this SET api execution when
+            // api mutex is acquired, channel destructor will be blocking on
+            // thread->join() and channel thread will start processing
+            // incoming notification. That notification will be synchronized
+            // with api mutex and will cause deadlock, so to mitigate this
+            // scenario we will unlock api mutex here.
+            //
+            // This is not the perfect, but assuming that communication mode is
+            // changed in single thread and before switch create then we should
+            // not hit race condition.
+
+            SWSS_LOG_NOTICE("unlocking api mutex for communication mode");
+
+            MUTEX_UNLOCK();
+        }
+
         // skip metadata if attribute is redis extension attribute
 
         // TODO this is setting on all contexts, but maybe we want one specific?


### PR DESCRIPTION
This will remove possible deadlock when notification arrives during communication channel destructor thread join.

Could result in deadlock when destructing RedisChannel and logs: ~RedisChannel: join ntf thread begin