### PR TITLE
[202012] Add ACL_TABLE object to break before make list

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -95,6 +95,9 @@ config_syncd_bcm()
         CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
     fi
 
+    echo "SAI_OBJECT_TYPE_ACL_TABLE" >> /break_before_make_objects
+    CMD_ARGS += " -b /break_before_make_objects"
+
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0
     [ -e /dev/linux-user-bde ] || mknod /dev/linux-user-bde c 126 0
     [ -e /dev/linux-kernel-bde ] || mknod /dev/linux-kernel-bde c 127 0

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -95,8 +95,8 @@ config_syncd_bcm()
         CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
     fi
 
-    echo "SAI_OBJECT_TYPE_ACL_TABLE" >> /break_before_make_objects
-    CMD_ARGS += " -b /break_before_make_objects"
+    echo "SAI_OBJECT_TYPE_ACL_TABLE" >> /tmp/break_before_make_objects
+    CMD_ARGS+=" -b /tmp/break_before_make_objects"
 
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0
     [ -e /dev/linux-user-bde ] || mknod /dev/linux-user-bde c 126 0


### PR DESCRIPTION
Cherry-picked https://github.com/Azure/sonic-sairedis/pull/970

Changes to add ACL_TABLE object to break-before-make list of objects during warm-reboot. This is done specifically for broadcom platforms where make-before-break approach results in insufficient resource error during ACL_TABLE creation, if old ACL__TABLEs are not deleted first.

Issue was observed during warm-reboot from 201811 to 202012