### PR TITLE
fix dvs test failure because of debian packages not installed correctly in base docker-vs image

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -4,6 +4,15 @@ ARG docker_container_name
 
 ADD ["debs", "/debs"]
 
+RUN dpkg --purge python-swsscommon
+RUN dpkg --purge python3-swsscommon
+RUN dpkg --purge swss
+RUN dpkg --purge libsairedis
+RUN dpkg --purge libswsscommon
+RUN dpkg --purge libsaimetadata
+RUN dpkg --purge libsaivs
+RUN dpkg --purge syncd-vs
+
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
What I did:
Looks like there is some issue with sonic-vs docker used in sonic-sai-redis repo for swss DVS test.
Swss debian package used in VS docker is not the same artifact generated by Azure pipeline
Compared md5sum of binaries of Azure artifact swss debian package and the one running in VS docker and they are not matching. And thus test fails.

Tried locally also:
Docker from Artifact ==> Test Fails
Docker from Artifact + Using swss debian from Artifact ==> Test passes.
Eg:
md5sum of sflowmgrd as part of docker-sonic-vs artifact 47e395fddbc5ab29c57477013e6dde70
md5sum of sflowmgrd as part of swss*.deb artifact beb6e096b2923716823754b3477133cb

Confirmed:-

- sflowmgrd as part of docker-sonic-vs is from the base sonic-docer-vs and dpkg -i swss*.deb did not updated all the processes.

- orchangent md5sum is same both in docker and swss*.deb artifact.

How I fixed:
 
Same fix as https://github.com/Azure/sonic-swss/pull/1654 where we do --purge of existing packages.
