### PR TITLE
Add the option to provide the package name in dh build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -46,8 +46,8 @@ binary-sairedis:
 binary-syncd:
 	echo > /tmp/syncd-build
 	dh clean  --with autotools-dev
-	dh build  -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
-	dh binary -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
+	dh build  -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev --filename $(PKG_NAME)
+	dh binary -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev --filename $(PKG_NAME)
 
 binary-syncd-rpc: | binary-syncd
 	echo '--enable-rpcserver=yes' > /tmp/syncd-build


### PR DESCRIPTION
Ref: https://github.com/Azure/sonic-buildimage/pull/7598

**NOTE** : Will be closing this PR as it is not needed.