### PR TITLE
[201911] Prevent other notification event storms to keep enqueue unchecked and drained all memory that leads to crashing the switch router

### DIFF
--- a/syncd/syncd_notifications.cpp
+++ b/syncd/syncd_notifications.cpp
@@ -669,6 +669,9 @@ private:
      * some extra buffer for other events like port-state, q-deadlock etc
      */
     const size_t limit = 300000;
+    const size_t m_thresholdLimit = 1000;
+    size_t m_lastEventCount = 0;
+    std::string m_lastEvent = "fdb_event";
 };
 
 
@@ -704,7 +707,7 @@ bool ntf_queue_t::enqueue(
         _In_ swss::KeyOpFieldsValuesTuple item)
 {
     SWSS_LOG_ENTER();
-
+    bool candidateToDrop = false;
     std::string notification = kfvKey(item);
 
     /*
@@ -712,9 +715,45 @@ bool ntf_queue_t::enqueue(
      * a temporary solution to handle high memory usage by syncd and the
      * notification queue keeps growing. The permanent solution would be to
      * make this stateful so that only the *latest* event is published.
+     *
+     * We have also seen other notification storms that can also cause this queue issue
+     * So the new scheme is to keep the last notification event and its consecutive count
+     * If threshold limit reached and the consecutive count also reached then this notification
+     * will also be dropped regardless of its event type to protect the device from crashing due to
+     * running out of memory
      */
 
-    if (queueStats() < limit || notification != "fdb_event")
+    auto queueSize = queueStats();
+
+    if (notification == m_lastEvent)
+    {
+        m_lastEventCount++;
+    }
+    else
+    {
+        m_lastEventCount = 1;
+        m_lastEvent = notification;
+    }
+    if (queueSize >= limit)
+    {
+        /* Too many queued up already check if notification fits condition to be dropped
+         * 1. All FDB events should be dropped at this point.
+         * 2. All other notification events will start to drop if it reached the consecutive threshold limit
+         */
+        if (notification == "fdb_event")
+        {
+            candidateToDrop = true;
+        }
+        else
+        {
+            if (m_lastEventCount >= m_thresholdLimit)
+            {
+                candidateToDrop = true;
+            }
+        }
+    }
+
+    if (!candidateToDrop)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
 
@@ -726,8 +765,10 @@ bool ntf_queue_t::enqueue(
 
     if (!(log_count % 1000))
     {
-        SWSS_LOG_NOTICE("Too many messages in queue (%zu), dropped %u FDB events!",
-                         queueStats(), (log_count+1));
+        SWSS_LOG_NOTICE(
+                "Too many messages in queue (%zu), dropped (%zu), lastEventCount (%zu) Dropping %s !",
+                queueSize,
+                (log_count+1), m_lastEventCount, m_lastEvent.c_str());
     }
 
     ++log_count;


### PR DESCRIPTION
This is to backport the fix made in master branch (https://github.com/Azure/sonic-sairedis/pull/968) to 201911 branch since it could not be cherry picked.

Note: 201911 SYNCD notification queueing implementation is slightly different from 20201230 and above branches so minor changes were made in this PR to accommodate the 20191130 notification queuing code.

Copying the same info from above PR that we are back porting to this branch here for clarity of what the issue was about and how we are fixing it:

Recently in one of the production devices we encountered a switch ran out of memory and crashed due to there were too many switch state event such as the following due to many multi bit ECC errors:
```

2021-11-06.18:20:10.251799|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.251845|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252289|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252359|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252406|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252460|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252841|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252917|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.252974|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253020|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253074|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253466|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253519|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253574|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253620|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.253674|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254067|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254119|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254197|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254243|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254768|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254871|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254916|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.254961|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255112|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255164|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255209|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255254|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255298|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
2021-11-06.18:20:10.255342|n|switch_state_change|{"status":"SAI_SWITCH_OPER_STATUS_FAILED","switch_id":"oid:0x0"}|
```
this created a notification storm that eventually all get queued to be serviced by SONiC but SONiC was not able to keep up with the incoming enqueue rate, so it eventually used up all the system memory and crashed...
A previous fix was in place to prevent this if the event was FDB event.  But that one was specifically for FDB events and did not catch this case, so the switch still crashed...

This PR is raised to address this issue by adding additional logic to also prevent other event types to create a storm and overwhelm SONiC.
The enhancement is to save the last event type and keep a count for having consecutively received this same event type.  if a different event type is received, the count will go back to 1 and get counted from there.
If it ever gets into the situation where the switch already exceeded the enqueue threshold (due to the storm) and has over 1000 consecutive notification of this same type, then it will also be dropped regardless of the event type.  
The original FDB event case handling is still kept the same way as before so that as soon as the queue reached its threshold, any new FDB events will be dropped regardless of the consecutive count.

I have tested this on a switch to ensure that the new logic works fine with FDB events or other events.  

