### PR TITLE
[vslib]: Remove invalid lane when create ports

### DIFF
--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1123,43 +1123,11 @@ sai_status_t SwitchStateBase::create_ports()
 
     auto lanesVector = map->getLaneVector();
 
-    if (m_useTapDevice)
+    if (m_switchConfig->m_useTapDevice)
     {
         SWSS_LOG_DEBUG("Check available lane");
 
-        auto lanes = lanesVector.begin();
-        while (lanes != lanesVector.end())
-        {
-            bool available_lane = false;
-
-            for (auto lane: *lanes)
-            {
-                std::string ifname = map->getInterfaceFromLaneNumber(lane);
-                std::string path = std::string("/sys/class/net/") + ifname + "/operstate";
-
-                if (access(path.c_str(), F_OK) != 0)
-                {
-                    SWSS_LOG_WARN("Port %s isn't available", ifname.c_str());
-
-                    available_lane &= false;
-
-                    break;
-                }
-                else
-                {
-                    available_lane = true;
-                }
-            }
-
-            if (!available_lane)
-            {
-                lanes = lanesVector.erase(lanes);
-            }
-            else
-            {
-                lanes++;
-            }
-        }
+        CHECK_STATUS(filter_available_lanes(lanesVector));
     }
 
     uint32_t port_count = (uint32_t)lanesVector.size();
@@ -2974,6 +2942,49 @@ sai_status_t SwitchStateBase::initialize_voq_switch_objects(
         CHECK_STATUS(create_fabric_ports());
 
         CHECK_STATUS(set_fabric_port_list());
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::filter_available_lanes(
+                    _Inout_ std::vector<std::vector<uint32_t>> &lanes_vector)
+{
+    SWSS_LOG_ENTER();
+
+    auto lanes = lanes_vector.begin();
+
+    while (lanes != lanes_vector.end())
+    {
+        bool available_lane = false;
+
+        for (auto lane: *lanes)
+        {
+            std::string ifname = m_switchConfig->m_laneMap->getInterfaceFromLaneNumber(lane);
+            std::string path = std::string("/sys/class/net/") + ifname + "/operstate";
+
+            if (access(path.c_str(), F_OK) != 0)
+            {
+                SWSS_LOG_WARN("Port %s isn't available", ifname.c_str());
+
+                available_lane &= false;
+
+                break;
+            }
+            else
+            {
+                available_lane = true;
+            }
+        }
+
+        if (!available_lane)
+        {
+            lanes = lanes_vector.erase(lanes);
+        }
+        else
+        {
+            lanes++;
+        }
     }
 
     return SAI_STATUS_SUCCESS;

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -98,6 +98,9 @@ namespace saivs
                     _In_ sai_switch_attr_t acl_resource,
                     _In_ int max_count);
 
+            sai_status_t filter_available_lanes(
+                    _Inout_ std::vector<std::vector<uint32_t>> &lanes_vector);
+
             sai_status_t create_system_ports(
                     _In_ int32_t voq_switch_id,
                     _In_ uint32_t sys_port_count,


### PR DESCRIPTION
To make the virtual SAI supports partial ports enabled.

Here is the qemu xml example that only enables two interfaces.
![image](https://user-images.githubusercontent.com/18609639/133824854-03f03f94-e71b-4bef-9349-5762efeb9dd1.png)

The SWSS will exit with an unexpected error as follow
![image](https://user-images.githubusercontent.com/18609639/133825053-c94a417f-a7e8-444b-b5bf-fef36786b5d8.png)
![image](https://user-images.githubusercontent.com/18609639/133825071-e810a4cd-3106-4c23-b55e-c983b6f6d2b5.png)

I check the availability of eth-x ports at creating port.

Signed-off-by: Ze Gan <ganze718@gmail.com>
