### PR TITLE
[syncd] Add event data for timer watchdog to log entire event

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -318,7 +318,7 @@ sai_status_t Syncd::processSingleEvent(
         return SAI_STATUS_SUCCESS;
     }
 
-    WatchdogScope ws(m_timerWatchdog, op + ":" + key);
+    WatchdogScope ws(m_timerWatchdog, op + ":" + key, &kco);
 
     if (op == REDIS_ASIC_STATE_COMMAND_CREATE)
         return processQuadEvent(SAI_COMMON_API_CREATE, kco);
@@ -1959,7 +1959,7 @@ void Syncd::processFlexCounterGroupEvent( // TODO must be moved to go via ASIC c
     auto& op = kfvOp(kco);
     auto& values = kfvFieldsValues(kco);
 
-    WatchdogScope ws(m_timerWatchdog, op + ":" + groupName);
+    WatchdogScope ws(m_timerWatchdog, op + ":" + groupName, &kco);
 
     if (op == SET_COMMAND)
     {
@@ -1989,7 +1989,7 @@ void Syncd::processFlexCounterEvent( // TODO must be moved to go via ASIC channe
     auto& key = kfvKey(kco);
     auto& op = kfvOp(kco);
 
-    WatchdogScope ws(m_timerWatchdog, op + ":" + key);
+    WatchdogScope ws(m_timerWatchdog, op + ":" + key, &kco);
 
     auto delimiter = key.find_first_of(":");
 
@@ -4575,7 +4575,7 @@ syncd_restart_type_t Syncd::handleRestartQuery(
 
     restartQuery.pop(op, data, values);
 
-    m_timerWatchdog.setEventName(op + ":" + data);
+    m_timerWatchdog.setEventData(op + ":" + data);
 
     SWSS_LOG_NOTICE("received %s switch shutdown event", op.c_str());
 

--- a/syncd/TimerWatchdog.h
+++ b/syncd/TimerWatchdog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "swss/sal.h"
+#include "swss/table.h"
 
 #include <thread>
 #include <atomic>
@@ -24,8 +25,9 @@ namespace syncd
 
             void setEndTime();
 
-            void setEventName(
-                    _In_ const std::string& eventName);
+            void setEventData(
+                    _In_ const std::string& eventName,
+                    _In_ const swss::KeyOpFieldsValuesTuple* kco = nullptr);
 
             void setCallback(
                     _In_ std::function<void(uint64_t)> callback);
@@ -40,6 +42,8 @@ namespace syncd
         private:
 
             void threadFunction();
+
+            void logEventData();
 
         private:
 
@@ -57,6 +61,8 @@ namespace syncd
             std::function<void(uint64_t)> m_callback;
 
             std::string m_eventName;
+
+            const swss::KeyOpFieldsValuesTuple* m_kco;
 
             std::mutex m_mutex;
     };

--- a/syncd/WatchdogScope.cpp
+++ b/syncd/WatchdogScope.cpp
@@ -4,14 +4,15 @@ using namespace syncd;
 
 WatchdogScope::WatchdogScope(
         _In_ TimerWatchdog& tw,
-        _In_ const std::string eventName):
+        _In_ const std::string& eventName,
+        _In_ const swss::KeyOpFieldsValuesTuple* kco):
     m_tw(tw)
 {
     // SWSS_LOG_ENTER(); // disabled
 
     m_tw.setStartTime();
 
-    m_tw.setEventName(eventName);
+    m_tw.setEventData(eventName, kco);
 }
 
 WatchdogScope::~WatchdogScope()

--- a/syncd/WatchdogScope.h
+++ b/syncd/WatchdogScope.h
@@ -8,9 +8,22 @@ namespace syncd
     {
         public:
 
+            /**
+             * @brief Watchdog scope constructor.
+             *
+             * @param timerWatchdog - Timer watchdog to work on.
+             * @param eventName - Name of the event.
+             * @param data - Event data. NOTE: event data is passed here as a
+             * pointer here to avoid expensive data copy, but then we must be
+             * sure that that data object was not destroyed before watchdog
+             * scope destructor will be called. This will make sure that if
+             * event was too long, then it data will be logged into syslog from
+             * object that is still alive and not destroyed.
+             */
             WatchdogScope(
-                    _In_ TimerWatchdog& tw,
-                    _In_ const std::string eventName);
+                    _In_ TimerWatchdog& timerWatchdog,
+                    _In_ const std::string& eventName,
+                    _In_ const swss::KeyOpFieldsValuesTuple* data = nullptr);
 
             ~WatchdogScope();
 


### PR DESCRIPTION
In case of long event execution time, we want to know all the parameters that were passed to events, not only event name. For example when doing create/set SAI api we also want to get all the parameters that were passed to it.