### PR TITLE
Updating keyserver and libhiredis package version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ that puts SAI objects into the redis database, 2) a syncd that takes the SAI obj
 
 Before installing, add key and package sources:
 
-    sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
     echo 'deb http://apt-mo.trafficmanager.net/repos/sonic/ trusty main' | sudo tee -a /etc/apt/sources.list.d/sonic.list
     sudo apt-get update
 
 Install dependencies:
 
     sudo apt-get install redis-server -t trusty
-    sudo apt-get install libhiredis0.13 -t trusty
+    sudo apt-get install libhiredis0.14 -t trusty
 
 Install building dependencies:
 


### PR DESCRIPTION
Updated keyserver to "hkp://keyserver.ubuntu.com:80" and apt packager libhiredis version to 0.14
Resolve [Issue-958](https://github.com/Azure/sonic-sairedis/issues/958)
Kindly review @kcudnik 