### PR TITLE
vslib: add support for read-only port capabilities

### DIFF
--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1220,6 +1220,29 @@ sai_status_t SwitchStateBase::set_port_list()
     return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
 }
 
+sai_status_t SwitchStateBase::set_port_capabilities()
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("set port capabilities");
+
+    sai_attribute_t attr;
+
+    for (auto &port_id: m_port_list)
+    {
+        attr.id = SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE;
+        attr.value.booldata = true;
+
+        CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+        attr.id = SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE;
+        attr.value.booldata = true;
+
+        CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+    }
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchStateBase::create_default_virtual_router()
 {
     SWSS_LOG_ENTER();
@@ -1597,6 +1620,7 @@ sai_status_t SwitchStateBase::initialize_default_objects(
     CHECK_STATUS(create_ports());
     CHECK_STATUS(create_port_serdes());
     CHECK_STATUS(set_port_list());
+    CHECK_STATUS(set_port_capabilities());
     CHECK_STATUS(create_bridge_ports());
     CHECK_STATUS(create_vlan_members());
     CHECK_STATUS(set_acl_entry_min_prio());
@@ -2289,6 +2313,12 @@ sai_status_t SwitchStateBase::refresh_read_only(
 
             case SAI_PORT_ATTR_PORT_SERDES_ID:
                 return refresh_port_serdes_id(object_id);
+
+            case SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE:
+                return SAI_STATUS_SUCCESS;
+
+            case SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE:
+                return SAI_STATUS_SUCCESS;
         }
     }
 

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1232,12 +1232,6 @@ sai_status_t SwitchStateBase::set_port_capabilities()
     {
         attr.id = SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE;
         attr.value.booldata = true;
-
-        CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
-
-        attr.id = SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE;
-        attr.value.booldata = true;
-
         CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
     }
     return SAI_STATUS_SUCCESS;
@@ -2315,9 +2309,6 @@ sai_status_t SwitchStateBase::refresh_read_only(
                 return refresh_port_serdes_id(object_id);
 
             case SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE:
-                return SAI_STATUS_SUCCESS;
-
-            case SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE:
                 return SAI_STATUS_SUCCESS;
         }
     }

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -65,6 +65,8 @@ namespace saivs
 
             virtual sai_status_t set_port_list();
 
+            virtual sai_status_t set_port_capabilities();
+
             virtual sai_status_t create_fabric_ports();
 
             virtual sai_status_t set_fabric_port_list();


### PR DESCRIPTION
This is part of HLD: Azure/SONiC#924,  Azure/SONiC#925

**What I did**
Add port capability query for AutoNeg and Link-Training

**Why I did it**
Fix the VS test failure for the port AutoNeg and Link-Training capability queries

**How I verified it**
Ran the sonic-swss/tests/test_port_an.py to verify
