### PR TITLE
Ported Marvell armhf build on amd64 host for debian buster to use cross-comp…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,11 @@ AC_ARG_ENABLE(redis-test,
 esac],[rtest=false])
 AM_CONDITIONAL(RTEST, test x$rtest = xtrue)
 
-AM_CONDITIONAL(ARCH64, test `getconf LONG_BIT` = "64")
+if test x$CONFIGURED_ARCH = xarmhf && test x$CROSS_BUILD_ENVIRON = xy; then
+	AM_CONDITIONAL(ARCH64, false)
+else
+	AM_CONDITIONAL(ARCH64, test `getconf LONG_BIT` = "64")
+fi
 
 AC_PATH_PROGS(SWIG, [swig3.0 swig])
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -3,7 +3,8 @@ from distutils.command.build_ext import build_ext
 from distutils.sysconfig import customize_compiler
 import os
 
-os.environ["CC"] = "g++"
+os.environ["CC"] = os.getenv("CROSS_COMPILE", "") + "g++"
+os.environ["CXX"] = os.getenv("CROSS_COMPILE", "") + "g++"
 
 swss_common_inc_dir = '@SWSS_COMMON_INC_DIR@'
 


### PR DESCRIPTION
…ilation instead of qemu emulation

…ilation instead of qemu emulation

Motivation:
Current armhf Sonic build on amd64 host uses qemu emulation. Due to the nature of the emulation it takes a very long time, about 22-24 hours to complete the build. The change I did to improve the building time ports Sonic armhf build on amd64 host for Marvell platform for debian buster to use cross-compilation on arm64 host for armhf target. The overall Sonic armhf building time using cross-compilation is about 6 hours.

The Sonic configure and build for the armhf cross-compilation is as following:
NOJESSIE=1 NOSTRETCH=1 BLDENV=buster CROSS_BLDENV=1 make configure PLATFORM=marvell-armhf PLATFORM_ARCH=armhf
NOJESSIE=1 NOSTRETCH=1 BLDENV=buster CROSS_BLDENV=1 make target/sonic-marvell-armhf.bin

Sonic module should check if $CROSS_BUILD_ENVIRON is 'y' to make sure that it is cross-compilation build.

