### PR TITLE
Disable syncd on binary-sairedis target during dh clean

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_ARG_ENABLE(syncd,
    no)  syncd=false ;;
    *) AC_MSG_ERROR(bad value ${enableval} for --enable-syncd) ;;
 esac],[syncd=true])
+AS_IF([test "x${ENABLESYNCD}" = "xno" ],[syncd=false],[])
 AM_CONDITIONAL(SYNCD, test x$syncd = xtrue)
 AM_COND_IF([SYNCD], [
         AM_COND_IF([SAIVS], [], [AC_CHECK_LIB([sai], [main], [AC_MSG_NOTICE(libsai found)], [AC_MSG_ERROR(libsai is required for syncd)])

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,7 @@ binary: binary-syncd-rpc binary-syncd
 
 binary-sairedis:
 	echo '--enable-syncd=no' > /tmp/syncd-build
-	dh clean  --with autotools-dev
+	ENABLESYNCD=no dh clean  --with autotools-dev
 	dh build  -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 	dh binary -N syncd -N syncd-dbg -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -8,9 +8,12 @@ install: all
 check:
 	true
 
-.PHONY: clean
+.PHONY: clean distclean
 
 clean:
 	rm -f *.o *~
 	rm -rf build
 
+distclean:
+	rm -f *.o *~
+	rm -rf build


### PR DESCRIPTION
When making build sairedis directory could be polluted by previous build
which was configured without '--enable-syncd=no', and that created
makefiles for previous build for example binary-syncd target, next when
dh clean is executed for target binary-sairedis, it's executing existing
configure with previous parameters by executing "./bin/bash
./config.status .recheck", this don't contain --enable-syncd=no, and
this requires libsai to be present for configuration, this will cause
configure to fail, but dh clean will ignore that error and continue next
commands. Because of this, make distclean was not executed, and
directory contains previous build artifacts like _pysairedis.la in pyext
directory, which was from stretch build, and points to different python
version 3.5 vs 3.7 on buster, and since _pysairedis.la exists, it's
content are used to pass that python library to link stage of python
build.

To workaround this, we can export shell variable to disable libsai
requirement, and distclean will succeed, but there still be left
artifacts in syncd directory and others conditioned in Makefile.am

Signed-off-by: kcudnik <kcudnik@gmail.com>