### PR TITLE
[syncd][bcm] Start syncd by passing context configuration file

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -163,7 +163,7 @@ config_syncd_bcm()
     fi
     
     if [ -f "$HWSKU_DIR/context_config.json" ]; then 
-        CMD_ARGS+=" -x $HWSKU_DIR/context_config.json"
+        CMD_ARGS+=" -x $HWSKU_DIR/context_config.json -g 0"
     fi
     
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -161,7 +161,11 @@ config_syncd_bcm()
       fi
 
     fi
-
+    
+    if [ -f "$HWSKU_DIR/context_config.json" ]; then 
+        CMD_ARGS+=" -x $HWSKU_DIR/context_config.json"
+    fi
+    
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0
     [ -e /dev/linux-user-bde ] || mknod /dev/linux-user-bde c 126 0
     [ -e /dev/linux-kernel-bde ] || mknod /dev/linux-kernel-bde c 127 0


### PR DESCRIPTION
In multi-asic BCM switch, there are multiple swss and syncd dockers. Orchagent process in each swss is started with a different hwinfo(asic_id). This PR is to ensure that context configuration is passed in syncd which has the hwinfo information with which each orchagent is started.
This change is similar to done for VS target