### PR TITLE
[VS] Add support for context and multiple switches

### DIFF
--- a/lib/src/ContextConfigContainer.cpp
+++ b/lib/src/ContextConfigContainer.cpp
@@ -132,9 +132,13 @@ std::shared_ptr<ContextConfigContainer> ContextConfigContainer::loadFromFile(
                 auto sc = std::make_shared<SwitchConfig>(switchIndex, hwinfo);
 
                 cc->insert(sc);
+
+                SWSS_LOG_NOTICE("insert into context '%s' config for hwinfo '%s'", cc->m_name.c_str(), hwinfo.c_str());
             }
 
             ccc->insert(cc);
+
+            SWSS_LOG_NOTICE("insert context '%s' into container list", cc->m_name.c_str());
         }
     }
     catch (const std::exception& e)
@@ -143,6 +147,8 @@ std::shared_ptr<ContextConfigContainer> ContextConfigContainer::loadFromFile(
 
         return getDefault();
     }
+
+    SWSS_LOG_NOTICE("loaded %zu context configs", ccc->m_map.size());
 
     return ccc;
 }

--- a/lib/src/SwitchConfigContainer.cpp
+++ b/lib/src/SwitchConfigContainer.cpp
@@ -24,7 +24,7 @@ void SwitchConfigContainer::insert(
                 config->m_hardwareInfo.c_str());
     }
 
-    SWSS_LOG_NOTICE("added switch: %u:%s",
+    SWSS_LOG_NOTICE("added switch: idx %u, hwinfo '%s'",
             config->m_switchIndex,
             config->m_hardwareInfo.c_str());
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -25,6 +25,8 @@
 
 #include "meta/sai_serialize.h"
 
+#include "vslib/inc/saivs.h"
+
 #include <unistd.h>
 #include <inttypes.h>
 
@@ -2670,6 +2672,10 @@ int Syncd::profileGetNextValue(
 void Syncd::loadProfileMap()
 {
     SWSS_LOG_ENTER();
+
+    // in case of virtual switch, populate context config
+    m_profileMap[SAI_KEY_VS_GLOBAL_CONTEXT] = std::to_string(m_commandLineOptions->m_globalContext);
+    m_profileMap[SAI_KEY_VS_CONTEXT_CONFIG] = m_commandLineOptions->m_contextConfig;
 
     if (m_commandLineOptions->m_profileMapFile.size() == 0)
     {

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -102,6 +102,7 @@ getVid
 github
 GRE
 gSwitchId
+GUID
 hardcoded
 hasEqualAttribute
 hostif
@@ -120,10 +121,10 @@ ini
 init
 INIT
 inout
-INSEG
-Inseg
-insegs
 inseg
+Inseg
+INSEG
+insegs
 ip
 IP
 ipc

--- a/vslib/inc/Context.h
+++ b/vslib/inc/Context.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ContextConfig.h"
+
+namespace saivs
+{
+    class Context
+    {
+        public:
+
+            Context(
+                    _In_ std::shared_ptr<ContextConfig> contextConfig);
+
+            virtual ~Context();
+
+        public:
+
+            std::shared_ptr<ContextConfig> getContextConfig() const;
+
+        private:
+
+            std::shared_ptr<ContextConfig> m_contextConfig;
+    };
+}

--- a/vslib/inc/ContextConfig.h
+++ b/vslib/inc/ContextConfig.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "SwitchConfigContainer.h"
+
+namespace saivs
+{
+    class ContextConfig
+    {
+        public:
+
+            ContextConfig(
+                    _In_ uint32_t guid,
+                    _In_ const std::string& name);
+
+            virtual ~ContextConfig();
+
+        public:
+
+            void insert(
+                    _In_ std::shared_ptr<SwitchConfig> config);
+
+
+        public: // TODO to private
+
+            uint32_t m_guid;
+
+            std::string m_name;
+
+            std::shared_ptr<SwitchConfigContainer> m_scc;
+    };
+}

--- a/vslib/inc/ContextConfigContainer.h
+++ b/vslib/inc/ContextConfigContainer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ContextConfig.h"
+
+#include "swss/sal.h"
+
+#include <memory>
+#include <map>
+#include <set>
+
+namespace saivs
+{
+    class ContextConfigContainer
+    {
+        public:
+
+            ContextConfigContainer();
+
+            virtual ~ContextConfigContainer();
+
+        public:
+
+            void insert(
+                    _In_ std::shared_ptr<ContextConfig> contextConfig);
+
+            std::shared_ptr<ContextConfig> get(
+                    _In_ uint32_t guid);
+
+            std::set<std::shared_ptr<ContextConfig>> getAllContextConfigs();
+
+        public:
+
+            static std::shared_ptr<ContextConfigContainer> loadFromFile(
+                    _In_ const char* contextConfig);
+
+            static std::shared_ptr<ContextConfigContainer> getDefault();
+
+        private:
+
+            std::map<uint32_t, std::shared_ptr<ContextConfig>> m_map;
+
+    };
+}

--- a/vslib/inc/Sai.h
+++ b/vslib/inc/Sai.h
@@ -6,6 +6,7 @@
 #include "EventPayloadNotification.h"
 #include "ResourceLimiterContainer.h"
 #include "CorePortIndexMapContainer.h"
+#include "Context.h"
 
 #include "meta/Meta.h"
 
@@ -403,6 +404,11 @@ namespace saivs
 
         private:
 
+            std::shared_ptr<Context> getContext(
+                    _In_ uint32_t globalContext) const;
+
+        private:
+
             bool m_apiInitialized;
 
             std::recursive_mutex m_apimutex;
@@ -424,5 +430,7 @@ namespace saivs
             std::shared_ptr<ResourceLimiterContainer> m_resourceLimiterContainer;
 
             std::shared_ptr<CorePortIndexMapContainer> m_corePortIndexMapContainer;
+
+            std::map<uint32_t, std::shared_ptr<Context>> m_contextMap;
     };
 }

--- a/vslib/inc/SwitchConfig.h
+++ b/vslib/inc/SwitchConfig.h
@@ -40,7 +40,9 @@ namespace saivs
     {
         public:
 
-            SwitchConfig();
+            SwitchConfig(
+                    _In_ uint32_t switchIndex,
+                    _In_ const std::string& hwinfo);
 
             virtual ~SwitchConfig() = default;
 

--- a/vslib/inc/SwitchConfigContainer.h
+++ b/vslib/inc/SwitchConfigContainer.h
@@ -3,6 +3,7 @@
 #include "SwitchConfig.h"
 
 #include <map>
+#include <set>
 #include <memory>
 
 namespace saivs
@@ -25,6 +26,8 @@ namespace saivs
 
             std::shared_ptr<SwitchConfig> getConfig(
                     _In_ const std::string& hardwareInfo) const;
+
+            std::set<std::shared_ptr<SwitchConfig>> getSwitchConfigs() const;
 
         private:
 

--- a/vslib/inc/saivs.h
+++ b/vslib/inc/saivs.h
@@ -69,6 +69,23 @@ extern "C" {
  */
 #define SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE  "SAI_VS_CORE_PORT_INDEX_MAP_FILE"
 
+/**
+ * @brief Context config.
+ *
+ * Optional. Should point to a context_config.json which will contain how many
+ * contexts (syncd) we have in the system globally and each context how many
+ * switches it manages. Only one of this contexts will be used in VS.
+ */
+#define SAI_KEY_VS_CONTEXT_CONFIG             "SAI_VS_CONTEXT_CONFIG"
+
+/**
+ * @brief Global context.
+ *
+ * Optional. Should point to GUID value which is provided in context_config.json
+ * by SAI_KEY_VS_CONTEXT_CONFIG. Default is 0.
+ */
+#define SAI_KEY_VS_GLOBAL_CONTEXT             "SAI_VS_GLOBAL_CONTEXT"
+
 #define SAI_VALUE_VS_SWITCH_TYPE_BCM56850     "SAI_VS_SWITCH_TYPE_BCM56850"
 #define SAI_VALUE_VS_SWITCH_TYPE_BCM81724     "SAI_VS_SWITCH_TYPE_BCM81724"
 #define SAI_VALUE_VS_SWITCH_TYPE_MLNX2700     "SAI_VS_SWITCH_TYPE_MLNX2700"

--- a/vslib/src/Context.cpp
+++ b/vslib/src/Context.cpp
@@ -1,0 +1,28 @@
+#include "Context.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+Context::Context(
+        _In_ std::shared_ptr<ContextConfig> contextConfig):
+    m_contextConfig(contextConfig)
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+Context::~Context()
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+std::shared_ptr<ContextConfig> Context::getContextConfig() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_contextConfig;
+}

--- a/vslib/src/ContextConfig.cpp
+++ b/vslib/src/ContextConfig.cpp
@@ -1,0 +1,31 @@
+#include "ContextConfig.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+ContextConfig::ContextConfig(
+        _In_ uint32_t guid,
+        _In_ const std::string& name):
+    m_guid(guid),
+    m_name(name)
+{
+    SWSS_LOG_ENTER();
+
+    m_scc = std::make_shared<SwitchConfigContainer>();
+}
+
+ContextConfig::~ContextConfig()
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+void ContextConfig::insert(
+        _In_ std::shared_ptr<SwitchConfig> config)
+{
+    SWSS_LOG_ENTER();
+
+    m_scc->insert(config);
+}

--- a/vslib/src/ContextConfigContainer.cpp
+++ b/vslib/src/ContextConfigContainer.cpp
@@ -1,0 +1,148 @@
+#include "ContextConfigContainer.h"
+
+#include "swss/logger.h"
+#include "swss/json.hpp"
+
+#include <cstring>
+#include <fstream>
+
+using json = nlohmann::json;
+
+using namespace saivs;
+
+ContextConfigContainer::ContextConfigContainer()
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+ContextConfigContainer::~ContextConfigContainer()
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+std::shared_ptr<ContextConfigContainer> ContextConfigContainer::getDefault()
+{
+    SWSS_LOG_ENTER();
+
+    auto ccc = std::make_shared<ContextConfigContainer>();
+
+    auto cc = std::make_shared<ContextConfig>(0, "VirtualSwitch");
+
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+
+    cc->insert(sc);
+
+    ccc->m_map[0] = cc;
+
+    return ccc;
+}
+
+void ContextConfigContainer::insert(
+        _In_ std::shared_ptr<ContextConfig> contextConfig)
+{
+    SWSS_LOG_ENTER();
+
+    m_map[contextConfig->m_guid] = contextConfig;
+}
+
+std::shared_ptr<ContextConfig> ContextConfigContainer::get(
+        _In_ uint32_t guid)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_map.find(guid);
+
+    if (it == m_map.end())
+        return nullptr;
+
+    return it->second;
+}
+
+std::shared_ptr<ContextConfigContainer> ContextConfigContainer::loadFromFile(
+        _In_ const char* contextConfig)
+{
+    SWSS_LOG_ENTER();
+
+    auto ccc = std::make_shared<ContextConfigContainer>();
+
+    if (contextConfig == nullptr || strlen(contextConfig) == 0)
+    {
+        SWSS_LOG_NOTICE("no context config specified, will load default context config");
+
+        return getDefault();
+    }
+
+    std::ifstream ifs(contextConfig);
+
+    if (!ifs.good())
+    {
+        SWSS_LOG_ERROR("failed to read '%s', err: %s, returning default", contextConfig, strerror(errno));
+
+        return getDefault();
+    }
+
+    try
+    {
+        json j;
+        ifs >> j;
+
+        for (size_t idx = 0; idx < j["CONTEXTS"].size(); idx++)
+        {
+            json& item = j["CONTEXTS"][idx];
+
+            uint32_t guid = item["guid"];
+
+            const std::string& name = item["name"];
+
+            SWSS_LOG_NOTICE("contextConfig: guid: %u, name: %s", guid, name.c_str());
+
+            auto cc = std::make_shared<ContextConfig>(guid, name);
+
+            for (size_t k = 0; k < item["switches"].size(); k++)
+            {
+                json& sw = item["switches"][k];
+
+                uint32_t switchIndex = sw["index"];
+                const std::string& hwinfo = sw["hwinfo"];
+
+                auto sc = std::make_shared<SwitchConfig>(switchIndex, hwinfo);
+
+                cc->insert(sc);
+
+                SWSS_LOG_NOTICE("insert into context '%s' config for hwinfo '%s'", cc->m_name.c_str(), hwinfo.c_str());
+            }
+
+            ccc->insert(cc);
+
+            SWSS_LOG_NOTICE("insert context '%s' into container list", cc->m_name.c_str());
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Failed to load '%s': %s, returning default", contextConfig, e.what());
+
+        return getDefault();
+    }
+
+    SWSS_LOG_NOTICE("loaded %zu context configs", ccc->m_map.size());
+
+    return ccc;
+}
+
+std::set<std::shared_ptr<ContextConfig>> ContextConfigContainer::getAllContextConfigs()
+{
+    SWSS_LOG_ENTER();
+
+    std::set<std::shared_ptr<ContextConfig>> set;
+
+    for (auto&item: m_map)
+    {
+        set.insert(item.second);
+    }
+
+    return set;
+}

--- a/vslib/src/Makefile.am
+++ b/vslib/src/Makefile.am
@@ -14,6 +14,9 @@ libSaiVS_a_SOURCES = \
 					  ../../lib/src/Notification.cpp \
 					  ../../lib/src/NotificationPortStateChange.cpp \
 					  ../../lib/src/PerformanceIntervalTimer.cpp \
+					  Context.cpp \
+					  ContextConfig.cpp \
+					  ContextConfigContainer.cpp \
 					  ResourceLimiter.cpp \
 					  ResourceLimiterContainer.cpp \
 					  ResourceLimiterParser.cpp \

--- a/vslib/src/SwitchConfig.cpp
+++ b/vslib/src/SwitchConfig.cpp
@@ -5,19 +5,20 @@
 
 using namespace saivs;
 
-SwitchConfig::SwitchConfig():
+SwitchConfig::SwitchConfig(
+        _In_ uint32_t switchIndex,
+        _In_ const std::string& hwinfo):
     m_saiSwitchType(SAI_SWITCH_TYPE_NPU),
     m_switchType(SAI_VS_SWITCH_TYPE_NONE),
     m_bootType(SAI_VS_BOOT_TYPE_COLD),
-    m_switchIndex(0),
-    m_hardwareInfo(""),
+    m_switchIndex(switchIndex),
+    m_hardwareInfo(hwinfo),
     m_useTapDevice(false)
 {
     SWSS_LOG_ENTER();
 
     // empty
 }
-
 
 bool SwitchConfig::parseSaiSwitchType(
         _In_ const char* saiSwitchTypeStr,

--- a/vslib/src/SwitchConfigContainer.cpp
+++ b/vslib/src/SwitchConfigContainer.cpp
@@ -24,7 +24,7 @@ void SwitchConfigContainer::insert(
                 config->m_hardwareInfo.c_str());
     }
 
-    SWSS_LOG_NOTICE("added switch: %u:%s",
+    SWSS_LOG_NOTICE("added switch: idx %u, hwinfo '%s'",
             config->m_switchIndex,
             config->m_hardwareInfo.c_str());
 
@@ -61,4 +61,18 @@ std::shared_ptr<SwitchConfig> SwitchConfigContainer::getConfig(
     }
 
     return nullptr;
+}
+
+std::set<std::shared_ptr<SwitchConfig>> SwitchConfigContainer::getSwitchConfigs() const
+{
+    SWSS_LOG_ENTER();
+
+    std::set<std::shared_ptr<SwitchConfig>> set;
+
+    for (auto& kvp: m_hwinfoToConfig)
+    {
+        set.insert(kvp.second);
+    }
+
+    return set;
 }

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -45,6 +45,9 @@ SwitchStateBase::SwitchStateBase(
         if (m_switchConfig->m_useTapDevice)
         {
             m_fdb_info_set = warmBootState->m_fdbInfoSet;
+
+            // TODO populate m_hostif_info_map - need to be able to remove port after warm boot
+            // should be auto populated vs_recreate_hostif_tap_interfaces on create_switch
         }
     }
 }


### PR DESCRIPTION
So far virtual switch supported only 1 switch to be created and only default hwinfo which was empty string. This change allows to reuse context_config.json to allow multiple switches to be created in virtual switch and each can have different hwinfo. This scenario can be useful when running VS test with multiple swss containers running.