### PR TITLE
Prevent other notification event storms to keep enqueue unchecked and drained all memory that leads to crashing the switch router

### DIFF
--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -45,7 +45,7 @@ bool NotificationQueue::enqueue(
      * We have also seen other notification storms that can also cause this queue issue
      * So the new scheme is to keep the last notification event and its consecutive count
      * If threshold limit reached and the consecutive count also reached then this notification
-     * will also be dropped regardless of its event type to protect us from crashing due to
+     * will also be dropped regardless of its event type to protect the device from crashing due to
      * running out of memory
      */
     auto queueSize = m_queue.size();

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -30,11 +30,11 @@ NotificationQueue::~NotificationQueue()
 bool NotificationQueue::enqueue(
         _In_ const swss::KeyOpFieldsValuesTuple& item)
 {
-    bool candidateToDrop = false;
-    std::string currentEvent;
     MUTEX;
 
     SWSS_LOG_ENTER();
+    bool candidateToDrop = false;
+    std::string currentEvent;
 
     /*
      * If the queue exceeds the limit, then drop all further FDB events This is

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -44,7 +44,7 @@ bool NotificationQueue::enqueue(
      *
      * We have also seen other notification storms that can also cause this emqueue issue
      * So the new scheme is to keep the last notification event and its consecutive count
-     * If threashold limit reached and the consecutive count also reached then this notification
+     * If threshold limit reached and the consecutive count also reached then this notification
      * will also be dropped regardless of its event type to protect us from crashing due to
      * running out of memory
      */
@@ -63,7 +63,7 @@ bool NotificationQueue::enqueue(
     {
         /* Too many queued up already check if notification fits condition to e dropped
          * 1. All FDB events should be dropped at this point.
-         * 2. All other notification events will start to drop if it reached the consecutive threashold limit
+         * 2. All other notification events will start to drop if it reached the consecutive threshold limit
          */
         if (currentEvent == SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
         {

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -42,7 +42,7 @@ bool NotificationQueue::enqueue(
      * notification queue keeps growing. The permanent solution would be to
      * make this stateful so that only the *latest* event is published.
      *
-     * We have also seen other notification storms that can also cause this enqueue issue
+     * We have also seen other notification storms that can also cause this queue issue
      * So the new scheme is to keep the last notification event and its consecutive count
      * If threshold limit reached and the consecutive count also reached then this notification
      * will also be dropped regardless of its event type to protect us from crashing due to

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -2,15 +2,16 @@
 #include "sairediscommon.h"
 
 #define NOTIFICATION_QUEUE_DROP_COUNT_INDICATOR (1000)
-#define DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD (1000)
 
 using namespace syncd;
 
 #define MUTEX std::lock_guard<std::mutex> _lock(m_mutex);
 
 NotificationQueue::NotificationQueue(
-        _In_ size_t queueLimit):
+        _In_ size_t queueLimit,
+        _In_ size_t consecutiveThresholdLimit):
     m_queueSizeLimit(queueLimit),
+    m_thresholdLimit(consecutiveThresholdLimit),
     m_dropCount(0),
     m_lastEventCount(0),
     m_lastEvent(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
@@ -71,7 +72,7 @@ bool NotificationQueue::enqueue(
         }
         else
         {
-            if (m_lastEventCount >= DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD)
+            if (m_lastEventCount >= m_thresholdLimit)
             {
                 candidateToDrop = true;
             }

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -42,7 +42,7 @@ bool NotificationQueue::enqueue(
      * notification queue keeps growing. The permanent solution would be to
      * make this stateful so that only the *latest* event is published.
      *
-     * We have also seen other notification storms that can also cause this emqueue issue
+     * We have also seen other notification storms that can also cause this enqueue issue
      * So the new scheme is to keep the last notification event and its consecutive count
      * If threshold limit reached and the consecutive count also reached then this notification
      * will also be dropped regardless of its event type to protect us from crashing due to

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -17,9 +17,9 @@ extern "C" {
  * some extra buffer for other events like port-state, q-deadlock etc
  *
  * Note: We recently found a case where SAI continuously sending switch notification events
- *       that also caused the enqueue to eventually exhaust all system memory and crashed.
- *       So a new detection/limit scheme is being implemented by keeping track of the lastEvent
- *       and if the currentEvent matches the lastEvent, then the lastEventCount will get
+ *       that also caused the queue to keep growing and eventually exhaust all system memory and crashed.
+ *       So a new detection/limit scheme is being implemented by keeping track of the last Event
+ *       and if the current Event matches the last Event, then the last Event Count will get
  *       incremented and this count will also be used as part of the equation to ensure this
  *       notification should also be dropped if the queue size limit has already reached and not
  *       just dropping FDB events only.

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -16,6 +16,13 @@ extern "C" {
  * Value based on typical L2 deployment with 256k MAC entries and
  * some extra buffer for other events like port-state, q-deadlock etc
  *
+ * Note: We recently found a case where SAI continuously sending switchnotification events
+ *       that also caused the enqueue to eventually exhaust all system memory and crashed.
+ *       So a new detection/limit scheme is being implemented by keeping track of the lastEvent
+ *       and if the currentEvent matches the lastEvent, then the lastEventCount will get
+ *       incremented and this count will also be used as part of the equation to ensure this
+ *       notification should also be dropped if the queue size limit has already reached and not
+ *       just dropping FDB events only.
  * TODO: move to config, also this limit only applies to fdb notifications
  */
 #define DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT (300000)
@@ -50,5 +57,9 @@ namespace syncd
             size_t m_queueSizeLimit;
 
             size_t m_dropCount;
+
+            size_t m_lastEventCount;
+
+            std::string m_lastEvent;
     };
 }

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -26,6 +26,7 @@ extern "C" {
  * TODO: move to config, also this limit only applies to fdb notifications
  */
 #define DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT (300000)
+#define DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD (1000)
 
 namespace syncd
 {
@@ -34,7 +35,8 @@ namespace syncd
         public:
 
             NotificationQueue(
-                    _In_ size_t limit = DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT);
+                    _In_ size_t limit = DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT,
+                    _In_ size_t consecutiveThresholdLimit = DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD);
 
             virtual ~NotificationQueue();
 
@@ -55,6 +57,8 @@ namespace syncd
             std::queue<swss::KeyOpFieldsValuesTuple> m_queue;
 
             size_t m_queueSizeLimit;
+
+            size_t m_thresholdLimit;
 
             size_t m_dropCount;
 

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -16,7 +16,7 @@ extern "C" {
  * Value based on typical L2 deployment with 256k MAC entries and
  * some extra buffer for other events like port-state, q-deadlock etc
  *
- * Note: We recently found a case where SAI continuously sending switchnotification events
+ * Note: We recently found a case where SAI continuously sending switch notification events
  *       that also caused the enqueue to eventually exhaust all system memory and crashed.
  *       So a new detection/limit scheme is being implemented by keeping track of the lastEvent
  *       and if the currentEvent matches the lastEvent, then the lastEventCount will get

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -9,7 +9,8 @@ tests_SOURCES = main.cpp \
                 MockableSaiInterface.cpp \
                 MockHelper.cpp \
 				TestCommandLineOptions.cpp \
-				TestFlexCounter.cpp
+				TestFlexCounter.cpp \
+				TestNotificationQueue.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/syncd/libSyncd.a -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/lib/.libs -lsairedis -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)

--- a/unittest/syncd/TestNotificationQueue.cpp
+++ b/unittest/syncd/TestNotificationQueue.cpp
@@ -1,0 +1,68 @@
+#include "NotificationQueue.h"
+
+#include "sairediscommon.h"
+
+#include <gtest/gtest.h>
+
+using namespace syncd;
+
+static std::string fdbData =
+"[{\"fdb_entry\":\"{\\\"bvid\\\":\\\"oid:0x260000000005be\\\",\\\"mac\\\":\\\"52:54:00:86:DD:7A\\\",\\\"switch_id\\\":\\\"oid:0x21000000000000\\\"}\","
+"\"fdb_event\":\"SAI_FDB_EVENT_LEARNED\","
+"\"list\":[{\"id\":\"SAI_FDB_ENTRY_ATTR_TYPE\",\"value\":\"SAI_FDB_ENTRY_TYPE_DYNAMIC\"},{\"id\":\"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID\",\"value\":\"oid:0x3a000000000660\"}]}]";
+
+static std::string sscData = "{\"status\":\"SAI_SWITCH_OPER_STATUS_UP\",\"switch_id\":\"oid:0x2100000000\"}";
+
+TEST(NotificationQueue, EnqueueLimitTest)
+{
+    bool status;
+    int i;
+    std::vector<swss::FieldValueTuple> fdbEntry;
+    std::vector<swss::FieldValueTuple> sscEntry;
+
+    // Set up a queue with limit at 5 and threshold at 3 where after this is reached event starts dropping
+    syncd::NotificationQueue testQ(5, 3); 
+
+    // Try enqueue 4 fake FDB event and expect themto be added successully
+    swss::KeyOpFieldsValuesTuple fdbItem(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, fdbData, fdbEntry);
+    for (i = 0; i < 4; ++i)
+    {
+        status = testQ.enqueue(fdbItem);
+        EXPECT_EQ(status, true);
+    }
+
+    // On the 5th fake FDB event enqueue expect it to be dropped right away
+    status = testQ.enqueue(fdbItem);
+    EXPECT_EQ(status, false);
+
+    // Add 2 switch state change events expect both are accepted as consecutive lmit not yet reached
+    swss::KeyOpFieldsValuesTuple sscItem(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_STATE_CHANGE, sscData, sscEntry);
+    for (i = 0; i < 2; ++i)
+    {
+        status = testQ.enqueue(sscItem);
+        EXPECT_EQ(status, true);
+    }
+
+    // On the 3rd consecutive switch state change event expect it to be dropped
+    status = testQ.enqueue(sscItem);
+    EXPECT_EQ(status, false);
+
+    // Add a fake FDB event to cause the consecutive event signature to change while this FDB event is dropped
+    status = testQ.enqueue(fdbItem);
+    EXPECT_EQ(status, false);
+
+    // Add 2 switch state change events expect both are accepted as consecutive lmit not yet reached
+    for (i = 0; i < 2; ++i)
+    {
+        status = testQ.enqueue(sscItem);
+        EXPECT_EQ(status, true);
+    }
+
+    // Add 2 switch state change events expect both are dropped as consecutive lmit has already reached
+    for (i = 0; i < 2; ++i)
+    {
+        status = testQ.enqueue(sscItem);
+        EXPECT_EQ(status, false);
+    }
+}
+

--- a/unittest/syncd/TestNotificationQueue.cpp
+++ b/unittest/syncd/TestNotificationQueue.cpp
@@ -23,15 +23,15 @@ TEST(NotificationQueue, EnqueueLimitTest)
     // Set up a queue with limit at 5 and threshold at 3 where after this is reached event starts dropping
     syncd::NotificationQueue testQ(5, 3);
 
-    // Try queue up 4 fake FDB event and expect them to be added successfully
+    // Try queue up 5 fake FDB event and expect them to be added successfully
     swss::KeyOpFieldsValuesTuple fdbItem(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, fdbData, fdbEntry);
-    for (i = 0; i < 4; ++i)
+    for (i = 0; i < 5; ++i)
     {
         status = testQ.enqueue(fdbItem);
         EXPECT_EQ(status, true);
     }
 
-    // On the 5th fake FDB event expect it to be dropped right away
+    // On the 6th fake FDB event expect it to be dropped right away
     status = testQ.enqueue(fdbItem);
     EXPECT_EQ(status, false);
 

--- a/unittest/syncd/TestNotificationQueue.cpp
+++ b/unittest/syncd/TestNotificationQueue.cpp
@@ -21,9 +21,9 @@ TEST(NotificationQueue, EnqueueLimitTest)
     std::vector<swss::FieldValueTuple> sscEntry;
 
     // Set up a queue with limit at 5 and threshold at 3 where after this is reached event starts dropping
-    syncd::NotificationQueue testQ(5, 3); 
+    syncd::NotificationQueue testQ(5, 3);
 
-    // Try enqueue 4 fake FDB event and expect themto be added successully
+    // Try queue up 4 fake FDB event and expect them to be added successfully
     swss::KeyOpFieldsValuesTuple fdbItem(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, fdbData, fdbEntry);
     for (i = 0; i < 4; ++i)
     {
@@ -31,11 +31,11 @@ TEST(NotificationQueue, EnqueueLimitTest)
         EXPECT_EQ(status, true);
     }
 
-    // On the 5th fake FDB event enqueue expect it to be dropped right away
+    // On the 5th fake FDB event expect it to be dropped right away
     status = testQ.enqueue(fdbItem);
     EXPECT_EQ(status, false);
 
-    // Add 2 switch state change events expect both are accepted as consecutive lmit not yet reached
+    // Add 2 switch state change events expect both are accepted as consecutive limit not yet reached
     swss::KeyOpFieldsValuesTuple sscItem(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_STATE_CHANGE, sscData, sscEntry);
     for (i = 0; i < 2; ++i)
     {
@@ -51,14 +51,14 @@ TEST(NotificationQueue, EnqueueLimitTest)
     status = testQ.enqueue(fdbItem);
     EXPECT_EQ(status, false);
 
-    // Add 2 switch state change events expect both are accepted as consecutive lmit not yet reached
+    // Add 2 switch state change events expect both are accepted as consecutive limit not yet reached
     for (i = 0; i < 2; ++i)
     {
         status = testQ.enqueue(sscItem);
         EXPECT_EQ(status, true);
     }
 
-    // Add 2 switch state change events expect both are dropped as consecutive lmit has already reached
+    // Add 2 switch state change events expect both are dropped as consecutive limit has already reached
     for (i = 0; i < 2; ++i)
     {
         status = testQ.enqueue(sscItem);


### PR DESCRIPTION
Recently in one of the production device we encountered a switch ran out of memory and crashed due to there were too many switch state event such as the following due to many multi bit ECC errors:
```

2021-11-06.18:20:10.251799|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.251845|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252289|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252359|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252406|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252460|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252841|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252917|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252974|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253020|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253074|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253466|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253519|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253574|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253620|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253674|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254067|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254119|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254197|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254243|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254768|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254871|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254916|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254961|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255112|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255164|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255209|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255254|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255298|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255342|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
```
this created a notification storm that eventually all get queued to be serviced by SONiC but SONiC was not able to keep up with the incoming enqueue rate so it eventualy used up all the system memory and crashed...
A previous fix was in place to prevent this if the event was FDB event.  But that one was specifically for FDB events and did not catch this case so the switch still crashed...

This PR is raised to address this issue by adding additional logic to also prevent other event types to create a storm and overwhelm SONiC.
The enhancement is to save the last event type and keep a count for having consecutively received this same event type.  if a different event type is received, the count will go back to 1 and get counted from there.
If it ever get into the situation where the switch already exceeded the enqueue threshold (due to the storm) and has over 1000 consecutive notification of this same type, then it will also be dropped regardless of the event type.  
The original FDB event case handling is still kept the same way as before so that as soon as the queue reached its threshold, any new FDB events will be dropped regardless of the consecutive count.

I have tested this on a switch to ensure that the new logic works fine with FDB events or other events.

this PR should be back ported to the following branches:
20201230
20210630
20191130
20181130