### PR TITLE
Change sonic-buildimage.vs artifact source from CI build to official build.

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -53,7 +53,7 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: 142
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'


### PR DESCRIPTION
This PR will unblock the PR checker of sonic-sairedis
https://dev.azure.com/mssonic/build/_build/results?buildId=64993&view=logs&j=fd654701-c975-5a82-4ee2-7dfa2e6fd174&t=5fe9eff9-6918-5942-3485-495aa73e6e4b