### PR TITLE
CISCO: Support for cisco-8000 platform for sonic-sairedis/syncd

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -193,6 +193,12 @@ config_syncd_innovium()
     mkdir -p $II_ROOT
 }
 
+config_syncd_cisco_8000()
+{
+    export BASE_OUTPUT_DIR=/opt/cisco/silicon-one
+    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+}
+
 config_syncd()
 {
     check_warm_boot
@@ -215,6 +221,8 @@ config_syncd()
         config_syncd_vs
     elif [ "$SONIC_ASIC_TYPE" == "innovium" ]; then
         config_syncd_innovium
+    elif [ "$SONIC_ASIC_TYPE" == "cisco-8000" ]; then
+        config_syncd_cisco_8000
     else
         echo "Unknown ASIC type $SONIC_ASIC_TYPE"
         exit 1


### PR DESCRIPTION
This fix brings in support for cisco-8000 platform into sonic-sairedis/syncd. It checks for the SONIC_ASIC_TYPE keyword and picksup the PLATFORM type to see if "cisco-8000" word is available. Accordingly, it sources the required paths for SDK to carry on its operations. 