### PR TITLE
[tests] Add vssyncd it's own main.cpp

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ endif
 
 SAILIB=-L$(top_srcdir)/vslib/src/.libs -lsaivs
 
-vssyncd_SOURCES = ../syncd/main.cpp
+vssyncd_SOURCES = main.cpp
 
 vssyncd_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 vssyncd_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(SAIFLAGS) $(CODE_COVERAGE_CXXFLAGS)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,10 @@
+#include "swss/logger.h"
+
+int syncd_main(int argc, char **argv);
+
+int main(int argc, char **argv)
+{
+    SWSS_LOG_ENTER();
+
+    return syncd_main(argc, argv);
+}


### PR DESCRIPTION
Main motivation is to avoid linking the same files across different directories to simplify future coverage data collection.