### PR TITLE
[sairedis] Add comment api to recorder

### DIFF
--- a/lib/inc/Recorder.h
+++ b/lib/inc/Recorder.h
@@ -379,6 +379,9 @@ namespace sairedis
 
             void requestLogRotate();
 
+            void recordComment(
+                    _In_ const std::string& comment);
+
         public: // static helper functions
 
             static std::string getTimestamp();

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -1153,3 +1153,11 @@ void Recorder::recordBulkGenericResponse(
         recordLine("E|" + sai_serialize_status(status) + "|" + statuses);
     }
 }
+
+void Recorder::recordComment(
+        _In_ const std::string& comment)
+{
+    SWSS_LOG_ENTER();
+
+    recordLine("#|" + comment);
+}

--- a/lib/src/RedisRemoteSaiInterface.cpp
+++ b/lib/src/RedisRemoteSaiInterface.cpp
@@ -194,6 +194,11 @@ sai_status_t RedisRemoteSaiInterface::create(
 
         auto hwinfo = getHardwareInfo(attr_count, attr_list);
 
+        if (hwinfo.size())
+        {
+            m_recorder->recordComment("SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO=" + hwinfo);
+        }
+
         switchId = m_virtualObjectIdManager->allocateNewSwitchObjectId(hwinfo);
 
         *objectId = switchId;


### PR DESCRIPTION
Use new api to record hardware info when creating switch for easy read. Since hardware info attribute type is s8list, it will be serialized as array of integers, so to actually improve readability of actual value, put it as comment in recording file. 