### PR TITLE
[Mellanox] Update Mellanoxs dump generation to include SDK dumps

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -111,6 +111,11 @@ config_syncd_mlnx()
     cat $HWSKU_DIR/sai.profile > /tmp/sai.profile
     echo "DEVICE_MAC_ADDRESS=$MAC_ADDRESS" >> /tmp/sai.profile
     echo "SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/" >> /tmp/sai.profile
+    
+    SDK_DUMP_PATH=`cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
+    if [ ! -d "$SDK_DUMP_PATH" ]; then
+        mkdir -p "$SDK_DUMP_PATH"
+    fi
 }
 
 config_syncd_centec()


### PR DESCRIPTION
Create in Mellanox devices a folder from sai.profile key SAI_DUMP_STORE_PATH in the syncd docker to have it ready for SDK dumps