### PR TITLE
[pyext] Update Makefile to disable warning Wconversion for older swig

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,17 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
     [AC_MSG_RESULT([no])])
 CXXFLAGS="$SAVED_FLAGS"
 
+AC_SUBST(NO_CAST_FUNCTION_TYPE)
+
+SAVED_FLAGS="$CXXFLAGS"
+CXXFLAGS="-Wno-cast-function-type"
+AC_MSG_CHECKING([whether CXX supports -Wno-cast-function-type])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+    [AC_MSG_RESULT([yes])]
+    [AC_SUBST([NO_CAST_FUNCTION_TYPE], ["-Wno-cast-function-type"])],
+    [AC_MSG_RESULT([no])])
+CXXFLAGS="$SAVED_FLAGS"
+
 AC_SUBST(CFLAGS_COMMON)
 
 AC_OUTPUT(Makefile

--- a/pyext/py2/Makefile.am
+++ b/pyext/py2/Makefile.am
@@ -8,7 +8,8 @@ INCLUDE=-I../../SAI/inc -I../../SAI/meta -I../../SAI/experimental -I../../lib/in
 
 _pysairedis_la_SOURCES = pysairedis_wrap.cpp $(SOURCES)
 _pysairedis_la_CPPFLAGS = $(INCLUDE) -I/usr/include/python$(PYTHON_VERSION) $(AM_CPPFLAGS) $(CFLAGS_COMMON) \
-						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-cast-function-type
+						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion
+
 _pysairedis_la_LDFLAGS = -module \
 		-lhiredis -lswsscommon -lpthread \
 		-L$(top_srcdir)/lib/src/.libs -lsairedis \

--- a/pyext/py2/Makefile.am
+++ b/pyext/py2/Makefile.am
@@ -8,7 +8,7 @@ INCLUDE=-I../../SAI/inc -I../../SAI/meta -I../../SAI/experimental -I../../lib/in
 
 _pysairedis_la_SOURCES = pysairedis_wrap.cpp $(SOURCES)
 _pysairedis_la_CPPFLAGS = $(INCLUDE) -I/usr/include/python$(PYTHON_VERSION) $(AM_CPPFLAGS) $(CFLAGS_COMMON) \
-						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion
+						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion $(NO_CAST_FUNCTION_TYPE)
 
 _pysairedis_la_LDFLAGS = -module \
 		-lhiredis -lswsscommon -lpthread \

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -8,7 +8,8 @@ INCLUDE=-I../../SAI/inc -I../../SAI/meta -I../../SAI/experimental -I../../lib/in
 
 _pysairedis_la_SOURCES = pysairedis_wrap.cpp $(SOURCES)
 _pysairedis_la_CPPFLAGS = $(INCLUDE) -I/usr/include/python$(PYTHON3_VERSION) $(AM_CPPFLAGS) $(CFLAGS_COMMON) \
-						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-cast-function-type
+						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion
+
 _pysairedis_la_LDFLAGS = -module \
 		-lhiredis -lswsscommon -lpthread \
 		-L$(top_srcdir)/lib/src/.libs -lsairedis \

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -8,7 +8,7 @@ INCLUDE=-I../../SAI/inc -I../../SAI/meta -I../../SAI/experimental -I../../lib/in
 
 _pysairedis_la_SOURCES = pysairedis_wrap.cpp $(SOURCES)
 _pysairedis_la_CPPFLAGS = $(INCLUDE) -I/usr/include/python$(PYTHON3_VERSION) $(AM_CPPFLAGS) $(CFLAGS_COMMON) \
-						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion
+						  -Wno-cast-qual -Wno-shadow -Wno-redundant-decls -Wno-conversion $(NO_CAST_FUNCTION_TYPE)
 
 _pysairedis_la_LDFLAGS = -module \
 		-lhiredis -lswsscommon -lpthread \


### PR DESCRIPTION
Older swig version may generate some code that can warn on long to double conversion - currently observed on sonic-buildimage repo 