### PR TITLE
[vslib] Refresh queue pause status

### DIFF
--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -145,6 +145,9 @@ namespace saivs
             virtual sai_status_t refresh_macsec_sci_in_ingress_macsec_acl(
                     _In_ sai_object_id_t object_id);
 
+            virtual sai_status_t refresh_queue_pause_status(
+                    _In_ sai_object_id_t object_id);
+
         public:
 
             virtual sai_status_t warm_boot_initialize_objects();

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -2000,6 +2000,11 @@ sai_status_t SwitchStateBase::refresh_read_only(
         return refresh_macsec_sci_in_ingress_macsec_acl(object_id);
     }
 
+    if (meta->objecttype == SAI_OBJECT_TYPE_QUEUE && meta->attrid == SAI_QUEUE_ATTR_PAUSE_STATUS)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     auto mmeta = m_meta.lock();
 
     if (mmeta)

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1851,6 +1851,20 @@ sai_status_t SwitchStateBase::refresh_macsec_sci_in_ingress_macsec_acl(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::refresh_queue_pause_status(
+        _In_ sai_object_id_t object_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_QUEUE_ATTR_PAUSE_STATUS;
+    attr.value.booldata = false;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_QUEUE, object_id, &attr));
+
+    return SAI_STATUS_SUCCESS;
+}
+
 // XXX extra work may be needed on GET api if N on list will be > then actual
 
 /*
@@ -2002,7 +2016,7 @@ sai_status_t SwitchStateBase::refresh_read_only(
 
     if (meta->objecttype == SAI_OBJECT_TYPE_QUEUE && meta->attrid == SAI_QUEUE_ATTR_PAUSE_STATUS)
     {
-        return SAI_STATUS_SUCCESS;
+        return refresh_queue_pause_status(object_id);
     }
 
     auto mmeta = m_meta.lock();

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1856,6 +1856,10 @@ sai_status_t SwitchStateBase::refresh_queue_pause_status(
 {
     SWSS_LOG_ENTER();
 
+    // To trigger fake PFC storm on fake Broadcom platform, PFC storm detection
+    // lua requires SAI_QUEUE_ATTR_PAUSE_STATUS field to be present in COUNTERS_DB.
+    // However, the actual value of the attribute does not matter in this regard,
+    // so a dummy one is assigned here.
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_PAUSE_STATUS;
     attr.value.booldata = false;


### PR DESCRIPTION
Fix the following error message, when setting PFC WD config on port in swss vs test development.

```
114470 Mar 27 11:48:56.959426 97dc8d648d1a WARNING #syncd: :- refresh_read_only: need to recalculate RO: SAI_QUEUE_ATTR_PAUSE_STATUS
114471 Mar 27 11:48:56.959444 97dc8d648d1a ERR #syncd: :- collectQueueAttrs: Failed to get attr of queue 0x15000000000168: -15
```

`SAI_QUEUE_ATTR_PAUSE_STATUS` is prevented from being set to `COUNTERS_DB` on fake broadcom platform. The absence of `SAI_QUEUE_ATTR_PAUSE_STATUS` will cause pfc detect lua to exist early, not being able to reach the point of faking PFC storm using `DEBUG_STORM` in vs test.

Needed by https://github.com/Azure/sonic-swss/pull/1612

```
2021-03-30T05:35:44.3797880Z =================================== FAILURES ===================================
2021-03-30T05:35:44.3802646Z __________________ TestPfcWd.test_pfc_en_bits_user_wd_cfg_sep __________________
2021-03-30T05:35:44.3804301Z 
2021-03-30T05:35:44.3804788Z self = <test_pfcwd.TestPfcWd object at 0x7f33cabcbbb0>
2021-03-30T05:35:44.3805537Z dvs = <conftest.DockerVirtualSwitch object at 0x7f33cada7f40>
2021-03-30T05:35:44.3806723Z testlog = <function testlog at 0x7f33cb478ca0>
2021-03-30T05:35:44.3807834Z 
2021-03-30T05:35:44.3808390Z     def test_pfc_en_bits_user_wd_cfg_sep(self, dvs, testlog):
2021-03-30T05:35:44.3810245Z         self.connect_dbs(dvs)
2021-03-30T05:35:44.3810736Z     
2021-03-30T05:35:44.3812004Z         # Enable pfc wd flex counter polling
2021-03-30T05:35:44.3812604Z         self.enable_flex_counter(CFG_FLEX_COUNTER_TABLE_PFCWD_KEY)
2021-03-30T05:35:44.3813716Z         # Verify pfc wd flex counter status published to FLEX_COUNTER_DB FLEX_COUNTER_GROUP_TABLE by flex counter orch
2021-03-30T05:35:44.3815221Z         fv_dict = {
2021-03-30T05:35:44.3816357Z             FLEX_COUNTER_STATUS: ENABLE,
2021-03-30T05:35:44.3817961Z         }
2021-03-30T05:35:44.3819057Z         self.check_db_fvs(self.flex_cntr_db, FC_FLEX_COUNTER_GROUP_TABLE_NAME, FC_FLEX_COUNTER_GROUP_TABLE_PFC_WD_KEY, fv_dict)
2021-03-30T05:35:44.3820369Z     
2021-03-30T05:35:44.3821459Z         # Enable pfc on tc 3
2021-03-30T05:35:44.3821991Z         pfc_tcs = [QUEUE_3]
2021-03-30T05:35:44.3822583Z         self.set_port_pfc(PORT_UNDER_TEST, pfc_tcs)
2021-03-30T05:35:44.3823427Z     
2021-03-30T05:35:44.3824268Z         # Verify pfc enable bits in ASIC_DB
2021-03-30T05:35:44.3827009Z         port_oid = dvs.asicdb.portnamemap[PORT_UNDER_TEST]
2021-03-30T05:35:44.3827563Z         fv_dict = {
2021-03-30T05:35:44.3828433Z             "SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL": "8",
2021-03-30T05:35:44.3828979Z         }
2021-03-30T05:35:44.3832409Z         self.check_db_fvs(self.asic_db, ASIC_PORT_TABLE_NAME, port_oid, fv_dict)
2021-03-30T05:35:44.3832967Z     
2021-03-30T05:35:44.3833418Z         # Start pfc wd (config) on port
2021-03-30T05:35:44.3833921Z         self.start_port_pfcwd(PORT_UNDER_TEST)
2021-03-30T05:35:44.3834568Z         # Verify port level counter to poll published to FLEX_COUNTER_DB FLEX_COUNTER_TABLE by pfc wd orch
2021-03-30T05:35:44.3835131Z         self.check_db_key_existence(self.flex_cntr_db, FC_FLEX_COUNTER_TABLE_NAME,
2021-03-30T05:35:44.3835717Z                                     "{}:{}".format(FC_FLEX_COUNTER_TABLE_PFC_WD_KEY_PREFIX, port_oid))
2021-03-30T05:35:44.3836556Z         # Verify queue level counter to poll published to FLEX_COUNTER_DB FLEX_COUNTER_TABLE by pfc wd orch
2021-03-30T05:35:44.3837038Z         queue_oid = self.get_queue_oid(dvs, PORT_UNDER_TEST, QUEUE_3)
2021-03-30T05:35:44.3837481Z         self.check_db_key_existence(self.flex_cntr_db, FC_FLEX_COUNTER_TABLE_NAME,
2021-03-30T05:35:44.3837985Z                                     "{}:{}".format(FC_FLEX_COUNTER_TABLE_PFC_WD_KEY_PREFIX, queue_oid))
2021-03-30T05:35:44.3838385Z     
2021-03-30T05:35:44.3838739Z         # Verify pfc enable bits stay unchanged in ASIC_DB
2021-03-30T05:35:44.3839591Z         time.sleep(2)
2021-03-30T05:35:44.3839959Z         fv_dict = {
2021-03-30T05:35:44.3840297Z             "SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL": "8",
2021-03-30T05:35:44.3840631Z         }
2021-03-30T05:35:44.3840958Z         self.check_db_fvs(self.asic_db, ASIC_PORT_TABLE_NAME, port_oid, fv_dict)
2021-03-30T05:35:44.3841285Z     
2021-03-30T05:35:44.3841554Z         # Start pfc storm on queue 3
2021-03-30T05:35:44.3841886Z         self.start_queue_pfc_storm(queue_oid)
2021-03-30T05:35:44.3842211Z         # Verify queue in storm from COUNTERS_DB
2021-03-30T05:35:44.3842522Z         fv_dict = {
2021-03-30T05:35:44.3842813Z             PFC_WD_STATUS: STORMED,
2021-03-30T05:35:44.3843106Z         }
2021-03-30T05:35:44.3843434Z >       self.check_db_fvs(self.cntrs_db, CNTR_COUNTERS_TABLE_NAME, queue_oid, fv_dict)
2021-03-30T05:35:44.3843768Z 
2021-03-30T05:35:44.3844022Z test_pfcwd.py:245: 
2021-03-30T05:35:44.3844377Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2021-03-30T05:35:44.3844735Z test_pfcwd.py:175: in check_db_fvs
2021-03-30T05:35:44.3845073Z     db.wait_for_field_match(table_name, key, fv_dict)
2021-03-30T05:35:44.3845445Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2021-03-30T05:35:44.3845679Z 
2021-03-30T05:35:44.3845984Z self = <dvslib.dvs_database.DVSDatabase object at 0x7f33ca8b8610>
2021-03-30T05:35:44.3846872Z table_name = 'COUNTERS', key = 'oid:0x15000000000168'
2021-03-30T05:35:44.3847402Z expected_fields = {'PFC_WD_STATUS': 'stormed'}
2021-03-30T05:35:44.3847789Z polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True)
2021-03-30T05:35:44.3848137Z failure_message = None
2021-03-30T05:35:44.3848311Z 
2021-03-30T05:35:44.3848576Z     def wait_for_field_match(
2021-03-30T05:35:44.3848846Z         self,
2021-03-30T05:35:44.3849329Z         table_name: str,
2021-03-30T05:35:44.3849656Z         key: str,
2021-03-30T05:35:44.3852684Z         expected_fields: Dict[str, str],
2021-03-30T05:35:44.3853253Z         polling_config: PollingConfig = PollingConfig(),
2021-03-30T05:35:44.3853664Z         failure_message: str = None,
2021-03-30T05:35:44.3854274Z     ) -> Dict[str, str]:
2021-03-30T05:35:44.3854732Z         """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
2021-03-30T05:35:44.3855120Z     
2021-03-30T05:35:44.3855524Z         This method is useful if you only care about the contents of a subset of the fields stored
2021-03-30T05:35:44.3855957Z         in the specified entry.
2021-03-30T05:35:44.3856272Z     
2021-03-30T05:35:44.3856558Z         Args:
2021-03-30T05:35:44.3856941Z             table_name: The name of the table where the entry is stored.
2021-03-30T05:35:44.3857403Z             key: The key that maps to the entry being checked.
2021-03-30T05:35:44.3857882Z             expected_fields: The fields and their values we expect to see in the entry.
2021-03-30T05:35:44.3858358Z             polling_config: The parameters to use to poll the db.
2021-03-30T05:35:44.3858868Z             failure_message: The message to print if the call times out. This will only take effect
2021-03-30T05:35:44.3859333Z                 if the PollingConfig is set to strict.
2021-03-30T05:35:44.3859679Z     
2021-03-30T05:35:44.3859970Z         Returns:
2021-03-30T05:35:44.3860388Z             The entry stored at `key`. If no entry is found, then an empty Dict is returned.
2021-03-30T05:35:44.3860944Z         """
2021-03-30T05:35:44.3861195Z     
2021-03-30T05:35:44.3861467Z         def access_function():
2021-03-30T05:35:44.3861804Z             fv_pairs = self.get_entry(table_name, key)
2021-03-30T05:35:44.3862106Z             return (
2021-03-30T05:35:44.3862449Z                 all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
2021-03-30T05:35:44.3862784Z                 fv_pairs,
2021-03-30T05:35:44.3863058Z             )
2021-03-30T05:35:44.3863298Z     
2021-03-30T05:35:44.3863583Z         status, result = wait_for_result(
2021-03-30T05:35:44.3863950Z             access_function, self._disable_strict_polling(polling_config)
2021-03-30T05:35:44.3864276Z         )
2021-03-30T05:35:44.3864536Z     
2021-03-30T05:35:44.3864797Z         if not status:
2021-03-30T05:35:44.3865097Z             message = failure_message or (
2021-03-30T05:35:44.3865498Z                 f"Expected field/value pairs not found: expected={expected_fields}, "
2021-03-30T05:35:44.3866146Z                 f'received={result}, key="{key}", table="{table_name}"'
2021-03-30T05:35:44.3866483Z             )
2021-03-30T05:35:44.3866793Z >           assert not polling_config.strict, message
2021-03-30T05:35:44.3869167Z E           AssertionError: Expected field/value pairs not found: expected={'PFC_WD_STATUS': 'stormed'}, received={'PFC_WD_DETECTION_TIME': '400000', 'PFC_WD_RESTORATION_TIME': '400000', 'PFC_WD_ACTION': 'drop', 'PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED': '0', 'PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED': '0', 'PFC_WD_STATUS': 'operational', 'SAI_QUEUE_STAT_PACKETS': '0', 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES': '0', 'DEBUG_STORM': 'enabled', 'SAI_QUEUE_STAT_DROPPED_PACKETS': '0', 'SAI_QUEUE_STAT_DROPPED_BYTES': '0', 'SAI_QUEUE_STAT_BYTES': '0'}, key="oid:0x15000000000168", table="COUNTERS"
```