### PR TITLE
[pipeline] Download swss common artifact in a separated directory

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -58,6 +58,9 @@ jobs:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: self
+    clean: true
+    submodules: true
   - script: |
       sudo apt-get install -qq -y \
         qtbase5-dev \
@@ -106,8 +109,6 @@ jobs:
       sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
     workingDirectory: $(Pipeline.Workspace)
     displayName: "Install sonic swss Common"
-  - checkout: self
-    submodules: true
   - script: |
       set -ex
       ./autogen.sh

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -98,8 +98,10 @@ jobs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
+      path: '$(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}'
     displayName: "Download sonic swss common deb packages"
   - script: |
+      cd $(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}
       sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
       sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
     workingDirectory: $(Pipeline.Workspace)


### PR DESCRIPTION
* Put the downloaded swss common artifact in a separated directory while build sairedis target. 
* The downloaded swss common artifact is in a sub-directory of sairedis artifact, then it avoids overriding
   the previous swss common packages.
   