### PR TITLE
[debian/rules] fail on script error during package build

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -114,7 +114,7 @@ jobs:
       set -ex
       rm ../*.deb || true
       ./autogen.sh
-      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="" binary-syncd-vs
+      DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="" binary-syncd-vs
       mv ../*.deb .
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |

--- a/debian/control
+++ b/debian/control
@@ -117,6 +117,7 @@ Description: debugging symbols for libsaimetadata
 
 Package: python-pysairedis
 Architecture: any
+Build-Profiles: <!nopython2>
 Depends: ${shlibs:Depends}, ${misc:Pre-Depends}
 Section: libs
 Description: This package contains Switch State Service sairedis Python2 library.

--- a/debian/python-pysairedis.install
+++ b/debian/python-pysairedis.install
@@ -1,1 +1,1 @@
-usr/lib/python2.7/dist-packages/pysairedis/*
+usr/lib/python2.7/dist-packages/sairedis/*

--- a/debian/python3-pysairedis.install
+++ b/debian/python3-pysairedis.install
@@ -1,1 +1,1 @@
-usr/lib/python3/dist-packages/pysairedis/*
+usr/lib/python3/dist-packages/sairedis/*

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@
 
 .ONESHELL:
 SHELL = /bin/bash
-.SHELLFLAGS += -x
+.SHELLFLAGS += -ex
 
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1

--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,16 @@ endif
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+DOPACKAGES = $(shell dh_listpackages)
+
+# For Debian jessie, stretch, and buster, and Ubuntu bionic and focal, build
+# Python 2 bindings. This is controlled by the build profile being used.
+ifneq (,$(filter python-pysairedis,$(DOPACKAGES)))
+configure_opts += --enable-python2
+else
+configure_opts += --disable-python2
+endif
+
 clean:
 	dh $@ --with autotools-dev
 


### PR DESCRIPTION
On bullseye, the following build command does not fail when configure
step is failing:

```
stepanb@3012cc6b379a:/sonic/src/sonic-sairedis$ fakeroot debian/rules binary-syncd
...
configure: exit 1
dh_auto_configure: error: ./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-option-checking --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --libexecdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking returned exit code 1
make[2]: *** [debian/rules:76: override_dh_auto_configure] Error 25
make[2]: Leaving directory '/sonic/src/sonic-sairedis'
+ dh binary -N syncd-rpc -N syncd-rpc-dbg -N syncd-vs -N syncd-vs-dbg --with autotools-dev
dh: warning: The autotools-dev sequence is deprecated and replaced by dh in debhelper (>= 9.20160115)
dh: warning: This feature will be removed in compat 12.
   debian/rules build
make[2]: Entering directory '/sonic/src/sonic-sairedis'
echo build stage is skipped. Please use binary to generate debian packages
+ DEB_BUILD_OPTIONS='nocheck parallel=12'
...
dpkg-deb: building package 'libsairedis-dbg' in '../libsairedis-dbg_1.0.0_amd64.deb'.
dpkg-deb: building package 'libsaivs-dbg' in '../libsaivs-dbg_1.0.0_amd64.deb'.
dpkg-deb: building package 'libsaimetadata-dbg' in '../libsaimetadata-dbg_1.0.0_amd64.deb'.
dpkg-deb: building package 'python-pysairedis' in '../python-pysairedis_1.0.0_amd64.deb'.
dpkg-deb: building package 'python3-pysairedis' in '../python3-pysairedis_1.0.0_amd64.deb'.
stepanb@3012cc6b379a:/sonic/src/sonic-sairedis$ echo $?
0
```

On previous buster, however, this command fails as expected:

```
stepanb@99083f3297fd:/sonic/src/sonic-sairedis$ fakeroot debian/rules binary-syncd
...
checking whether CXX supports -Wno-cast-function-type... yes
checking SAI headers API version and library version check... failed
configure: error: "SAI headers API version and library version mismatch"
make[1]: *** [Makefile:404: config.status] Error 1
make[1]: Leaving directory '/sonic/src/sonic-sairedis'
dh_auto_install: error: make -j1 install DESTDIR=/sonic/src/sonic-sairedis/debian/tmp AM_UPDATE_INFO_DIR=no returned exit code 2
make: *** [debian/rules:47: binary-syncd] Error 2
stepanb@99083f3297fd:/sonic/src/sonic-sairedis$ echo $?
2
```

It is required to have -e in .SHELLFLAGS to fail on such errors.

Also, fixed install pathes for python bindings and disabled python2 bindings when DEB_BUILD_PROFILES=nopython2 is passed.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>