### PR TITLE
Added Support for enum query capability of Nexthop Group Type.

### DIFF
--- a/unittest/vslib/TestSwitchBCM56850.cpp
+++ b/unittest/vslib/TestSwitchBCM56850.cpp
@@ -418,3 +418,64 @@ TEST(SwitchBCM56850, test_vlan_flood_capability)
 
     EXPECT_EQ(flood_types_found, 3);
 }
+
+TEST(SwitchBCM56850, test_nexthop_group_type_enum_values_capability)
+{
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+    auto signal = std::make_shared<Signal>();
+    auto eventQueue = std::make_shared<EventQueue>(signal);
+
+    sc->m_saiSwitchType = SAI_SWITCH_TYPE_NPU;
+    sc->m_switchType = SAI_VS_SWITCH_TYPE_BCM56850;
+    sc->m_bootType = SAI_VS_BOOT_TYPE_COLD;
+    sc->m_useTapDevice = false;
+    sc->m_laneMap = LaneMap::getDefaultLaneMap(0);
+    sc->m_eventQueue = eventQueue;
+
+    auto scc = std::make_shared<SwitchConfigContainer>();
+
+    scc->insert(sc);
+
+    SwitchBCM56850 sw(
+            0x2100000000,
+            std::make_shared<RealObjectIdManager>(0, scc),
+            sc);
+
+    sai_s32_list_t enum_val_cap;
+    int32_t list[5];
+    memset(list, 0, sizeof(list));
+
+    enum_val_cap.count = 4;
+    enum_val_cap.list = list;
+
+    EXPECT_EQ(sw.queryAttrEnumValuesCapability(0x2100000000,
+                                             SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                             SAI_NEXT_HOP_GROUP_ATTR_TYPE,
+                                             &enum_val_cap),
+                                             SAI_STATUS_BUFFER_OVERFLOW);
+    enum_val_cap.count = 5;
+    EXPECT_EQ(sw.queryAttrEnumValuesCapability(0x2100000000,
+                                             SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                             SAI_NEXT_HOP_GROUP_ATTR_TYPE,
+                                             &enum_val_cap),
+                                             SAI_STATUS_SUCCESS);
+
+
+    EXPECT_EQ(enum_val_cap.count, 5);
+
+    int nexthop_group_types_found = 0;
+
+    for (uint32_t i = 0; i < enum_val_cap.count; i++)
+    {
+        if (enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP ||
+            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP ||
+            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_FINE_GRAIN_ECMP ||
+            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_PROTECTION || 
+            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_CLASS_BASED)
+        {
+            nexthop_group_types_found++;
+        }
+    }
+
+    EXPECT_EQ(nexthop_group_types_found, 5);
+}

--- a/unittest/vslib/TestSwitchBCM56850.cpp
+++ b/unittest/vslib/TestSwitchBCM56850.cpp
@@ -470,7 +470,7 @@ TEST(SwitchBCM56850, test_nexthop_group_type_enum_values_capability)
         if (enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP ||
             enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP ||
             enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_FINE_GRAIN_ECMP ||
-            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_PROTECTION || 
+            enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_PROTECTION ||
             enum_val_cap.list[i] == SAI_NEXT_HOP_GROUP_TYPE_CLASS_BASED)
         {
             nexthop_group_types_found++;

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3384,6 +3384,27 @@ sai_status_t SwitchStateBase::queryVlanfloodTypeCapability(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::queryNextHopGroupTypeCapability(
+                   _Inout_ sai_s32_list_t *enum_values_capability)
+{
+    SWSS_LOG_ENTER();
+
+    if (enum_values_capability->count < 5)
+    {
+        return SAI_STATUS_BUFFER_OVERFLOW;
+    }
+
+    enum_values_capability->count = 5;
+    enum_values_capability->list[0] = SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP;
+    enum_values_capability->list[1] = SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP;
+    enum_values_capability->list[2] = SAI_NEXT_HOP_GROUP_TYPE_FINE_GRAIN_ECMP;
+    enum_values_capability->list[3] = SAI_NEXT_HOP_GROUP_TYPE_PROTECTION;
+    enum_values_capability->list[4] = SAI_NEXT_HOP_GROUP_TYPE_CLASS_BASED;
+
+    return SAI_STATUS_SUCCESS;
+}
+
+
 sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
                               _In_ sai_object_id_t switch_id,
                               _In_ sai_object_type_t object_type,
@@ -3401,6 +3422,10 @@ sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
                                                      attr_id == SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE))
     {
         return queryVlanfloodTypeCapability(enum_values_capability);
+    }
+    else if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP && attr_id == SAI_NEXT_HOP_GROUP_ATTR_TYPE)
+    {
+        return queryNextHopGroupTypeCapability(enum_values_capability);
     }
     return SAI_STATUS_NOT_SUPPORTED;
 }

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -650,6 +650,11 @@ namespace saivs
             virtual sai_status_t queryVlanfloodTypeCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability);
 
+            virtual sai_status_t queryNextHopGroupTypeCapability(
+                                      _Inout_ sai_s32_list_t *enum_values_capability);
+
+
+
         public: // TODO private
 
             std::set<FdbInfo> m_fdb_info_set;


### PR DESCRIPTION
What/Why I did:
Added Support for enum query capability of Nexthop Group Type.
This is needed for DVS testing of Ordered ECMP Feature.
Design Doc: https://github.com/Azure/SONiC/pull/896

Signed-off-by: Abhishek Dosi <abdosi@microsoft.com>