### PR TITLE
[FlexCounter] Fix shutdown syncd hanging problem

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2380,10 +2380,13 @@ void FlexCounter::flexCounterThreadRunFunction()
 
             SWSS_LOG_DEBUG("End of flex counter thread FC %s, took %d ms", m_instanceId.c_str(), delay);
 
-            std::unique_lock<std::mutex> lk(m_mtxSleep);
+            // If m_runFlexCounterThread is already disabled, do not wait for signal
+            if (m_runFlexCounterThread)
+            {
+                std::unique_lock<std::mutex> lk(m_mtxSleep);
 
-            m_cvSleep.wait_for(lk, std::chrono::milliseconds(correction));
-
+                m_cvSleep.wait_for(lk, std::chrono::milliseconds(correction));
+            }
             continue;
         }
 


### PR DESCRIPTION
**What I did**

Add a check before the FlexCounter thread execute the wait_for() funciton.

**Why I did it**

I encountered syncd shutdown overtime issue during running the test, sonic-mgmt/ansible/roles/test/tasks/restart_syncd.yml
I found it is due to it stuck by FlexCounter during removeAllCounters()

**How I verified it**

After modification, run the test for over 50 times