### PR TITLE
Use the test agent pool managed by SONiC instead of the latest Azure image

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -11,8 +11,7 @@ jobs:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool:
-    vmImage: 'ubuntu-20.04'
+  pool: sonic-common
 
   steps:
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
This is a port of the changes in Azure/sonic-swss#2138.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>