### PR TITLE
[202106] Prevent other notification event storms to keep enqueue unchecked and drained all memory that leads to crashing the switch router

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -16,6 +16,9 @@ extraction:
       - dh-exec
       - libzmq3-dev
       - libzmq5
+      - autoconf-archive
+      - libgtest-dev
+      - libgmock-dev
     after_prepare:
       - ls -l
       - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -8,9 +8,13 @@ using namespace syncd;
 #define MUTEX std::lock_guard<std::mutex> _lock(m_mutex);
 
 NotificationQueue::NotificationQueue(
-        _In_ size_t queueLimit):
+        _In_ size_t queueLimit,
+        _In_ size_t consecutiveThresholdLimit):
     m_queueSizeLimit(queueLimit),
-    m_dropCount(0)
+    m_thresholdLimit(consecutiveThresholdLimit),
+    m_dropCount(0),
+    m_lastEventCount(0),
+    m_lastEvent(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
 {
     SWSS_LOG_ENTER();
 
@@ -30,16 +34,52 @@ bool NotificationQueue::enqueue(
     MUTEX;
 
     SWSS_LOG_ENTER();
+    bool candidateToDrop = false;
+    std::string currentEvent;
 
     /*
      * If the queue exceeds the limit, then drop all further FDB events This is
      * a temporary solution to handle high memory usage by syncd and the
      * notification queue keeps growing. The permanent solution would be to
      * make this stateful so that only the *latest* event is published.
+     *
+     * We have also seen other notification storms that can also cause this queue issue
+     * So the new scheme is to keep the last notification event and its consecutive count
+     * If threshold limit reached and the consecutive count also reached then this notification
+     * will also be dropped regardless of its event type to protect the device from crashing due to
+     * running out of memory
      */
     auto queueSize = m_queue.size();
+    currentEvent = kfvKey(item);
+    if (currentEvent == m_lastEvent)
+    {
+        m_lastEventCount++;
+    }
+    else
+    {
+        m_lastEventCount = 1;
+        m_lastEvent = currentEvent;
+    }
+    if (queueSize >= m_queueSizeLimit)
+    {
+        /* Too many queued up already check if notification fits condition to be dropped
+         * 1. All FDB events should be dropped at this point.
+         * 2. All other notification events will start to drop if it reached the consecutive threshold limit
+         */
+        if (currentEvent == SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
+        {
+            candidateToDrop = true;
+        }
+        else
+        {
+            if (m_lastEventCount >= m_thresholdLimit)
+            {
+                candidateToDrop = true;
+            }
+        }
+    }
 
-    if (queueSize < m_queueSizeLimit || kfvOp(item) != SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT) // TODO use enum instead of strings
+    if (!candidateToDrop)
     {
         m_queue.push(item);
 
@@ -51,9 +91,9 @@ bool NotificationQueue::enqueue(
     if (!(m_dropCount % NOTIFICATION_QUEUE_DROP_COUNT_INDICATOR))
     {
         SWSS_LOG_NOTICE(
-                "Too many messages in queue (%zu), dropped %zu FDB events!",
+                "Too many messages in queue (%zu), dropped (%zu), lastEventCount (%zu) Dropping %s !",
                 queueSize,
-                m_dropCount);
+                m_dropCount, m_lastEventCount, m_lastEvent.c_str());
     }
 
     return false;

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -15,9 +15,18 @@ extern "C" {
  * Value based on typical L2 deployment with 256k MAC entries and
  * some extra buffer for other events like port-state, q-deadlock etc
  *
+ * Note: We recently found a case where SAI continuously sending switch notification events
+ *       that also caused the queue to keep growing and eventually exhaust all system memory and crashed.
+ *       So a new detection/limit scheme is being implemented by keeping track of the last Event
+ *       and if the current Event matches the last Event, then the last Event Count will get
+ *       incremented and this count will also be used as part of the equation to ensure this
+ *       notification should also be dropped if the queue size limit has already reached and not
+ *       just dropping FDB events only.
+ *
  * TODO: move to config, also this limit only applies to fdb notifications
  */
 #define DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT (300000)
+#define DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD (1000)
 
 namespace syncd
 {
@@ -26,7 +35,8 @@ namespace syncd
         public:
 
             NotificationQueue(
-                    _In_ size_t limit = DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT);
+                    _In_ size_t limit = DEFAULT_NOTIFICATION_QUEUE_SIZE_LIMIT,
+                    _In_ size_t consecutiveThresholdLimit = DEFAULT_NOTIFICATION_CONSECUTIVE_THRESHOLD);
 
             virtual ~NotificationQueue();
 
@@ -48,6 +58,12 @@ namespace syncd
 
             size_t m_queueSizeLimit;
 
+            size_t m_thresholdLimit;
+
             size_t m_dropCount;
+
+            size_t m_lastEventCount;
+
+            std::string m_lastEvent;
     };
 }


### PR DESCRIPTION
This is to backport the fix made in master branch (https://github.com/Azure/sonic-sairedis/pull/968) to 202106 branch since it could not be cherry picked.

Copying the same info from above PR that we are back porting to this branch here for clarity of what the issue was about and how we are fixing it:

Recently in one of the production devices we encountered a switch ran out of memory and crashed due to there were too many switch state event such as the following due to many multi bit ECC errors:
```

2021-11-06.18:20:10.251799|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.251845|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252289|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252359|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252406|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252460|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252841|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252917|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252974|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253020|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253074|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253466|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253519|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253574|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253620|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253674|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254067|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254119|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254197|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254243|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254768|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254871|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254916|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254961|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255112|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255164|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255209|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255254|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255298|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255342|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
```
this created a notification storm that eventually all get queued to be serviced by SONiC but SONiC was not able to keep up with the incoming enqueue rate, so it eventually used up all the system memory and crashed...
A previous fix was in place to prevent this if the event was FDB event.  But that one was specifically for FDB events and did not catch this case, so the switch still crashed...

This PR is raised to address this issue by adding additional logic to also prevent other event types to create a storm and overwhelm SONiC.
The enhancement is to save the last event type and keep a count for having consecutively received this same event type.  if a different event type is received, the count will go back to 1 and get counted from there.
If it ever gets into the situation where the switch already exceeded the enqueue threshold (due to the storm) and has over 1000 consecutive notification of this same type, then it will also be dropped regardless of the event type.  
The original FDB event case handling is still kept the same way as before so that as soon as the queue reached its threshold, any new FDB events will be dropped regardless of the consecutive count.

I have tested this on a switch to ensure that the new logic works fine with FDB events or other events.  The testing was done on Master branch only since it is the same code back porting to 202106.

