### PR TITLE
Sonic sairedis changes for SAI SRV6

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -1179,6 +1179,38 @@ sai_status_t ClientSai::bulkCreate(
             object_statuses);
 }
 
+sai_status_t ClientSai::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    // TODO support mode
+
+    std::vector<std::string> serialized_object_ids;
+
+    // on create vid is put in db by syncd
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        std::string str_object_id = sai_serialize_my_sid_entry(my_sid_entry[idx]);
+        serialized_object_ids.push_back(str_object_id);
+    }
+
+    return bulkCreate(
+            SAI_OBJECT_TYPE_MY_SID_ENTRY,
+            serialized_object_ids,
+            attr_count,
+            attr_list,
+            mode,
+            object_statuses);
+}
+
 // BULK CREATE HELPERS
 
 sai_status_t ClientSai::bulkCreate(
@@ -1335,6 +1367,26 @@ sai_status_t ClientSai::bulkRemove(
     return bulkRemove(SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, mode, object_statuses);
 }
 
+sai_status_t ClientSai::bulkRemove(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkRemove(SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, mode, object_statuses);
+}
+
 // BULK REMOVE HELPERS
 
 sai_status_t ClientSai::bulkRemove(
@@ -1483,6 +1535,27 @@ sai_status_t ClientSai::bulkSet(
     }
 
     return bulkSet(SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
+}
+
+sai_status_t ClientSai::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkSet(SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
 }
 
 // BULK SET HELPERS

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -65,7 +65,7 @@ libsairedis_la_SOURCES = \
 						 sai_redis_samplepacket.cpp \
 						 sai_redis_scheduler.cpp \
 						 sai_redis_schedulergroup.cpp \
-						 sai_redis_segmentroute.cpp \
+						 sai_redis_srv6.cpp \
 						 sai_redis_stp.cpp \
 						 sai_redis_switch.cpp \
 						 sai_redis_system_port.cpp \

--- a/lib/Recorder.h
+++ b/lib/Recorder.h
@@ -170,6 +170,7 @@ namespace sairedis
             SAI_REDIS_RECORDER_DECLARE_RECORD_CREATE(neighbor_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_CREATE(route_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_CREATE(nat_entry);
+            SAI_REDIS_RECORDER_DECLARE_RECORD_CREATE(my_sid_entry);
 
         public: // remove ENTRY
 
@@ -181,6 +182,7 @@ namespace sairedis
             SAI_REDIS_RECORDER_DECLARE_RECORD_REMOVE(neighbor_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_REMOVE(route_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_REMOVE(nat_entry);
+            SAI_REDIS_RECORDER_DECLARE_RECORD_REMOVE(my_sid_entry);
 
         public: // set ENTRY
 
@@ -192,6 +194,7 @@ namespace sairedis
             SAI_REDIS_RECORDER_DECLARE_RECORD_SET(neighbor_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_SET(route_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_SET(nat_entry);
+            SAI_REDIS_RECORDER_DECLARE_RECORD_SET(my_sid_entry);
 
         public: // get ENTRY
 
@@ -203,7 +206,7 @@ namespace sairedis
             SAI_REDIS_RECORDER_DECLARE_RECORD_GET(neighbor_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_GET(route_entry);
             SAI_REDIS_RECORDER_DECLARE_RECORD_GET(nat_entry);
-
+            SAI_REDIS_RECORDER_DECLARE_RECORD_GET(my_sid_entry);
 
         public: // SAI stats API
 

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1390,6 +1390,24 @@ sai_status_t RedisRemoteSaiInterface::bulkRemove(
     return bulkRemove(SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, mode, object_statuses);
 }
 
+sai_status_t RedisRemoteSaiInterface::bulkRemove(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkRemove(SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, mode, object_statuses);
+}
+
 sai_status_t RedisRemoteSaiInterface::bulkSet(
         _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,
@@ -1484,6 +1502,25 @@ sai_status_t RedisRemoteSaiInterface::bulkSet(
     }
 
     return bulkSet(SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
+}
+
+sai_status_t RedisRemoteSaiInterface::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkSet(SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
 }
 
 sai_status_t RedisRemoteSaiInterface::bulkSet(
@@ -1758,6 +1795,36 @@ sai_status_t RedisRemoteSaiInterface::bulkCreate(
 
     return bulkCreate(
             SAI_OBJECT_TYPE_NAT_ENTRY,
+            serialized_object_ids,
+            attr_count,
+            attr_list,
+            mode,
+            object_statuses);
+}
+
+sai_status_t RedisRemoteSaiInterface::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO support mode
+
+    std::vector<std::string> serialized_object_ids;
+
+    // on create vid is put in db by syncd
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        std::string str_object_id = sai_serialize_my_sid_entry(my_sid_entry[idx]);
+        serialized_object_ids.push_back(str_object_id);
+    }
+
+    return bulkCreate(
+            SAI_OBJECT_TYPE_MY_SID_ENTRY,
             serialized_object_ids,
             attr_count,
             attr_list,

--- a/lib/ServerSai.cpp
+++ b/lib/ServerSai.cpp
@@ -1255,6 +1255,25 @@ sai_status_t ServerSai::processBulkCreateEntry(
         }
         break;
 
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
+            }
+
+            status = m_sai->bulkCreate(
+                    object_count,
+                    entries.data(),
+                    attr_counts.data(),
+                    attr_lists.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
         default:
             return SAI_STATUS_NOT_SUPPORTED;
     }
@@ -1334,6 +1353,23 @@ sai_status_t ServerSai::processBulkRemoveEntry(
             for (uint32_t it = 0; it < object_count; it++)
             {
                 sai_deserialize_inseg_entry(objectIds[it], entries[it]);
+            }
+
+            status = m_sai->bulkRemove(
+                    object_count,
+                    entries.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
             }
 
             status = m_sai->bulkRemove(
@@ -1435,6 +1471,24 @@ sai_status_t ServerSai::processBulkSetEntry(
             for (uint32_t it = 0; it < object_count; it++)
             {
                 sai_deserialize_inseg_entry(objectIds[it], entries[it]);
+            }
+
+            status = m_sai->bulkSet(
+                    object_count,
+                    entries.data(),
+                    attr_lists.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
             }
 
             status = m_sai->bulkSet(

--- a/lib/sai_redis.h
+++ b/lib/sai_redis.h
@@ -48,7 +48,7 @@ PRIVATE extern const sai_rpf_group_api_t        redis_rpf_group_api;
 PRIVATE extern const sai_samplepacket_api_t     redis_samplepacket_api;
 PRIVATE extern const sai_scheduler_api_t        redis_scheduler_api;
 PRIVATE extern const sai_scheduler_group_api_t  redis_scheduler_group_api;
-PRIVATE extern const sai_segmentroute_api_t     redis_segmentroute_api;
+PRIVATE extern const sai_srv6_api_t             redis_srv6_api;
 PRIVATE extern const sai_stp_api_t              redis_stp_api;
 PRIVATE extern const sai_switch_api_t           redis_switch_api;
 PRIVATE extern const sai_system_port_api_t      redis_system_port_api;

--- a/lib/sai_redis_interfacequery.cpp
+++ b/lib/sai_redis_interfacequery.cpp
@@ -67,7 +67,7 @@ static sai_apis_t redis_apis = {
     API(mcast_fdb),
     API(bridge),
     API(tam),
-    API(segmentroute),
+    API(srv6),
     API(mpls),
     API(dtel),
     API(bfd),

--- a/lib/sai_redis_srv6.cpp
+++ b/lib/sai_redis_srv6.cpp
@@ -1,0 +1,18 @@
+#include "sai_redis.h"
+
+REDIS_BULK_CREATE(SRV6_SIDLIST, srv6_sidlist);
+REDIS_BULK_REMOVE(SRV6_SIDLIST, srv6_sidlist);
+REDIS_GENERIC_QUAD(SRV6_SIDLIST,srv6_sidlist);
+REDIS_BULK_QUAD_ENTRY(MY_SID_ENTRY,my_sid_entry);
+REDIS_GENERIC_QUAD_ENTRY(MY_SID_ENTRY,my_sid_entry);
+
+const sai_srv6_api_t redis_srv6_api = {
+
+    REDIS_GENERIC_QUAD_API(srv6_sidlist)
+
+    redis_bulk_create_srv6_sidlist,
+    redis_bulk_remove_srv6_sidlist,
+
+    REDIS_GENERIC_QUAD_API(my_sid_entry)
+    REDIS_BULK_QUAD_API(my_sid_entry)
+};

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -276,6 +276,19 @@ sai_status_t DummySaiInterface::bulkRemove(
     return m_status;
 }
 
+sai_status_t DummySaiInterface::bulkRemove(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+        object_statuses[idx] = m_status;
+
+    return m_status;
+}
 
 sai_status_t DummySaiInterface::bulkSet(
         _In_ sai_object_type_t object_type,
@@ -341,6 +354,21 @@ sai_status_t DummySaiInterface::bulkSet(
 sai_status_t DummySaiInterface::bulkSet(
         _In_ uint32_t object_count,
         _In_ const sai_fdb_entry_t *fdb_entry,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+        object_statuses[idx] = m_status;
+
+    return m_status;
+}
+
+sai_status_t DummySaiInterface::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
         _In_ const sai_attribute_t *attr_list,
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses)
@@ -422,6 +450,22 @@ sai_status_t DummySaiInterface::bulkCreate(
 sai_status_t DummySaiInterface::bulkCreate(
         _In_ uint32_t object_count,
         _In_ const sai_nat_entry_t *nat_entry,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+        object_statuses[idx] = m_status;
+
+    return m_status;
+}
+
+sai_status_t DummySaiInterface::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
         _In_ const uint32_t *attr_count,
         _In_ const sai_attribute_t **attr_list,
         _In_ sai_bulk_op_error_mode_t mode,

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -472,6 +472,46 @@ sai_status_t Meta::remove(
     return status;
 }
 
+sai_status_t Meta::remove(
+        _In_ const sai_my_sid_entry_t* my_sid_entry)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status = meta_sai_validate_my_sid_entry(my_sid_entry, false);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = *my_sid_entry  } } };
+
+    status = meta_generic_validation_remove(meta_key);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    status = m_implementation->remove(my_sid_entry);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_DEBUG("remove status: %s", sai_serialize_status(status).c_str());
+    }
+    else
+    {
+        SWSS_LOG_ERROR("remove status: %s", sai_serialize_status(status).c_str());
+    }
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        meta_generic_validation_post_remove(meta_key);
+    }
+
+    return status;
+}
+
 sai_status_t Meta::create(
         _In_ const sai_fdb_entry_t* fdb_entry,
         _In_ uint32_t attr_count,
@@ -807,6 +847,48 @@ sai_status_t Meta::create(
     return status;
 }
 
+sai_status_t Meta::create(
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status = meta_sai_validate_my_sid_entry(my_sid_entry, true);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = *my_sid_entry  } } };
+
+    status = meta_generic_validation_create(meta_key, my_sid_entry->switch_id, attr_count, attr_list);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    status = m_implementation->create(my_sid_entry, attr_count, attr_list);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_DEBUG("create status: %s", sai_serialize_status(status).c_str());
+    }
+    else
+    {
+        SWSS_LOG_ERROR("create status: %s", sai_serialize_status(status).c_str());
+    }
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        meta_generic_validation_post_create(meta_key, my_sid_entry->switch_id, attr_count, attr_list);
+    }
+
+    return status;
+}
+
 sai_status_t Meta::set(
         _In_ const sai_fdb_entry_t* fdb_entry,
         _In_ const sai_attribute_t *attr)
@@ -1134,6 +1216,46 @@ sai_status_t Meta::set(
     return status;
 }
 
+sai_status_t Meta::set(
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+    sai_status_t status = meta_sai_validate_my_sid_entry(my_sid_entry, false);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = *my_sid_entry  } } };
+
+    status = meta_generic_validation_set(meta_key, attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    status = m_implementation->set(my_sid_entry, attr);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_DEBUG("set status: %s", sai_serialize_status(status).c_str());
+    }
+    else
+    {
+        SWSS_LOG_ERROR("set status: %s", sai_serialize_status(status).c_str());
+    }
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        meta_generic_validation_post_set(meta_key, attr);
+    }
+
+    return status;
+}
+
 sai_status_t Meta::get(
         _In_ const sai_fdb_entry_t* fdb_entry,
         _In_ uint32_t attr_count,
@@ -1397,6 +1519,39 @@ sai_status_t Meta::get(
     if (status == SAI_STATUS_SUCCESS)
     {
         meta_generic_validation_post_get(meta_key, nat_entry->switch_id, attr_count, attr_list);
+    }
+
+    return status;
+}
+
+sai_status_t Meta::get(
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status = meta_sai_validate_my_sid_entry(my_sid_entry, false);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = *my_sid_entry  } } };
+
+    status = meta_generic_validation_get(meta_key, attr_count, attr_list);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    status = m_implementation->get(my_sid_entry, attr_count, attr_list);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        meta_generic_validation_post_get(meta_key, my_sid_entry->switch_id, attr_count, attr_list);
     }
 
     return status;
@@ -2265,6 +2420,65 @@ sai_status_t Meta::bulkRemove(
 
 sai_status_t Meta::bulkRemove(
         _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    // all objects must be same type and come from the same switch
+    // TODO check multiple switches
+
+    PARAMETER_CHECK_IF_NOT_NULL(object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        object_statuses[idx] = SAI_STATUS_NOT_EXECUTED;
+    }
+
+    //PARAMETER_CHECK_OBJECT_TYPE_VALID(object_type);
+    PARAMETER_CHECK_POSITIVE(object_count);
+    PARAMETER_CHECK_IF_NOT_NULL(my_sid_entry);
+
+    if (sai_metadata_get_enum_value_name(&sai_metadata_enum_sai_bulk_op_error_mode_t, mode) == nullptr)
+    {
+        SWSS_LOG_ERROR("mode value %d is not in range on %s", mode, sai_metadata_enum_sai_bulk_op_error_mode_t.name);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    std::vector<sai_object_meta_key_t> vmk;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        sai_status_t status = meta_sai_validate_my_sid_entry(&my_sid_entry[idx], false);
+
+        CHECK_STATUS_SUCCESS(status);
+
+        sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = my_sid_entry[idx] } } };
+
+        vmk.push_back(meta_key);
+
+        status = meta_generic_validation_remove(meta_key);
+
+        CHECK_STATUS_SUCCESS(status);
+    }
+
+    auto status = m_implementation->bulkRemove(object_count, my_sid_entry, mode, object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        if (object_statuses[idx] == SAI_STATUS_SUCCESS)
+        {
+            meta_generic_validation_post_remove(vmk[idx]);
+        }
+    }
+
+    return status;
+}
+
+sai_status_t Meta::bulkRemove(
+        _In_ uint32_t object_count,
         _In_ const sai_fdb_entry_t *fdb_entry,
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses)
@@ -2547,6 +2761,64 @@ sai_status_t Meta::bulkSet(
     }
 
     auto status = m_implementation->bulkSet(object_count, nat_entry, attr_list, mode, object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        if (object_statuses[idx] == SAI_STATUS_SUCCESS)
+        {
+            meta_generic_validation_post_set(vmk[idx], &attr_list[idx]);
+        }
+    }
+
+    return status;
+}
+
+sai_status_t Meta::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    PARAMETER_CHECK_IF_NOT_NULL(object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        object_statuses[idx] = SAI_STATUS_NOT_EXECUTED;
+    }
+
+    //PARAMETER_CHECK_OBJECT_TYPE_VALID(object_type);
+    PARAMETER_CHECK_POSITIVE(object_count);
+    PARAMETER_CHECK_IF_NOT_NULL(my_sid_entry);
+    PARAMETER_CHECK_IF_NOT_NULL(attr_list);
+
+    if (sai_metadata_get_enum_value_name(&sai_metadata_enum_sai_bulk_op_error_mode_t, mode) == nullptr)
+    {
+        SWSS_LOG_ERROR("mode value %d is not in range on %s", mode, sai_metadata_enum_sai_bulk_op_error_mode_t.name);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    std::vector<sai_object_meta_key_t> vmk;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        sai_status_t status = meta_sai_validate_my_sid_entry(&my_sid_entry[idx], false);
+
+        CHECK_STATUS_SUCCESS(status);
+
+        sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = my_sid_entry[idx] } } };
+
+        vmk.push_back(meta_key);
+
+        status = meta_generic_validation_set(meta_key, &attr_list[idx]);
+
+        CHECK_STATUS_SUCCESS(status);
+    }
+
+    auto status = m_implementation->bulkSet(object_count, my_sid_entry, attr_list, mode, object_statuses);
 
     for (uint32_t idx = 0; idx < object_count; idx++)
     {
@@ -2995,6 +3267,66 @@ sai_status_t Meta::bulkCreate(
         if (object_statuses[idx] == SAI_STATUS_SUCCESS)
         {
             meta_generic_validation_post_create(vmk[idx], nat_entry[idx].switch_id, attr_count[idx], attr_list[idx]);
+        }
+    }
+
+    return status;
+}
+
+sai_status_t Meta::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    PARAMETER_CHECK_IF_NOT_NULL(object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        object_statuses[idx] = SAI_STATUS_NOT_EXECUTED;
+    }
+
+    //PARAMETER_CHECK_OBJECT_TYPE_VALID(object_type);
+    PARAMETER_CHECK_POSITIVE(object_count);
+    PARAMETER_CHECK_IF_NOT_NULL(my_sid_entry);
+    PARAMETER_CHECK_IF_NOT_NULL(attr_count);
+    PARAMETER_CHECK_IF_NOT_NULL(attr_list);
+
+    if (sai_metadata_get_enum_value_name(&sai_metadata_enum_sai_bulk_op_error_mode_t, mode) == nullptr)
+    {
+        SWSS_LOG_ERROR("mode value %d is not in range on %s", mode, sai_metadata_enum_sai_bulk_op_error_mode_t.name);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    std::vector<sai_object_meta_key_t> vmk;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        sai_status_t status = meta_sai_validate_my_sid_entry(&my_sid_entry[idx], true);
+
+        CHECK_STATUS_SUCCESS(status);
+
+        sai_object_meta_key_t meta_key = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = my_sid_entry[idx] } } };
+
+        vmk.push_back(meta_key);
+
+        status = meta_generic_validation_create(meta_key, my_sid_entry[idx].switch_id, attr_count[idx], attr_list[idx]);
+
+        CHECK_STATUS_SUCCESS(status);
+    }
+
+    auto status = m_implementation->bulkCreate(object_count, my_sid_entry, attr_count, attr_list, mode, object_statuses);
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        if (object_statuses[idx] == SAI_STATUS_SUCCESS)
+        {
+            meta_generic_validation_post_create(vmk[idx], my_sid_entry[idx].switch_id, attr_count[idx], attr_list[idx]);
         }
     }
 
@@ -3523,6 +3855,7 @@ void Meta::meta_generic_validation_post_remove(
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
+            case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
                 // no special action required
                 break;
 
@@ -4312,6 +4645,87 @@ sai_status_t Meta::meta_sai_validate_inseg_entry(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t Meta::meta_sai_validate_my_sid_entry(
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ bool create)
+{
+    SWSS_LOG_ENTER();
+
+    if (my_sid_entry == NULL)
+    {
+        SWSS_LOG_ERROR("my_sid_entry pointer is NULL");
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_id_t vr = my_sid_entry->vr_id;
+
+    if (vr == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("virtual router is set to null object id");
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_type_t object_type = objectTypeQuery(vr);
+
+    if (object_type == SAI_OBJECT_TYPE_NULL)
+    {
+        SWSS_LOG_ERROR("virtual router oid 0x%" PRIx64 " is not valid object type, "
+                        "returned null object type", vr);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_type_t expected = SAI_OBJECT_TYPE_VIRTUAL_ROUTER;
+
+    if (object_type != expected)
+    {
+        SWSS_LOG_ERROR("virtual router oid 0x%" PRIx64 " type %d is wrong type, "
+                       "expected object type %d", vr, object_type, expected);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    // check if virtual router exists
+    sai_object_meta_key_t meta_key_vr = { .objecttype = expected, .objectkey = { .key = { .object_id = vr } } };
+
+    if (!m_saiObjectCollection.objectExists(meta_key_vr))
+    {
+        SWSS_LOG_ERROR("object key %s doesn't exist",
+                sai_serialize_object_meta_key(meta_key_vr).c_str());
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    // check if my_sid_entry exists
+    sai_object_meta_key_t meta_key_my_sid_entry = { .objecttype = SAI_OBJECT_TYPE_MY_SID_ENTRY, .objectkey = { .key = { .my_sid_entry = *my_sid_entry } } };
+
+    if (create)
+    {
+        if (m_saiObjectCollection.objectExists(meta_key_my_sid_entry))
+        {
+            SWSS_LOG_ERROR("object key %s already exists",
+                    sai_serialize_object_meta_key(meta_key_my_sid_entry).c_str());
+
+            return SAI_STATUS_ITEM_ALREADY_EXISTS;
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    // set, get, remove
+    if (!m_saiObjectCollection.objectExists(meta_key_my_sid_entry))
+    {
+        SWSS_LOG_ERROR("object key %s doesn't exist",
+                    sai_serialize_object_meta_key(meta_key_my_sid_entry).c_str());
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t Meta::meta_generic_validation_create(
         _In_ const sai_object_meta_key_t& meta_key,
         _In_ sai_object_id_t switch_id,
@@ -4705,6 +5119,10 @@ sai_status_t Meta::meta_generic_validation_create(
                 break;
             case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
                 VALIDATION_LIST(md, value.ipaddrlist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+                VALIDATION_LIST(md, value.segmentlist);
                 break;
 
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
@@ -5369,6 +5787,10 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.ipaddrlist);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+            VALIDATION_LIST(md, value.segmentlist);
+            break;
+
         case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
 
             if (value.u32range.min > value.u32range.max)
@@ -5771,6 +6193,10 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.ipaddrlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+                VALIDATION_LIST(md, value.segmentlist);
+                break;
+
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
                 // primitives
@@ -6008,6 +6434,10 @@ void Meta::meta_generic_validation_post_get(
                 break;
             case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
                 VALIDATION_LIST_GET(md, value.ipaddrlist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+                VALIDATION_LIST_GET(md, value.segmentlist);
                 break;
 
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
@@ -6924,6 +7354,7 @@ void Meta::meta_generic_validation_post_create(
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
+            case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
                 // no special action required
                 break;
 
@@ -7162,6 +7593,7 @@ void Meta::meta_generic_validation_post_set(
         case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
         case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
         case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY:
+        case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
             // no special action required
             break;
 

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -429,6 +429,10 @@ namespace saimeta
                     _In_ const sai_inseg_entry_t* inseg_entry,
                     _In_ bool create);
 
+            sai_status_t meta_sai_validate_my_sid_entry(
+                    _In_ const sai_my_sid_entry_t* my_sid_entry,
+                    _In_ bool create);
+
         public:
 
             /*

--- a/meta/MetaKeyHasher.cpp
+++ b/meta/MetaKeyHasher.cpp
@@ -98,6 +98,22 @@ static bool operator==(
         a.label == b.label;
 }
 
+static bool operator==(
+        _In_ const sai_my_sid_entry_t& a,
+        _In_ const sai_my_sid_entry_t& b)
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    bool part = a.switch_id == b.switch_id &&
+        a.vr_id == b.vr_id &&
+        a.locator_block_len == b.locator_block_len &&
+        a.locator_node_len == b.locator_node_len &&
+        a.function_len == b.function_len &&
+        a.args_len == b.args_len;
+
+    return part && memcmp(a.sid, b.sid, sizeof(a.sid)) == 0;
+}
+
 bool MetaKeyHasher::operator()(
         _In_ const sai_object_meta_key_t& a,
         _In_ const sai_object_meta_key_t& b) const
@@ -126,6 +142,9 @@ bool MetaKeyHasher::operator()(
 
     if (a.objecttype == SAI_OBJECT_TYPE_INSEG_ENTRY)
         return a.objectkey.key.inseg_entry == b.objectkey.key.inseg_entry;
+
+    if (a.objecttype == SAI_OBJECT_TYPE_MY_SID_ENTRY)
+        return a.objectkey.key.my_sid_entry == b.objectkey.key.my_sid_entry;
 
     SWSS_LOG_THROW("not implemented: %s",
             sai_serialize_object_meta_key(a).c_str());
@@ -211,6 +230,17 @@ static inline std::size_t sai_get_hash(
     return ie.label;
 }
 
+static inline std::size_t sai_get_hash(
+        _In_ const sai_my_sid_entry_t& se)
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    uint32_t ip6[4];
+    memcpy(ip6, se.sid, sizeof(ip6));
+
+    return ip6[0] ^ ip6[1] ^ ip6[2] ^ ip6[3];
+}
+
 std::size_t MetaKeyHasher::operator()(
         _In_ const sai_object_meta_key_t& k) const
 {
@@ -240,6 +270,9 @@ std::size_t MetaKeyHasher::operator()(
 
         case SAI_OBJECT_TYPE_INSEG_ENTRY:
             return sai_get_hash(k.objectkey.key.inseg_entry);
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+            return sai_get_hash(k.objectkey.key.my_sid_entry);
 
         default:
             SWSS_LOG_THROW("not handled: %s", sai_serialize_object_type(k.objecttype).c_str());

--- a/meta/SaiInterface.cpp
+++ b/meta/SaiInterface.cpp
@@ -43,6 +43,9 @@ sai_status_t SaiInterface::create(
         case SAI_OBJECT_TYPE_INSEG_ENTRY:
             return create(&metaKey.objectkey.key.inseg_entry, attr_count, attr_list);
 
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+            return create(&metaKey.objectkey.key.my_sid_entry, attr_count, attr_list);
+
         default:
 
             SWSS_LOG_ERROR("object type %s not implemented, FIXME", info->objecttypename);
@@ -86,6 +89,9 @@ sai_status_t SaiInterface::remove(
 
         case SAI_OBJECT_TYPE_INSEG_ENTRY:
             return remove(&metaKey.objectkey.key.inseg_entry);
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+            return remove(&metaKey.objectkey.key.my_sid_entry);
 
         default:
 
@@ -132,6 +138,9 @@ sai_status_t SaiInterface::set(
         case SAI_OBJECT_TYPE_INSEG_ENTRY:
             return set(&metaKey.objectkey.key.inseg_entry, attr);
 
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+            return set(&metaKey.objectkey.key.my_sid_entry, attr);
+
         default:
 
             SWSS_LOG_ERROR("object type %s not implemented, FIXME", info->objecttypename);
@@ -177,6 +186,9 @@ sai_status_t SaiInterface::get(
 
         case SAI_OBJECT_TYPE_INSEG_ENTRY:
             return get(&metaKey.objectkey.key.inseg_entry, attr_count, attr_list);
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+            return get(&metaKey.objectkey.key.my_sid_entry, attr_count, attr_list);
 
         default:
 

--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -14,12 +14,14 @@ extern "C" {
     _X(NEIGHBOR_ENTRY,neighbor_entry);      \
     _X(ROUTE_ENTRY,route_entry);            \
     _X(NAT_ENTRY,nat_entry);                \
+    _X(MY_SID_ENTRY,my_sid_entry);                \
 
 #define SAIREDIS_DECLARE_EVERY_BULK_ENTRY(_X)   \
     _X(FDB_ENTRY,fdb_entry);                    \
     _X(INSEG_ENTRY,inseg_entry);                \
     _X(NAT_ENTRY,nat_entry);                    \
     _X(ROUTE_ENTRY,route_entry);                \
+    _X(MY_SID_ENTRY,my_sid_entry);              \
 
 #define SAIREDIS_SAIINTERFACE_DECLARE_QUAD_ENTRY_VIRTUAL(OT,ot)     \
     virtual sai_status_t create(                                    \

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -125,6 +125,9 @@ std::string sai_serialize_tunnel_stat(
 std::string sai_serialize_queue_attr(
         _In_ const sai_queue_attr_t attr);
 
+std::string sai_serialize_my_sid_entry(
+        _In_ const sai_my_sid_entry_t &my_sid_entry);
+
 std::string sai_serialize_hex_binary(
         _In_ const void *buffer,
         _In_ size_t length);
@@ -323,6 +326,10 @@ void sai_deserialize_ip_prefix(
 void sai_deserialize_mac(
         _In_ const std::string& s,
         _Out_ sai_mac_t& mac);
+
+void sai_deserialize_my_sid_entry(
+        _In_ const std::string& s,
+        _Out_ sai_my_sid_entry_t& my_sid_entry);
 
 // deserialize notifications
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1003,6 +1003,28 @@ sai_status_t Syncd::processBulkCreateEntry(
         }
         break;
 
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
+
+                entries[it].switch_id = m_translator->translateVidToRid(entries[it].switch_id);
+                entries[it].vr_id = m_translator->translateVidToRid(entries[it].vr_id);
+            }
+
+            status = m_vendorSai->bulkCreate(
+                    object_count,
+                    entries.data(),
+                    attr_counts.data(),
+                    attr_lists.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
         default:
             return SAI_STATUS_NOT_SUPPORTED;
     }
@@ -1077,6 +1099,26 @@ sai_status_t Syncd::processBulkRemoveEntry(
             for (uint32_t it = 0; it < object_count; it++)
             {
                 sai_deserialize_nat_entry(objectIds[it], entries[it]);
+
+                entries[it].switch_id = m_translator->translateVidToRid(entries[it].switch_id);
+                entries[it].vr_id = m_translator->translateVidToRid(entries[it].vr_id);
+            }
+
+            status = m_vendorSai->bulkRemove(
+                    object_count,
+                    entries.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
 
                 entries[it].switch_id = m_translator->translateVidToRid(entries[it].switch_id);
                 entries[it].vr_id = m_translator->translateVidToRid(entries[it].vr_id);
@@ -1194,6 +1236,27 @@ sai_status_t Syncd::processBulkSetEntry(
             for (uint32_t it = 0; it < object_count; it++)
             {
                 sai_deserialize_nat_entry(objectIds[it], entries[it]);
+
+                entries[it].switch_id = m_translator->translateVidToRid(entries[it].switch_id);
+                entries[it].vr_id = m_translator->translateVidToRid(entries[it].vr_id);
+            }
+
+            status = m_vendorSai->bulkSet(
+                    object_count,
+                    entries.data(),
+                    attr_lists.data(),
+                    mode,
+                    statuses.data());
+
+        }
+        break;
+
+        case SAI_OBJECT_TYPE_MY_SID_ENTRY:
+        {
+            std::vector<sai_my_sid_entry_t> entries(object_count);
+            for (uint32_t it = 0; it < object_count; it++)
+            {
+                sai_deserialize_my_sid_entry(objectIds[it], entries[it]);
 
                 entries[it].switch_id = m_translator->translateVidToRid(entries[it].switch_id);
                 entries[it].vr_id = m_translator->translateVidToRid(entries[it].vr_id);

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -621,7 +621,7 @@ sai_status_t VendorSai::bulkCreate(
             break;
 
         case SAI_OBJECT_TYPE_SEGMENTROUTE_SIDLIST:
-            ptr = m_apis.segmentroute_api->create_segmentroute_sidlists;
+            ptr = m_apis.srv6_api->create_srv6_sidlists;
             break;
 
         case SAI_OBJECT_TYPE_STP_PORT:
@@ -680,7 +680,7 @@ sai_status_t VendorSai::bulkRemove(
             break;
 
         case SAI_OBJECT_TYPE_SEGMENTROUTE_SIDLIST:
-            ptr = m_apis.segmentroute_api->remove_segmentroute_sidlists;
+            ptr = m_apis.srv6_api->remove_srv6_sidlists;
             break;
 
         case SAI_OBJECT_TYPE_STP_PORT:
@@ -832,6 +832,32 @@ sai_status_t VendorSai::bulkCreate(
             object_statuses);
 }
 
+sai_status_t VendorSai::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t* entries,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    if (!m_apis.srv6_api->create_my_sid_entries)
+    {
+        SWSS_LOG_INFO("create_my_sid_entries is not supported");
+        return SAI_STATUS_NOT_SUPPORTED;
+    }
+
+    return m_apis.srv6_api->create_my_sid_entries(
+            object_count,
+            entries,
+            attr_count,
+            attr_list,
+            mode,
+            object_statuses);
+}
 // BULK REMOVE
 
 sai_status_t VendorSai::bulkRemove(
@@ -921,6 +947,29 @@ sai_status_t VendorSai::bulkRemove(
     }
 
     return m_apis.nat_api->remove_nat_entries(
+            object_count,
+            entries,
+            mode,
+            object_statuses);
+}
+
+sai_status_t VendorSai::bulkRemove(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *entries,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    if (!m_apis.srv6_api->remove_my_sid_entries)
+    {
+        SWSS_LOG_INFO("remove_my_sid_entries is not supported");
+        return SAI_STATUS_NOT_SUPPORTED;
+    }
+
+    return m_apis.srv6_api->remove_my_sid_entries(
             object_count,
             entries,
             mode,
@@ -1029,6 +1078,30 @@ sai_status_t VendorSai::bulkSet(
             object_statuses);
 }
 
+sai_status_t VendorSai::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *entries,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    if (!m_apis.srv6_api->set_my_sid_entries_attribute)
+    {
+        SWSS_LOG_INFO("set_my_sid_entries_attribute is not supported");
+        return SAI_STATUS_NOT_SUPPORTED;
+    }
+
+    return m_apis.srv6_api->set_my_sid_entries_attribute(
+            object_count,
+            entries,
+            attr_list,
+            mode,
+            object_statuses);
+}
 // NON QUAD API
 
 sai_status_t VendorSai::flushFdbEntries(

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -229,10 +229,12 @@ void test_bulk_next_hop_group_member_create()
     sai_next_hop_api_t  *sai_next_hop_api = NULL;
     sai_next_hop_group_api_t  *sai_next_hop_group_api = NULL;
     sai_switch_api_t *sai_switch_api = NULL;
+    sai_srv6_api_t *sai_srv6_api = NULL;
 
     sai_api_query(SAI_API_NEXT_HOP, (void**)&sai_next_hop_api);
     sai_api_query(SAI_API_NEXT_HOP_GROUP, (void**)&sai_next_hop_group_api);
     sai_api_query(SAI_API_SWITCH, (void**)&sai_switch_api);
+    sai_api_query(SAI_API_SRV6, (void **)&sai_srv6_api);
 
     uint32_t count = 3;
 
@@ -264,18 +266,24 @@ void test_bulk_next_hop_group_member_create()
 
     for (uint32_t i = 0; i <  count; ++i)
     {
+        // srv6 sidlist object
+        sai_object_id_t sidlist;
+        sai_attribute_t sidattr[1] = { };
+        sidattr[0].id = SAI_SRV6_SIDLIST_ATTR_TYPE;
+        sidattr[0].value.s32 = SAI_SRV6_SIDLIST_TYPE_ENCAPS_RED;
+        status = sai_srv6_api->create_srv6_sidlist(&sidlist, switch_id, 1, sidattr);
+
         sai_object_id_t hop_vid;
 
-        sai_attribute_t nhattr[3] = { };
+        sai_attribute_t nhattr[2] = { };
 
         nhattr[0].id = SAI_NEXT_HOP_ATTR_TYPE;
-        nhattr[0].value.s32 = SAI_NEXT_HOP_TYPE_SEGMENTROUTE_ENDPOINT;
+        nhattr[0].value.s32 = SAI_NEXT_HOP_TYPE_SRV6_SIDLIST;
 
-        nhattr[1].id = SAI_NEXT_HOP_ATTR_SEGMENTROUTE_ENDPOINT_TYPE;
+        nhattr[1].id = SAI_NEXT_HOP_ATTR_SRV6_SIDLIST_ID;
+        nhattr[1].value.oid = sidlist;
 
-        nhattr[2].id = SAI_NEXT_HOP_ATTR_SEGMENTROUTE_ENDPOINT_POP_TYPE;
-
-        status = sai_next_hop_api->create_next_hop(&hop_vid, switch_id, 3, nhattr);
+        status = sai_next_hop_api->create_next_hop(&hop_vid, switch_id, 2, nhattr);
 
         ASSERT_SUCCESS("failed to create next hop");
 
@@ -467,11 +475,13 @@ void test_bulk_route_set()
     sai_switch_api_t *sai_switch_api = NULL;
     sai_virtual_router_api_t * sai_virtual_router_api = NULL;
     sai_next_hop_api_t  *sai_next_hop_api = NULL;
+    sai_srv6_api_t  *sai_srv6_api = NULL;
 
     sai_api_query(SAI_API_ROUTE, (void**)&sai_route_api);
     sai_api_query(SAI_API_SWITCH, (void**)&sai_switch_api);
     sai_api_query(SAI_API_VIRTUAL_ROUTER, (void**)&sai_virtual_router_api);
     sai_api_query(SAI_API_NEXT_HOP, (void**)&sai_next_hop_api);
+    sai_api_query(SAI_API_SRV6, (void**)&sai_srv6_api);
 
     uint32_t count = 3;
 
@@ -505,17 +515,23 @@ void test_bulk_route_set()
 
         ASSERT_SUCCESS("failed to create virtual router");
 
+        // sidlist object
+        sai_object_id_t sidlist;
+        sai_attribute_t sidattr[1] = { };
+        sidattr[0].id = SAI_SRV6_SIDLIST_ATTR_TYPE;
+        sidattr[0].value.s32 = SAI_SRV6_SIDLIST_TYPE_ENCAPS_RED;
+        status = sai_srv6_api->create_srv6_sidlist(&sidlist, switch_id, 1, sidattr);
         // next hop
         sai_object_id_t hop;
 
-        sai_attribute_t nhattr[3] = { };
+        sai_attribute_t nhattr[2] = { };
 
         nhattr[0].id = SAI_NEXT_HOP_ATTR_TYPE;
-        nhattr[0].value.s32 = SAI_NEXT_HOP_TYPE_SEGMENTROUTE_ENDPOINT;
-        nhattr[1].id = SAI_NEXT_HOP_ATTR_SEGMENTROUTE_ENDPOINT_TYPE;
-        nhattr[2].id = SAI_NEXT_HOP_ATTR_SEGMENTROUTE_ENDPOINT_POP_TYPE;
+        nhattr[0].value.s32 = SAI_NEXT_HOP_TYPE_SRV6_SIDLIST;
+        nhattr[1].id = SAI_NEXT_HOP_ATTR_SRV6_SIDLIST_ID;
+        nhattr[1].value.oid = sidlist;
 
-        status = sai_next_hop_api->create_next_hop(&hop, switch_id, 3, nhattr);
+        status = sai_next_hop_api->create_next_hop(&hop, switch_id, 2, nhattr);
 
         ASSERT_SUCCESS("failed to create next hop");
 

--- a/vslib/Makefile.am
+++ b/vslib/Makefile.am
@@ -95,7 +95,7 @@ libsaivs_la_SOURCES = \
 					  sai_vs_samplepacket.cpp \
 					  sai_vs_scheduler.cpp \
 					  sai_vs_schedulergroup.cpp \
-					  sai_vs_segmentroute.cpp \
+					  sai_vs_srv6.cpp \
 					  sai_vs_stp.cpp \
 					  sai_vs_switch.cpp \
 					  sai_vs_system_port.cpp \

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -982,6 +982,24 @@ sai_status_t VirtualSwitchSaiInterface::bulkRemove(
 
 sai_status_t VirtualSwitchSaiInterface::bulkRemove(
         _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkRemove(my_sid_entry->switch_id, SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, mode, object_statuses);
+}
+
+sai_status_t VirtualSwitchSaiInterface::bulkRemove(
+        _In_ uint32_t object_count,
         _In_ const sai_nat_entry_t *nat_entry,
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses)
@@ -1073,6 +1091,25 @@ sai_status_t VirtualSwitchSaiInterface::bulkSet(
     }
 
     return bulkSet(route_entry->switch_id, SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
+}
+
+sai_status_t VirtualSwitchSaiInterface::bulkSet(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t *my_sid_entry,
+        _In_ const sai_attribute_t *attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> serializedObjectIds;
+
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
+    }
+
+    return bulkSet(my_sid_entry->switch_id, SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
 }
 
 sai_status_t VirtualSwitchSaiInterface::bulkSet(
@@ -1274,6 +1311,35 @@ sai_status_t VirtualSwitchSaiInterface::bulkCreate(
     return bulkCreate(
             inseg_entry->switch_id,
             SAI_OBJECT_TYPE_INSEG_ENTRY,
+            serialized_object_ids,
+            attr_count,
+            attr_list,
+            mode,
+            object_statuses);
+}
+
+sai_status_t VirtualSwitchSaiInterface::bulkCreate(
+        _In_ uint32_t object_count,
+        _In_ const sai_my_sid_entry_t* my_sid_entry,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> serialized_object_ids;
+
+    // on create vid is put in db by syncd
+    for (uint32_t idx = 0; idx < object_count; idx++)
+    {
+        std::string str_object_id = sai_serialize_my_sid_entry(my_sid_entry[idx]);
+        serialized_object_ids.push_back(str_object_id);
+    }
+
+    return bulkCreate(
+            my_sid_entry->switch_id,
+            SAI_OBJECT_TYPE_MY_SID_ENTRY,
             serialized_object_ids,
             attr_count,
             attr_list,

--- a/vslib/sai_vs.h
+++ b/vslib/sai_vs.h
@@ -48,7 +48,7 @@ PRIVATE extern const sai_rpf_group_api_t        vs_rpf_group_api;
 PRIVATE extern const sai_samplepacket_api_t     vs_samplepacket_api;
 PRIVATE extern const sai_scheduler_api_t        vs_scheduler_api;
 PRIVATE extern const sai_scheduler_group_api_t  vs_scheduler_group_api;
-PRIVATE extern const sai_segmentroute_api_t     vs_segmentroute_api;
+PRIVATE extern const sai_srv6_api_t             vs_srv6_api;
 PRIVATE extern const sai_stp_api_t              vs_stp_api;
 PRIVATE extern const sai_switch_api_t           vs_switch_api;
 PRIVATE extern const sai_system_port_api_t      vs_system_port_api;

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -65,7 +65,7 @@ static sai_apis_t vs_apis = {
     API(mcast_fdb),
     API(bridge),
     API(tam),
-    API(segmentroute),
+    API(srv6),
     API(mpls),
     API(dtel),
     API(bfd),

--- a/vslib/sai_vs_srv6.cpp
+++ b/vslib/sai_vs_srv6.cpp
@@ -1,0 +1,20 @@
+#include "sai_vs.h"
+
+VS_BULK_CREATE(SRV6_SIDLIST,srv6_sidlists);
+VS_BULK_REMOVE(SRV6_SIDLIST,srv6_sidlists);
+
+VS_GENERIC_QUAD(SRV6_SIDLIST,srv6_sidlist);
+
+VS_GENERIC_QUAD_ENTRY(MY_SID_ENTRY, my_sid_entry);
+VS_BULK_QUAD_ENTRY(MY_SID_ENTRY, my_sid_entry);
+
+const sai_srv6_api_t vs_srv6_api = {
+
+    VS_GENERIC_QUAD_API(srv6_sidlist)
+
+    vs_bulk_create_srv6_sidlists,
+    vs_bulk_remove_srv6_sidlists,
+
+    VS_GENERIC_QUAD_API(my_sid_entry)
+    VS_BULK_QUAD_API(my_sid_entry)
+};


### PR DESCRIPTION
sairedis changes to support SAI SRV6 changes - opencomputeproject/SAI@2e934ff

Update SAI SEGMENTROUTE object to SAI SRV6 object
Serialize and deserialize APIs for SRV6 MY_SID_ENTRY object

These changes are needed to update Sonic SAI refpoint with SRV6 changes.

SAI refpoint with SRV6 update and this PR has to be merged together.