### PR TITLE
[vs]: Start syncd by passing context configuration file and global context index.

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -181,7 +181,10 @@ config_syncd_nephos()
 
 config_syncd_vs()
 {
-    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0"
+    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    if [ -f $HWSKU_DIR/context_config.json ]; then
+        CMD_ARGS+=" -x $HWSKU_DIR/context_config.json -g 0"
+    fi
 }
 
 config_syncd_innovium()

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -181,7 +181,7 @@ config_syncd_nephos()
 
 config_syncd_vs()
 {
-    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0"
 }
 
 config_syncd_innovium()


### PR DESCRIPTION
https://github.com/Azure/sonic-sairedis/pull/830 adds support to bring up multi-asic Virtual switch.
In multi-asic VS switch, there are multiple swss and syncd dockers. Orchagent process in each swss is started with a different hwinfo(asic_id). This PR is to ensure that context configuration is passed in syncd which has the hwinfo information with which each orchagent is started. 

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>