### PR TITLE
[configure.ac] SAI version check fix for gcc 10.2 (bullseye)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AC_SUBST(SAIINC, "-I\$(top_srcdir)/SAI/inc -I\$(top_srcdir)/SAI/experimental -I\
 AM_COND_IF([SYNCD], [
 AM_COND_IF([SAIVS], [], [
 SAVED_FLAGS="$CXXFLAGS"
-CXXFLAGS="-lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
+CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
 AC_MSG_CHECKING([SAI headers API version and library version check])
 AC_TRY_RUN([
 extern "C" {


### PR DESCRIPTION
The command to build a check program was:

```
gcc -lsai -I./SAI/inc -I./SAI/experimental -I./SAI/meta conftest.cpp -o conftest
```

This, however, does not work on gcc 10.2 where the linker wants first
the executable and then the shared library:

```
gcc -I./SAI/inc -I./SAI/experimental -I./SAI/meta conftest.cpp -lsai -o conftest
```

However CXX_FLAGS comes first before the source file, so added
--no-as-needed as a fix for this issue to make it link against libsai in
any order passed to the linker.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>