### PR TITLE
Fixed Popen args in physyncd_spawn()

### DIFF
--- a/syncd/scripts/gbsyncdmgrd
+++ b/syncd/scripts/gbsyncdmgrd
@@ -34,7 +34,7 @@ def physyncd_spawn(gearbox_config):
 
     for i, phy in enumerate(gearbox_config['phys'], 1):
         cmd = '/usr/bin/syncd -p /etc/sai.d/pai.profile -x /usr/share/sonic/hwsku/context_config.json -g {}"'.format(i)
-        proc = subprocess.Popen(cmd, close_fds=True)
+        proc = subprocess.Popen(cmd.split(), close_fds=True)
         proc_list.append(proc)
         syslog.syslog(syslog.LOG_INFO, 'Spawned PID {}'.format(proc.pid))
 


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>

Fixed the spawning of gearbox syncd processes.
```
Jul 11 09:30:17.336147 localhost INFO gbsyncd#supervisord 2021-07-11 09:30:17,334 INFO spawned: 'gbsyncdmgrd' with pid 20 
Jul 11 09:30:17.393517 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd Traceback (most recent call last):
Jul 11 09:30:17.393601 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd   File "/usr/bin/gbsyncdmgrd", line 93, in <module>
Jul 11 09:30:17.393640 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd     sys.exit(main())
Jul 11 09:30:17.393675 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd   File "/usr/bin/gbsyncdmgrd", line 66, in main
Jul 11 09:30:17.393709 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd     proc_list = physyncd_spawn(gearbox_config)
Jul 11 09:30:17.393744 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd   File "/usr/bin/gbsyncdmgrd", line 37, in physyncd_spawn
Jul 11 09:30:17.393778 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd     proc = subprocess.Popen(cmd, close_fds=True)
Jul 11 09:30:17.393812 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd   File "/usr/lib/python3.7/subprocess.py", line 775, in __init__
Jul 11 09:30:17.393845 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd     restore_signals, start_new_session)
Jul 11 09:30:17.393880 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd   File "/usr/lib/python3.7/subprocess.py", line 1522, in _execute_child
Jul 11 09:30:17.393914 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd     raise child_exception_type(errno_num, err_msg, err_filename)
Jul 11 09:30:17.393947 localhost INFO gbsyncd#/supervisord: gbsyncdmgrd FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/syncd -p /etc/sai.d/pai.profile -x /usr/share/sonic/hwsku/context
_config.json -g 1"': '/usr/bin/syncd -p /etc/sai.d/pai.profile -x /usr/share/sonic/hwsku/context_config.json -g 1"'
```

As per `subprocess.Popen()` documentation:
```
args should be a sequence of program arguments or else a single string or path-like object.
By default, the program to execute is the first item in args if args is a sequence. If args is a string,
the interpretation is platform-dependent...
```
https://docs.python.org/3/library/subprocess.html#subprocess.Popen

The fix should be cherry-picked into 202012 as well.