### PR TITLE
Fix hung issue when installing linux kernel modules

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -48,6 +48,8 @@ function build_and_install_kmodule()
     grep NET_TEAM .config.bk >> .config
     echo CONFIG_NET_VRF=m >> .config
     echo CONFIG_MACSEC=m >> .config
+    echo CONFIG_NET_VENDOR_MICROSOFT=y >> .config
+    echo CONFIG_MICROSOFT_MANA=m >> .config
     echo CONFIG_SYSTEM_REVOCATION_LIST=n >> .config
     make VERSION=$VERSION PATCHLEVEL=$PATCHLEVEL SUBLEVEL=$SUBLEVEL EXTRAVERSION=-${EXTRAVERSION} LOCALVERSION=-${LOCALVERSION} modules_prepare
     make M=drivers/net/team


### PR DESCRIPTION
Fix the timeout issue when running the "install dependencies" step.
See https://dev.azure.com/mssonic/build/_build/results?buildId=51240&view=logs&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e&j=3f6395b2-1619-5ebe-f305-2aedcf353cb5

Make the script .azure-pipelines/build_and_install_module.sh the same as https://github.com/Azure/sonic-utilities/blob/master/.azure-pipelines/build_and_install_module.sh