### PR TITLE
Query counters capabilities with new SAI API - master

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -886,6 +886,16 @@ sai_status_t ClientSai::getStats(
     return waitForGetStatsResponse(number_of_counters, counters);
 }
 
+sai_status_t ClientSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t ClientSai::waitForGetStatsResponse(
         _In_ uint32_t number_of_counters,
         _Out_ uint64_t *counters)

--- a/lib/ClientSai.h
+++ b/lib/ClientSai.h
@@ -97,6 +97,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/lib/ClientServerSai.cpp
+++ b/lib/ClientServerSai.cpp
@@ -247,6 +247,18 @@ sai_status_t ClientServerSai::getStats(
             counters);
 }
 
+sai_status_t ClientServerSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t ClientServerSai::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/lib/ClientServerSai.h
+++ b/lib/ClientServerSai.h
@@ -89,6 +89,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1125,6 +1125,16 @@ sai_status_t RedisRemoteSaiInterface::getStats(
     return waitForGetStatsResponse(number_of_counters, counters);
 }
 
+sai_status_t RedisRemoteSaiInterface::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t RedisRemoteSaiInterface::waitForGetStatsResponse(
         _In_ uint32_t number_of_counters,
         _Out_ uint64_t *counters)

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -108,6 +108,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -351,6 +351,16 @@ sai_status_t Sai::getStats(
             counters);
 }
 
+sai_status_t Sai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t Sai::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/lib/Sai.h
+++ b/lib/Sai.h
@@ -98,6 +98,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/lib/ServerSai.cpp
+++ b/lib/ServerSai.cpp
@@ -269,6 +269,16 @@ sai_status_t ServerSai::getStats(
             counters);
 }
 
+sai_status_t ServerSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t ServerSai::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/lib/ServerSai.h
+++ b/lib/ServerSai.h
@@ -94,6 +94,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -179,6 +179,16 @@ sai_status_t DummySaiInterface::getStats(
     return m_status;
 }
 
+sai_status_t DummySaiInterface::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t DummySaiInterface::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -98,6 +98,11 @@ namespace saimeta
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1870,6 +1870,16 @@ sai_status_t Meta::getStats(
     return status;
 }
 
+sai_status_t Meta::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t Meta::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1850,6 +1850,37 @@ sai_status_t Meta::meta_validate_stats(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t Meta::meta_validate_query_stats_capability(
+        _In_ sai_object_type_t object_type,
+        _In_ sai_object_id_t object_id)
+{
+    SWSS_LOG_ENTER();
+
+    PARAMETER_CHECK_OBJECT_TYPE_VALID(object_type);
+    PARAMETER_CHECK_OID_OBJECT_TYPE(object_id, object_type);
+    PARAMETER_CHECK_OID_EXISTS(object_id, object_type);
+
+    sai_object_id_t switch_id = switchIdQuery(object_id);
+
+    // checks also if object type is OID
+    sai_status_t status = meta_sai_validate_oid(object_type, &object_id, switch_id, false);
+
+    CHECK_STATUS_SUCCESS(status);
+
+    auto info = sai_metadata_get_object_type_info(object_type);
+
+    PARAMETER_CHECK_IF_NOT_NULL(info);
+
+    if (info->statenum == nullptr)
+    {
+        SWSS_LOG_ERROR("%s does not support stats", info->objecttypename);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t Meta::getStats(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,
@@ -1877,7 +1908,15 @@ sai_status_t Meta::queryStatsCapability(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    auto status = meta_validate_query_stats_capability(objectType, switchId);
+
+    CHECK_STATUS_SUCCESS(status);
+
+    status = m_implementation->queryStatsCapability(switchId, objectType, stats_capability);
+
+    // no post validation required
+
+    return status;
 }
 
 sai_status_t Meta::getStatsExt(

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -399,6 +399,10 @@ namespace saimeta
                     _Out_ uint64_t *counters,
                     _In_ sai_stats_mode_t mode);
 
+            sai_status_t meta_validate_query_stats_capability(
+                    _In_ sai_object_type_t object_type,
+                    _In_ sai_object_id_t object_id);
+
         private: // validate OID
 
             sai_status_t meta_sai_validate_oid(

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -105,6 +105,11 @@ namespace saimeta
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -194,6 +194,11 @@ namespace sairedis
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) = 0;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) = 0;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -185,7 +185,16 @@ namespace syncd
             bool isBufferPoolCounterSupported(
                     _In_ sai_buffer_pool_stat_t counter) const;
 
+            bool isStatsModeSupported(
+                    uint32_t statsMode, sai_stats_mode_t statCapability);
+
         private: // update supported counters
+
+            sai_status_t querySupportedPortCounters(
+                    sai_object_id_t portRid);
+
+            void getSupportedPortCounters(
+                    sai_object_id_t portRid);
 
             void updateSupportedPortCounters(
                     _In_ sai_object_id_t portRid);
@@ -194,17 +203,45 @@ namespace syncd
                     _In_ sai_object_id_t portRid,
                     _In_ const std::vector<sai_port_stat_t> &counterIds);
 
+            sai_status_t querySupportedQueueCounters(
+                    sai_object_id_t queueId);
+
+            void getSupportedQueueCounters(
+                    sai_object_id_t queueId, const std::vector<sai_queue_stat_t> &counterIds);
+
             void updateSupportedQueueCounters(
                     _In_ sai_object_id_t queueRid,
                     _In_ const std::vector<sai_queue_stat_t> &counterIds);
 
+            sai_status_t querySupportedRifCounters(
+                    sai_object_id_t rifRid);
+
+            void getSupportedRifCounters(
+                    sai_object_id_t rifRid);
+
             void updateSupportedRifCounters(
                     _In_ sai_object_id_t rifRid);
+
+            sai_status_t querySupportedBufferPoolCounters(
+                    sai_object_id_t bufferPoolId,
+                    sai_stats_mode_t statsMode);
+
+            void getSupportedBufferPoolCounters(
+                    sai_object_id_t bufferPoolId,
+                    const std::vector<sai_buffer_pool_stat_t> &counterIds,
+                    sai_stats_mode_t statsMode);
 
             void updateSupportedBufferPoolCounters(
                     _In_ sai_object_id_t bufferPoolRid,
                     _In_ const std::vector<sai_buffer_pool_stat_t> &counterIds,
                     _In_ sai_stats_mode_t statsMode);
+
+            sai_status_t querySupportedPriorityGroupCounters(
+                    sai_object_id_t priorityGroupRid);
+
+            void getSupportedPriorityGroupCounters(
+                    sai_object_id_t priorityGroupRid, 
+                    const std::vector<sai_ingress_priority_group_stat_t> &counterIds);
 
             void updateSupportedPriorityGroupCounters(
                     _In_ sai_object_id_t priorityGroupRid,

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -427,6 +427,21 @@ sai_status_t VendorSai::getStats(
     return ptr(object_id, number_of_counters, counter_ids, counters);
 }
 
+sai_status_t VendorSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    return sai_query_stats_capability(
+            switchId,
+            objectType,
+            stats_capability);
+}
+
 sai_status_t VendorSai::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -95,6 +95,11 @@ namespace syncd
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -471,9 +471,14 @@ sai_status_t Sai::queryStatsCapability(
         _In_ sai_object_type_t objectType,
         _Inout_ sai_stat_capability_list_t *stats_capability)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
+    VS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_meta->queryStatsCapability(
+            switchId,
+            objectType,
+            stats_capability);
 }
 
 sai_status_t Sai::getStatsExt(

--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -466,6 +466,16 @@ sai_status_t Sai::getStats(
             counters);
 }
 
+sai_status_t Sai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t Sai::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/vslib/Sai.h
+++ b/vslib/Sai.h
@@ -103,6 +103,11 @@ namespace saivs
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/vslib/SwitchState.cpp
+++ b/vslib/SwitchState.cpp
@@ -278,6 +278,35 @@ sai_status_t SwitchState::getStatsExt(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchState::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    auto info = sai_metadata_get_object_type_info(objectType);
+
+    if (stats_capability->count == 0 || stats_capability->list == nullptr)
+    {
+        stats_capability->count = (uint32_t)info->statenum->valuescount;
+        return SAI_STATUS_BUFFER_OVERFLOW;
+    }
+
+    SWSS_LOG_NOTICE("query counter capability for object ID %s of counter type %s",
+            sai_serialize_object_id(switchId).c_str(),
+            info->statenum->name);
+
+    auto statenumlist = info->statenum->values;
+
+    for (uint32_t i = 0; i < stats_capability->count; i++)
+    {
+        stats_capability->list[i].stat_enum = statenumlist[i];
+        stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR;
+    }
+    return SAI_STATUS_SUCCESS;
+}
+
 std::shared_ptr<saimeta::Meta> SwitchState::getMeta()
 {
     SWSS_LOG_ENTER();

--- a/vslib/SwitchState.h
+++ b/vslib/SwitchState.h
@@ -56,6 +56,11 @@ namespace saivs
                     _In_ sai_stats_mode_t mode,
                     _Out_ uint64_t *counters);
 
+            sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t objectType,
+                    _Inout_ sai_stat_capability_list_t *stats_capability);
+
         public:
 
             sai_object_id_t getSwitchId() const;

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -864,7 +864,36 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    sai_object_id_t switch_id = SAI_NULL_OBJECT_ID;
+
+    if (m_switchStateMap.size() == 0)
+    {
+        SWSS_LOG_ERROR("no switch!, was removed but some function still call");
+        return SAI_STATUS_FAILURE;
+    }
+
+    if (m_switchStateMap.size() == 1)
+    {
+        switch_id = m_switchStateMap.begin()->first;
+    }
+    else
+    {
+        SWSS_LOG_THROW("multiple switches not supported, FIXME");
+    }
+
+    if (m_switchStateMap.find(switch_id) == m_switchStateMap.end())
+    {
+        SWSS_LOG_ERROR("failed to find switch %s in switch state map", sai_serialize_object_id(switch_id).c_str());
+
+        return SAI_STATUS_FAILURE;
+    }
+
+    auto ss = m_switchStateMap.at(switch_id);
+
+    return ss->queryStatsCapability(
+            switchId,
+            objectType,
+            stats_capability);
 }
 
 sai_status_t VirtualSwitchSaiInterface::getStatsExt(

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -857,6 +857,16 @@ sai_status_t VirtualSwitchSaiInterface::getStats(
             counters);
 }
 
+sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t VirtualSwitchSaiInterface::getStatsExt(
         _In_ sai_object_type_t object_type,
         _In_ sai_object_id_t object_id,

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -102,6 +102,11 @@ namespace saivs
                     _In_ const sai_stat_id_t *counter_ids,
                     _Out_ uint64_t *counters) override;
 
+            virtual sai_status_t queryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t *stats_capability) override;
+
             virtual sai_status_t getStatsExt(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -188,5 +188,5 @@ sai_status_t sai_query_stats_capability(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return vs_sai->queryStatsCapability(switch_id, object_type, stats_capability);
 }

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -180,3 +180,13 @@ sai_object_id_t sai_switch_id_query(
 
     return vs_sai->switchIdQuery(objectId);
 }
+
+sai_status_t sai_query_stats_capability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton shlomibi@nvidia.com

Implement new SAI API to query counters capabilities.
This API is used to get the capabilities in a way which is not accessing the HW and performs much quicker.
New API introduced on this PR: opencomputeproject/SAI#1148