### PR TITLE
Revert "Upgrade SAI to the latest" 

### DIFF
--- a/vslib/src/VirtualSwitchSaiInterface.cpp
+++ b/vslib/src/VirtualSwitchSaiInterface.cpp
@@ -879,6 +879,21 @@ sai_status_t VirtualSwitchSaiInterface::queryAattributeEnumValuesCapability(
 
         return SAI_STATUS_SUCCESS;
     }
+    else if (object_type == SAI_OBJECT_TYPE_DEBUG_COUNTER && attr_id == SAI_DEBUG_COUNTER_ATTR_TYPE)
+    {
+        if (enum_values_capability->count < 4)
+        {
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        enum_values_capability->count = 4;
+        enum_values_capability->list[0] = SAI_DEBUG_COUNTER_TYPE_PORT_IN_DROP_REASONS;
+        enum_values_capability->list[1] = SAI_DEBUG_COUNTER_TYPE_PORT_OUT_DROP_REASONS;
+        enum_values_capability->list[2] = SAI_DEBUG_COUNTER_TYPE_SWITCH_IN_DROP_REASONS;
+        enum_values_capability->list[3] = SAI_DEBUG_COUNTER_TYPE_SWITCH_OUT_DROP_REASONS;
+
+        return SAI_STATUS_SUCCESS;
+    }
 
     return SAI_STATUS_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Reverts Azure/sonic-sairedis#893
testing if the test failure existing before this commit
test failed:
**test_SpeedAndBufferSet**
tests/test_speed.py
Unexpected number of keys: expected=4, received=3 (('egress_lossy_profile', 'ingress_lossy_profile', 'egress_lossless_profile')), table="BUFFER_PROFILE"

failed reason:
`lost key : "pg_lossless_40000_300m_profile"`

**test_zero_cable_len_profile_update **
tests/test_buffer_traditional.py
'SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE'

failed reason:
            new_lossless_profile = "pg_lossless_{}_{}_profile".format(test_speed, orig_cable_len)
            fvs = self.app_db.get_entry("BUFFER_PROFILE_TABLE", new_lossless_profile)
also cause by the pg_lossless_{}_{}_profile
