### PR TITLE
[RIF] Bug fix for Issue #729

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -853,7 +853,7 @@ void FlexCounter::removeRif(
         if (fc.isEmpty())
         {
             lkMgr.unlock();
-            removeInstance(instanceId);
+            fc.removeCollectCountersHandler(RIF_COUNTER_ID_LIST);
         }
         return;
     }
@@ -868,7 +868,7 @@ void FlexCounter::removeRif(
     if (fc.isEmpty())
     {
         lkMgr.unlock();
-        removeInstance(instanceId);
+        fc.removeCollectCountersHandler(RIF_COUNTER_ID_LIST);
     }
 }
 


### PR DESCRIPTION
Issue:
Rif Counters can not work when removing one router interface https://github.com/Azure/SONiC/issues/729 

Root cause:
In function FlexCounter::removeRif in 201911 branch, removing the whole instance leads to zero the poll interval and therefore will not receive rif events.
As a result of not receiving rif events, the rif thread will not started and therefore the counters table will not filled up.
The symptom is N/A values in "show interfaces counters rif" command.

Fix:
Instead of removing the whole instance, remove the counter from the m_collectCountersHandlers.

Signed-off-by: Noa Or <noaor@nvidia.com>