### PR TITLE
[syncd] Fix status success on bulk fallback

### DIFF
--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -1337,7 +1337,7 @@ sai_status_t RedisRemoteSaiInterface::waitForBulkResponse(
 
         if (values.size () != object_count)
         {
-            SWSS_LOG_THROW("wrong number of counters, got %zu, expected %u", values.size(), object_count);
+            SWSS_LOG_THROW("wrong number of statuses, got %zu, expected %u", values.size(), object_count);
         }
 
         // deserialize statuses for all objects

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1285,6 +1285,8 @@ sai_status_t Syncd::processBulkEntry(
 
     // vendor SAI don't bulk API yet, so execute one by one
 
+    all = SAI_STATUS_SUCCESS;
+
     for (size_t idx = 0; idx < objectIds.size(); ++idx)
     {
         sai_object_meta_key_t metaKey;
@@ -1584,6 +1586,10 @@ sai_status_t Syncd::processBulkOid(
             return all;
         }
     }
+
+    // vendor SAI don't bulk API yet, so execute one by one
+
+    all = SAI_STATUS_SUCCESS;
 
     for (size_t idx = 0; idx < objectIds.size(); ++idx)
     {


### PR DESCRIPTION
If bulk api is not supported, syncd will fallback to execute 1 by 1, but status overall was not success when started, this will address that.