### PR TITLE
[syncd] bulk OID remove requires RID

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1495,7 +1495,7 @@ sai_status_t Syncd::processBulkOidRemove(
     status = m_vendorSai->bulkRemove(
                                 objectType,
                                 (uint32_t)object_count,
-                                objectVids.data(),
+                                objectRids.data(),
                                 mode,
                                 statuses.data());
 


### PR DESCRIPTION
Syncd::processBulkOidRemove() is incorrectly passing objectVids.data() to m_vendorSai->bulkRemove() when it should be passing objectRids.data(). 
Only RID should be passed to m_vendorSai calls. 
Issue can be seen when SAI bulk APIs are enabled in syncd and the following sequence of iproute2 commands are executed:
"ip route add \<ip-prefix> nexthop via inet \<ip-gateway-1> dev \<port-1> nexthop via inet \<ip-gateway-2> dev \<port-2>"
"ip route del \<ip-prefix> nexthop via inet \<ip-gateway-1> dev \<port-1> nexthop via inet \<ip-gateway-2> dev \<port-2>"
