### PR TITLE
Revert "[vs]: Start syncd by passing context configuration file and g…

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -255,9 +255,6 @@ config_syncd_nephos()
 config_syncd_vs()
 {
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
-    if [ -f $HWSKU_DIR/context_config.json ]; then
-        CMD_ARGS+=" -x $HWSKU_DIR/context_config.json -g 0"
-    fi
 }
 
 config_syncd_innovium()


### PR DESCRIPTION
…lobal context index. (#832)"

This reverts commit 0e2105a8e5c6e14c3551ec2bf65b1ad41bb5060b.
multi-asic VS with multiple swss and syncd dockers, comes up without context_config.json or hwinfo.
Just like a single asic vs, multi-asic vs will spawn multiple instances of swss and syncd with default hwinfo.
Reverting this PR as it is not required currently for multi-asic VS.