### PR TITLE
Fix one compiling error

### DIFF
--- a/saiasiccmp/SaiSwitchAsic.h
+++ b/saiasiccmp/SaiSwitchAsic.h
@@ -3,6 +3,7 @@
 #include "syncd/SaiSwitchInterface.h"
 
 #include <map>
+#include <string>
 
 namespace saiasiccmp
 {


### PR DESCRIPTION
Add the header file <string> to fix the following error.

g++ -DHAVE_CONFIG_H -I. -I..    -g -I../SAI/inc -I../SAI/experimental
-I../SAI/meta -I../meta -I../lib -I../syncd -ansi -fPIC -std=c++14 -Wall
-Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Werror
-Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security
-Wformat-y2k -Wimport -Winit-self -Wno-inline -Winvalid-pch
-Wmissing-field-initializers -Wmissing-format-attribute
-Wmissing-include-dirs -Wmissing-noreturn -Wno-aggregate-return
-Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked
-Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector
-Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code
-Wunused -Wvariadic-macros -Wwrite-strings -Wno-switch-default
-Wconversion -Wno-psabi -Wcast-align=strict  -g -O2 -MT
libAsicCmp_a-SaiSwitchAsic.o -MD -MP -MF
.deps/libAsicCmp_a-SaiSwitchAsic.Tpo -c -o libAsicCmp_a-SaiSwitchAsic.o
`test -f 'SaiSwitchAsic.cpp' || echo './'`SaiSwitchAsic.cpp
In file included from SaiSwitchAsic.cpp:1:
SaiSwitchAsic.h:24:46: error: ‘string’ is not a member of ‘std’
   24 |                     _In_ const std::map<std::string,
      sai_object_id_t>& hidden,