### PR TITLE
[syncd] Fix SwitchNotifications to be const reference

### DIFF
--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -5,7 +5,7 @@
 using namespace syncd;
 
 SwitchNotifications::SlotBase::SlotBase(
-        _In_ sai_switch_notifications_t sn):
+        _In_ const sai_switch_notifications_t& sn):
     m_handler(nullptr),
     m_sn(sn)
 {

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -20,7 +20,7 @@ namespace syncd
                 public:
 
                     SlotBase(
-                            _In_ sai_switch_notifications_t sn);
+                            _In_ const sai_switch_notifications_t& sn);
 
                     virtual ~SlotBase();
 


### PR DESCRIPTION
To satisfy LGTM alert and for performance reasons to
skip making unnecessary copy of struct.