### PR TITLE
[build] Use 202106 branches in azure pipeline

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -55,7 +55,7 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: 142
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202106'

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -40,6 +40,8 @@ jobs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202106'
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -39,7 +39,7 @@ jobs:
       pipeline: 9
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202106'
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -56,7 +56,7 @@ jobs:
       pipeline: 1
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202106'
     displayName: "Download sonic buildimage"
   - script: |
       echo $(Build.DefinitionName).$(Build.BuildNumber)

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -67,7 +67,7 @@ jobs:
       pipeline: 9
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202106'
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -68,6 +68,8 @@ jobs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202106'
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -86,6 +86,8 @@ jobs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202106'
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download sonic swss common deb packages"
   - script: |
       sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -85,7 +85,7 @@ jobs:
       pipeline: 9
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202106'
     displayName: "Download sonic swss common deb packages"
   - script: |
       sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -27,7 +27,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202106'
     displayName: "Download sonic swss common deb packages"
 
   - checkout: self

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -28,6 +28,8 @@ jobs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202106'
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download sonic swss common deb packages"
 
   - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ resources:
   repositories:
   - repository: sonic-swss
     type: github
+    ref: refs/heads/202106
     name: Azure/sonic-swss
     endpoint: build
 


### PR DESCRIPTION
Download upstream pipelines 202106 branches' artifacts.

- [ ] TODO: remove allowPartiallySucceededBuilds and allowFailedBuilds after swss-common pipeline fully passes.