### PR TITLE
Fix submodule SAI branch name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = SAI
 	url = https://github.com/opencomputeproject/SAI.git
 	ignore = dirty
-	branch = v1.3
+	branch = v1.7


### PR DESCRIPTION
This PR is to fix the branch name of submodule SAI.

The `202012` branch is depending on `v1.7` of OCP SAI. To avoid confusion, this PR corrects the branch name in `.gitmodules` of SAI, although the submodule version is specified to a particular, and the branch name in `.gitmodules` does nothing when checking out submodules.


Signed-off-by: bingwang <bingwang@microsoft.com>