### PR TITLE
remove multiple cisco-8000 references

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -86,12 +86,6 @@ function set_start_type()
     fi
 }
 
-config_syncd_cisco_8000()
-{
-    export BASE_OUTPUT_DIR=/opt/cisco/silicon-one
-    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
-}
-
 config_syncd_bcm()
 {
     if [ -f "/etc/sai.d/sai.profile" ]; then
@@ -237,8 +231,6 @@ config_syncd()
         config_syncd_vs
     elif [ "$SONIC_ASIC_TYPE" == "innovium" ]; then
         config_syncd_innovium
-    elif [ "$SONIC_ASIC_TYPE" == "cisco-8000" ]; then
-        config_syncd_cisco_8000
     else
         echo "Unknown ASIC type $SONIC_ASIC_TYPE"
         exit 1


### PR DESCRIPTION
Clean up: Multiple references of cisco-8000 show up in syncd_init_common.sh 