### PR TITLE
[vslib]: Skip to create tap interface if the KVM interface isn't enabled

### DIFF
--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -455,6 +455,8 @@ namespace saivs
                     _In_ const char*name,
                     _In_ int mtu);
 
+            bool ifexists(const char *dev);
+
             int ifup(
                     _In_ const char *dev,
                     _In_ sai_object_id_t port_id,


### PR DESCRIPTION
This PR https://github.com/Azure/sonic-sairedis/pull/923/files fixed the return value of `ifup`, but it introduces a new bug. If the SONiC KVM didn't enable full 32 ports.
Here is the qemu xml example that only enables two interfaces.
![image](https://user-images.githubusercontent.com/18609639/133824854-03f03f94-e71b-4bef-9349-5762efeb9dd1.png)

The SWSS will exit with an unexpected error as follow
![image](https://user-images.githubusercontent.com/18609639/133825053-c94a417f-a7e8-444b-b5bf-fef36786b5d8.png)
![image](https://user-images.githubusercontent.com/18609639/133825071-e810a4cd-3106-4c23-b55e-c983b6f6d2b5.png)

So, I add a new function `ifexists` to check whether the target interface of KVM has been enabled, I will skip to create the tap interface if the target interface wasn't enabled.

Signed-off-by: Ze Gan <ganze718@gmail.com>