### PR TITLE
[syncd] Add fdb notification event throttle

### DIFF
--- a/syncd/EventThrottle.cpp
+++ b/syncd/EventThrottle.cpp
@@ -1,0 +1,75 @@
+#include "EventThrottle.h"
+
+#include "swss/logger.h"
+
+using namespace syncd;
+
+/*
+ * Defines fdb event notification limit. When this many notification will be
+ * seen in specific period of time then receiving of this event will be dropped.
+ */
+#define FDB_EVENT_NOTIFICATION_LIMIT (10)
+
+#define FDB_EVENT_NOTIFICATION_LIMIT_TIMESPAN_NS (1000*1000*1000)
+#define ONE_SECOND_TIMESPAN_NS (1000*1000*1000)
+
+EventThrottle::EventThrottle(
+        _In_ const std::string& name):
+    m_name(name),
+    m_count(0),
+    m_dropped(0)
+{
+    SWSS_LOG_ENTER();
+
+    m_time = getTime();
+}
+
+uint64_t EventThrottle::getTime()
+{
+    // SWSS_LOG_ENTER(); // disabled
+
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+bool EventThrottle::shouldEnqueue()
+{
+    // SWSS_LOG_ENTER(); // disabled
+
+    auto time = getTime();
+
+    if (time < m_time)
+    {
+        m_dropped++;
+        return false;
+    }
+
+    if (m_dropped)
+    {
+        SWSS_LOG_WARN("dropped fdb event %s %ld times", m_name.c_str(), m_dropped);
+        m_dropped = 0;
+    }
+
+    if (m_count == 0)
+    {
+        m_time = getTime(); // first notification time stamp
+    }
+
+    m_count++;
+
+    if (m_count < FDB_EVENT_NOTIFICATION_LIMIT)
+        return true;
+
+    if (time - m_time < FDB_EVENT_NOTIFICATION_LIMIT_TIMESPAN_NS)
+    {
+        SWSS_LOG_WARN("fdb entry %s seen %ld times, dropping for 1 seconds",
+                m_name.c_str(),
+                m_count);
+
+        // set time in the future for 1 second, this will cause drop
+        m_time = time + ONE_SECOND_TIMESPAN_NS;
+    }
+
+    m_count = 0;
+
+    return true;
+}

--- a/syncd/EventThrottle.h
+++ b/syncd/EventThrottle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "swss/sal.h"
+
+#include <string>
+
+namespace syncd
+{
+    class EventThrottle
+    {
+        public:
+
+            EventThrottle(
+                    _In_ const std::string& name);
+
+        public:
+
+            static uint64_t getTime();
+
+            bool shouldEnqueue();
+
+        private:
+
+            std::string m_name;
+
+            uint64_t m_time;
+            uint64_t m_count;
+            uint64_t m_dropped;
+    };
+}

--- a/syncd/FdbEntryKeyHasher.cpp
+++ b/syncd/FdbEntryKeyHasher.cpp
@@ -1,0 +1,32 @@
+#include "FdbEntryKeyHasher.h"
+
+#include "swss/logger.h"
+
+#include <cstring>
+
+using namespace syncd;
+
+std::size_t FdbEntryKeyHasher::operator()(
+        _In_ const sai_fdb_entry_t& fe) const
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    uint32_t data;
+
+    // use low 4 bytes of mac address as hash value
+    // use memcpy instead of cast because of strict-aliasing rules
+    memcpy(&data, fe.mac_address + 2, sizeof(uint32_t));
+
+    return data;
+}
+
+bool FdbEntryKeyHasher::operator()(
+        _In_ const sai_fdb_entry_t& a,
+        _In_ const sai_fdb_entry_t& b) const
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    return a.switch_id == b.switch_id &&
+        a.bv_id == b.bv_id &&
+        memcmp(a.mac_address, b.mac_address, sizeof(a.mac_address)) == 0;
+}

--- a/syncd/FdbEntryKeyHasher.h
+++ b/syncd/FdbEntryKeyHasher.h
@@ -1,0 +1,22 @@
+#pragma once
+
+extern "C" {
+#include "saimetadata.h"
+}
+
+#include "swss/sal.h"
+
+#include <cstddef>
+
+namespace syncd
+{
+    struct FdbEntryKeyHasher
+    {
+        std::size_t operator()(
+                _In_ const sai_fdb_entry_t& fe) const;
+
+        bool operator()(
+                _In_ const sai_fdb_entry_t& a,
+                _In_ const sai_fdb_entry_t& b) const;
+    };
+}

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -19,6 +19,8 @@ libSyncd_a_SOURCES = \
 				CommandLineOptions.cpp \
 				CommandLineOptionsParser.cpp \
 				ComparisonLogic.cpp \
+				EventThrottle.cpp \
+				FdbEntryKeyHasher.cpp \
 				FlexCounter.cpp \
 				FlexCounterManager.cpp \
 				GlobalSwitchId.cpp \

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -6,12 +6,15 @@ extern "C"{
 
 #include "NotificationQueue.h"
 #include "NotificationProcessor.h"
+#include "EventThrottle.h"
+#include "FdbEntryKeyHasher.h"
 
 #include "swss/table.h"
 
 #include <string>
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 namespace syncd
 {
@@ -71,6 +74,9 @@ namespace syncd
                     _In_ const std::string& op,
                     _In_ const std::string& data);
 
+            bool shouldEnqueueFdbEvent(
+                    _In_ const sai_fdb_event_notification_data_t& data);
+
         private:
 
             sai_switch_notifications_t m_switchNotifications;
@@ -78,5 +84,7 @@ namespace syncd
             std::shared_ptr<NotificationQueue> m_notificationQueue;
 
             std::shared_ptr<NotificationProcessor> m_processor;
+
+            std::unordered_map<sai_fdb_entry_t, std::shared_ptr<EventThrottle>, FdbEntryKeyHasher, FdbEntryKeyHasher> m_fdbThrottleHash;
     };
 }

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -9,7 +9,10 @@ tests_SOURCES = main.cpp \
                 MockableSaiInterface.cpp \
                 MockHelper.cpp \
 				TestCommandLineOptions.cpp \
+				TestEventThrottle.cpp \
+				TestFdbEntryKeyHasher.cpp \
 				TestFlexCounter.cpp \
+				TestNotificationHandler.cpp \
 				TestNotificationQueue.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)

--- a/unittest/syncd/MockHelper.cpp
+++ b/unittest/syncd/MockHelper.cpp
@@ -10,11 +10,3 @@ namespace test_syncd {
         mock_objectTypeQuery_result = mock_result;
     }
 }
-
-namespace syncd {
-    sai_object_type_t VidManager::objectTypeQuery(_In_ sai_object_id_t objectId)
-    {
-        SWSS_LOG_ENTER();
-        return test_syncd::mock_objectTypeQuery_result;
-    }
-}

--- a/unittest/syncd/TestEventThrottle.cpp
+++ b/unittest/syncd/TestEventThrottle.cpp
@@ -1,0 +1,31 @@
+#include "EventThrottle.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace syncd;
+
+TEST(EventThrottle, getTime)
+{
+    EXPECT_NE(EventThrottle::getTime(), 0);
+}
+
+TEST(EventThrottle, shouldEnqueue)
+{
+    EventThrottle et("test");
+
+    for (int i = 0; i < 10; i++)
+    {
+        EXPECT_TRUE(et.shouldEnqueue());
+    }
+
+    for (int i = 0; i < 100; i++)
+    {
+        EXPECT_FALSE(et.shouldEnqueue());
+    }
+
+    sleep(1);
+
+    EXPECT_TRUE(et.shouldEnqueue());
+}

--- a/unittest/syncd/TestFdbEntryKeyHasher.cpp
+++ b/unittest/syncd/TestFdbEntryKeyHasher.cpp
@@ -1,0 +1,31 @@
+#include "FdbEntryKeyHasher.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace syncd;
+
+TEST(FdbEntryKeyHasher, operator_eq)
+{
+    sai_fdb_entry_t a;
+    sai_fdb_entry_t b;
+
+    memset(&a, 0, sizeof(a));
+    memset(&b, 0, sizeof(a));
+
+    FdbEntryKeyHasher kh;
+
+    EXPECT_TRUE(kh.operator()(a, b));
+}
+
+TEST(FdbEntryKeyHasher, operator_hash)
+{
+    sai_fdb_entry_t a;
+
+    memset(&a, 0, sizeof(a));
+
+    FdbEntryKeyHasher kh;
+
+    EXPECT_EQ(kh.operator()(a), 0);
+}

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -13,8 +13,8 @@ TEST(FlexCounter, addRemoveCounterForFlowCounter)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t counterVid{100};
-    sai_object_id_t counterRid{100};
+    sai_object_id_t counterVid{0x54000000000000};
+    sai_object_id_t counterRid{0x54000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
 
@@ -46,12 +46,12 @@ TEST(FlexCounter, addRemoveCounterForFlowCounter)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x64");
+    EXPECT_EQ(keys[0], "oid:0x54000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x64", "SAI_COUNTER_STAT_PACKETS", value);
+    countersTable.hget("oid:0x54000000000000", "SAI_COUNTER_STAT_PACKETS", value);
     EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x64", "SAI_COUNTER_STAT_BYTES", value);
+    countersTable.hget("oid:0x54000000000000", "SAI_COUNTER_STAT_BYTES", value);
     EXPECT_EQ(value, "200");
 
     fc.removeCounter(counterVid);
@@ -81,8 +81,8 @@ TEST(FlexCounter, addRemoveCounterForMACsecFlow)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t macsecFlowVid{101};
-    sai_object_id_t macsecFlowRid{101};
+    sai_object_id_t macsecFlowVid{0x5a000000000000};
+    sai_object_id_t macsecFlowRid{0x5a000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(MACSEC_FLOW_COUNTER_ID_LIST, "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS,SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED");
 
@@ -114,17 +114,17 @@ TEST(FlexCounter, addRemoveCounterForMACsecFlow)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x65");
+    EXPECT_EQ(keys[0], "oid:0x5a000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x65", "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", value);
+    countersTable.hget("oid:0x5a000000000000", "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", value);
     //EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x65", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED", value);
+    countersTable.hget("oid:0x5a000000000000", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED", value);
     //EXPECT_EQ(value, "200");
 
     fc.removeCounter(macsecFlowVid);
     EXPECT_EQ(fc.isEmpty(), true);
-    countersTable.del("oid:0x65");
+    countersTable.del("oid:0x5a000000000000");
     countersTable.getKeys(keys);
 
     ASSERT_TRUE(keys.empty());
@@ -136,8 +136,8 @@ TEST(FlexCounter, addRemoveCounterForMACsecSA)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t macsecSAVid{102};
-    sai_object_id_t macsecSARid{102};
+    sai_object_id_t macsecSAVid{0x5c000000000000};
+    sai_object_id_t macsecSARid{0x5c000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(MACSEC_SA_COUNTER_ID_LIST, "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED,SAI_MACSEC_SA_STAT_OCTETS_PROTECTED");
 
@@ -169,17 +169,17 @@ TEST(FlexCounter, addRemoveCounterForMACsecSA)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x66");
+    EXPECT_EQ(keys[0], "oid:0x5c000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x66", "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", value);
+    countersTable.hget("oid:0x5c000000000000", "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", value);
     //EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x66", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED", value);
+    countersTable.hget("oid:0x5c000000000000", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED", value);
     //EXPECT_EQ(value, "200");
 
     fc.removeCounter(macsecSAVid);
     EXPECT_EQ(fc.isEmpty(), true);
-    countersTable.del("oid:0x66");
+    countersTable.del("oid:0x5c000000000000");
     countersTable.getKeys(keys);
 
     ASSERT_TRUE(keys.empty());

--- a/unittest/syncd/TestNotificationHandler.cpp
+++ b/unittest/syncd/TestNotificationHandler.cpp
@@ -1,0 +1,61 @@
+#include "NotificationHandler.h"
+#include "SwitchNotifications.h"
+#include "RedisNotificationProducer.h"
+#include "RedisClient.h"
+
+#include "swss/dbconnector.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace syncd;
+using namespace std::placeholders;
+
+static std::shared_ptr<NotificationProcessor> g_processor;
+
+static void syncProcessNotification(
+        _In_ const swss::KeyOpFieldsValuesTuple& item)
+{
+    SWSS_LOG_ENTER();
+
+    g_processor->syncProcessNotification(item);
+}
+
+TEST(NotificationHandler, onFdbEvent)
+{
+    sai_fdb_event_notification_data_t data;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+    attr.value.oid = 0x3a00000001;
+
+    data.fdb_entry.switch_id = 0x2100000000;
+    data.fdb_entry.bv_id = 0x2600000000;
+    data.fdb_entry.mac_address[0] = 0x00;
+    data.fdb_entry.mac_address[1] = 0x22;
+    data.fdb_entry.mac_address[2] = 0x48;
+    data.fdb_entry.mac_address[3] = 0x58;
+    data.fdb_entry.mac_address[4] = 0xD1;
+    data.fdb_entry.mac_address[5] = 0x29;
+
+    data.event_type = SAI_FDB_EVENT_LEARNED;
+
+    data.attr_count = 1;
+    data.attr = &attr;
+
+    auto dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    auto client = std::make_shared<RedisClient>(dbAsic);
+    auto notifications = std::make_shared<RedisNotificationProducer>("ASIC_DB");
+    g_processor = std::make_shared<NotificationProcessor>(notifications, client, std::bind(syncProcessNotification, _1));
+    auto handler = std::make_shared<NotificationHandler>(g_processor);
+
+    SwitchNotifications sn;
+
+    sn.onFdbEvent = std::bind(&NotificationHandler::onFdbEvent, handler.get(), _1, _2);
+
+    handler->setSwitchNotifications(sn.getSwitchNotifications());
+
+    handler->onFdbEvent(1, &data);
+}


### PR DESCRIPTION
When L2 loop happen, a mac can jump between ports very rapid, and it will cause flood of fdb notification events like (aged, learned, aged learned) between 2 ports. Vendor sai will produce stream of messages that will use 100% cpu, and syncd will be trying to push those notifications to OA. To prevent this, we are adding event throttle on fdb events per MAC basis, and by default that throttle will limit number of messages to 10 events per 1 second per MAC.