### PR TITLE
[syncd] Fix comparison logic for new transferred objects

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -1473,7 +1473,7 @@ bool ComparisonLogic::performObjectSetTransition(
 
                 if (m_switch->isDiscoveredRid(rid))
                 {
-                    SWSS_LOG_INFO("performing default on existing object VID %s: %s: %s, we need default dependency TREE, FIXME",
+                    SWSS_LOG_WARN("performing default on existing object VID %s: %s: %s, we need default dependency TREE, FIXME",
                             sai_serialize_object_id(vid).c_str(),
                             meta->attridname,
                             currentAttr->getStrAttrValue().c_str());
@@ -2452,7 +2452,7 @@ void ComparisonLogic::populateExistingObjects(
             }
         }
 
-        if (warmBootNewDiscoveredVids.size())
+        if (warmBootNewDiscoveredVids.find(vid) != warmBootNewDiscoveredVids.end())
         {
             // We have some new discovered VIDs after warm boot, we need to
             // create temporary objects from them, so comparison logic will not
@@ -2464,8 +2464,11 @@ void ComparisonLogic::populateExistingObjects(
 
             performColdCheck = false;
 
-            SWSS_LOG_NOTICE("creating and matching %zu new discovered WARM BOOT objects",
-                    warmBootNewDiscoveredVids.size());
+            sai_object_type_t ot = VidManager::objectTypeQuery(vid);
+
+            SWSS_LOG_NOTICE("creating temporary object for new discovered VID %s:%s",
+                    sai_serialize_object_type(ot).c_str(),
+                    sai_serialize_object_id(vid).c_str());
         }
 
         if (performColdCheck && coldBootDiscoveredVids.find(vid) == coldBootDiscoveredVids.end())

--- a/tests/BCM56850.pl
+++ b/tests/BCM56850.pl
@@ -707,7 +707,11 @@ sub test_brcm_warm_new_object_port_serdes
 {
     fresh_start;
 
-    play "empty_sw.rec";
+    # use buffer profile and pool objects since they
+    # are not default created on the switch
+    # so asic operations should still be zero
+
+    play "buffer_profile_get_A.rec";
 
     print "port serdes objects in ASIC_DB: ";
     print `redis-cli -n 1 keys "*_SERDES*" | wc -l`;
@@ -732,7 +736,7 @@ sub test_brcm_warm_new_object_port_serdes
 
     start_syncd_warm;
 
-    play "empty_sw.rec", 0;
+    play "buffer_profile_get_A.rec", 0;
 
     print "check ASIC_DB for serdes\n";
     print "RIDTOVID: ", `redis-cli -n 1 HKEYS RIDTOVID |grep oid:0x5700 |wc -l`;


### PR DESCRIPTION
For created objects like buffer pool or buffer profile
those are not on the switch, but they were treated as such
and transferred to temporary view during comparison logic
causing to duplicate objects on temporary view