### PR TITLE
[syncd] Fix comparison logic for new transferred objects

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -1477,7 +1477,7 @@ bool ComparisonLogic::performObjectSetTransition(
 
                 if (m_switch->isDiscoveredRid(rid))
                 {
-                    SWSS_LOG_INFO("performing default on existing object VID %s: %s: %s, we need default dependency TREE, FIXME",
+                    SWSS_LOG_WARN("performing default on existing object VID %s: %s: %s, we need default dependency TREE, FIXME",
                             sai_serialize_object_id(vid).c_str(),
                             meta->attridname,
                             currentAttr->getStrAttrValue().c_str());
@@ -2456,7 +2456,7 @@ void ComparisonLogic::populateExistingObjects(
             }
         }
 
-        if (warmBootNewDiscoveredVids.size())
+        if (warmBootNewDiscoveredVids.find(vid) != warmBootNewDiscoveredVids.end())
         {
             // We have some new discovered VIDs after warm boot, we need to
             // create temporary objects from them, so comparison logic will not
@@ -2468,8 +2468,11 @@ void ComparisonLogic::populateExistingObjects(
 
             performColdCheck = false;
 
-            SWSS_LOG_NOTICE("creating and matching %zu new discovered WARM BOOT objects",
-                    warmBootNewDiscoveredVids.size());
+            sai_object_type_t ot = VidManager::objectTypeQuery(vid);
+
+            SWSS_LOG_NOTICE("creating temporary object for new discovered VID %s:%s",
+                    sai_serialize_object_type(ot).c_str(),
+                    sai_serialize_object_id(vid).c_str());
         }
 
         if (performColdCheck && coldBootDiscoveredVids.find(vid) == coldBootDiscoveredVids.end())

--- a/tests/BCM56850.pl
+++ b/tests/BCM56850.pl
@@ -709,7 +709,11 @@ sub test_brcm_warm_new_object_port_serdes
 {
     fresh_start;
 
-    play "empty_sw.rec";
+    # use buffer profile and pool objects since they
+    # are not default created on the switch
+    # so asic operations should still be zero
+
+    play "buffer_profile_get_A.rec";
 
     print "port serdes objects in ASIC_DB: ";
     print `redis-cli -n 1 keys "*_SERDES*" | wc -l`;
@@ -734,7 +738,7 @@ sub test_brcm_warm_new_object_port_serdes
 
     start_syncd_warm;
 
-    play "empty_sw.rec", 0;
+    play "buffer_profile_get_A.rec", 0;
 
     print "check ASIC_DB for serdes\n";
     print "RIDTOVID: ", `redis-cli -n 1 HKEYS RIDTOVID |grep oid:0x5700 |wc -l`;

--- a/vslib/SwitchBCM81724.cpp
+++ b/vslib/SwitchBCM81724.cpp
@@ -96,7 +96,7 @@ sai_status_t SwitchBCM81724::create(
     // Bypass MACsec creating because the existing implementation of MACsec cannot be directly used by Gearbox
     if (is_macsec_type(object_type))
     {
-        SWSS_LOG_INFO("Bypass creating %s", sai_serialize_object_type(object_type));
+        SWSS_LOG_INFO("Bypass creating %s", sai_serialize_object_type(object_type).c_str());
 
         return create_internal(object_type, serializedObjectId, switch_id, attr_count, attr_list);
     }
@@ -113,7 +113,7 @@ sai_status_t SwitchBCM81724::remove(
     // Bypass MACsec removing because the existing implementation of MACsec cannot be directly used by Gearbox
     if (is_macsec_type(object_type))
     {
-        SWSS_LOG_INFO("Bypass removing %s", sai_serialize_object_type(object_type));
+        SWSS_LOG_INFO("Bypass removing %s", sai_serialize_object_type(object_type).c_str());
 
         return remove_internal(object_type, serializedObjectId);
     }
@@ -132,7 +132,7 @@ sai_status_t SwitchBCM81724::set(
     if (is_macsec_type(objectType) ||
         (objectType == SAI_OBJECT_TYPE_ACL_ENTRY && attr && attr->id == SAI_ACL_ENTRY_ATTR_ACTION_MACSEC_FLOW))
     {
-        SWSS_LOG_INFO("Bypass setting %s", sai_serialize_object_type(objectType));
+        SWSS_LOG_INFO("Bypass setting %s", sai_serialize_object_type(objectType).c_str());
 
         return set_internal(objectType, serializedObjectId, attr);;
     }


### PR DESCRIPTION
For created objects like buffer pool or buffer profile
those are not on the switch, but they were treated as such
and transferred to temporary view during comparison logic
causing to duplicate objects on temporary view