### PR TITLE
Add to save sai objects which are created during onPostPortCreate

### DIFF
--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -1030,6 +1030,20 @@ void SaiSwitch::onPostPortCreate(
          */
 
         redisSetDummyAsicStateForRealObjectId(rid);
+
+	/*
+         * The ports which is without QUEUE related configurations still created
+         * related SCHEDULER_GROUPs in the onPostPortCreate() during the syncd
+         * startup in some platform - e.g. montara. But these created objects
+	 * did NOT be recorded in the `COLDVIDS` and `m_warmBootDiscoveredVids`
+         * set. While swss is perform warmstart, the `compareViews()` would be
+         * called before apply the view, and it would detect the differences
+         * between the current view and temp view. Then syncd would remove these
+         * schedulers groups in the finalize. Therefore, add to record these
+         * object into the m_warmBootDiscoveredVids
+         */
+        sai_object_id_t vid = m_translator->translateRidToVid(rid, m_switch_vid);
+        m_warmBootDiscoveredVids.insert(vid);
     }
 
     redisUpdatePortLaneMap(port_rid);


### PR DESCRIPTION
The ports which is without QUEUE related configurations still created related
SCHEDULER_GROUPs in the onPostPortCreate() during the syncd startup in some
platform - e.g. barefoot montara. But these created objects did NOT be recorded
in the `COLDVIDS` and `m_warmBootDiscoveredVids` set. While swss is perform
warmstart, the `compareViews()` would be called before apply the view, and it
would detect the differences between the current view and temp view. Then syncd
would remove these schedulers groups in the finalize.

This patch adds to record the objects which are created during onPostPortCreate
into the `m_warmBootDiscoveredVids` set.

###  Verified by 
1. Applied sonic-mgmt t0 minigraph
2. SONiC CLI command: `config warm_restart enable swss`
3. System CLI command: `service swss restart`
Verify the syslog is there any WARNING/ERR in `checkInternalObjects` 