### PR TITLE
[counter] Fix port flex counter 

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2451,6 +2451,10 @@ sai_status_t FlexCounter::querySupportedPortCounters(
         SAI_OBJECT_TYPE_PORT,
         &stats_capability);
 
+	SWSS_LOG_NOTICE("queryStatsCapability on port RID %s: %s",
+			sai_serialize_object_id(portRid).c_str(),
+			sai_serialize_status(status).c_str());
+
     /* Second call is for query statistics capability */
     if (status == SAI_STATUS_BUFFER_OVERFLOW)
     {
@@ -2463,8 +2467,9 @@ sai_status_t FlexCounter::querySupportedPortCounters(
 
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_INFO("Unable to get port supported counters for %s",
-                sai_serialize_object_id(portRid).c_str());
+            SWSS_LOG_NOTICE("Unable to get port supported counters for %s: %s",
+                sai_serialize_object_id(portRid).c_str(),
+				sai_serialize_status(status).c_str());
         }
         else
         {
@@ -2472,6 +2477,9 @@ sai_status_t FlexCounter::querySupportedPortCounters(
             {
                 sai_port_stat_t counter = static_cast<sai_port_stat_t>(statCapability.stat_enum);
                 m_supportedPortCounters.insert(counter);
+				SWSS_LOG_NOTICE("queryStatsCapability counter %s on port RID %s",
+						sai_serialize_port_stat(counter).c_str(),
+						sai_serialize_object_id(portRid).c_str());
             }
         }
     }
@@ -2493,7 +2501,7 @@ void FlexCounter::getSupportedPortCounters(
 
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_INFO("Counter %s is not supported on port RID %s: %s",
+            SWSS_LOG_NOTICE("Counter %s is not supported on port RID %s: %s",
                     sai_serialize_port_stat(counter).c_str(),
                     sai_serialize_object_id(portRid).c_str(),
                     sai_serialize_status(status).c_str());
@@ -2501,6 +2509,10 @@ void FlexCounter::getSupportedPortCounters(
             continue;
         }
 
+		SWSS_LOG_NOTICE("Counter %s is supported on port RID %s: %s",
+				sai_serialize_port_stat(counter).c_str(),
+				sai_serialize_object_id(portRid).c_str(),
+				sai_serialize_status(status).c_str());
         m_supportedPortCounters.insert(counter);
     }
 }

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2431,7 +2431,8 @@ void FlexCounter::endFlexCounterThread(void)
 }
 
 sai_status_t FlexCounter::querySupportedPortCounters(
-        _In_ sai_object_id_t portRid, _Out_ PortCountersSet &supportedPortCounters)
+        _In_ sai_object_id_t portRid,
+        _Out_ PortCountersSet &supportedPortCounters)
 {
     SWSS_LOG_ENTER();
 

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2431,7 +2431,7 @@ void FlexCounter::endFlexCounterThread(void)
 }
 
 sai_status_t FlexCounter::querySupportedPortCounters(
-        _In_ sai_object_id_t portRid, PortCountersSet &supportedPortCounters)
+        _In_ sai_object_id_t portRid, _Out_ PortCountersSet &supportedPortCounters)
 {
     SWSS_LOG_ENTER();
 
@@ -2445,10 +2445,6 @@ sai_status_t FlexCounter::querySupportedPortCounters(
         SAI_OBJECT_TYPE_PORT,
         &stats_capability);
 
-    SWSS_LOG_NOTICE("queryStatsCapability on port RID %s: %s",
-            sai_serialize_object_id(portRid).c_str(),
-            sai_serialize_status(status).c_str());
-
     /* Second call is for query statistics capability */
     if (status == SAI_STATUS_BUFFER_OVERFLOW)
     {
@@ -2461,7 +2457,7 @@ sai_status_t FlexCounter::querySupportedPortCounters(
 
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_NOTICE("Unable to get port supported counters for %s: %s",
+            SWSS_LOG_NOTICE("Unable to query port supported counters for %s: %s",
                 sai_serialize_object_id(portRid).c_str(),
                 sai_serialize_status(status).c_str());
         }
@@ -2471,9 +2467,6 @@ sai_status_t FlexCounter::querySupportedPortCounters(
             {
                 sai_port_stat_t counter = static_cast<sai_port_stat_t>(statCapability.stat_enum);
                 supportedPortCounters.insert(counter);
-                SWSS_LOG_NOTICE("queryStatsCapability counter %s on port RID %s",
-                        sai_serialize_port_stat(counter).c_str(),
-                        sai_serialize_object_id(portRid).c_str());
             }
         }
     }
@@ -2482,7 +2475,7 @@ sai_status_t FlexCounter::querySupportedPortCounters(
 
 void FlexCounter::getSupportedPortCounters(
         _In_ sai_object_id_t portRid,
-        PortCountersSet &supportedPortCounters)
+        _Out_ PortCountersSet &supportedPortCounters)
 {
     SWSS_LOG_ENTER();
 
@@ -2504,17 +2497,13 @@ void FlexCounter::getSupportedPortCounters(
             continue;
         }
 
-        SWSS_LOG_NOTICE("Counter %s is supported on port RID %s: %s",
-                sai_serialize_port_stat(counter).c_str(),
-                sai_serialize_object_id(portRid).c_str(),
-                sai_serialize_status(status).c_str());
         supportedPortCounters.insert(counter);
     }
 }
 
 void FlexCounter::updateSupportedPortCounters(
         _In_ sai_object_id_t portRid,
-        PortCountersSet &supportedPortCounters)
+        _Out_ PortCountersSet &supportedPortCounters)
 {
     SWSS_LOG_ENTER();
 

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -20,6 +20,7 @@ namespace syncd
     {
         private:
 
+            typedef std::set<sai_port_stat_t> PortCountersSet;
             FlexCounter(const FlexCounter&) = delete;
 
         public:
@@ -213,9 +214,6 @@ namespace syncd
 
         private: // is counter supported
 
-            bool isPortCounterSupported(
-                    _In_ sai_port_stat_t counter) const;
-
             bool isPriorityGroupCounterSupported(
                     _In_ sai_ingress_priority_group_stat_t counter) const;
 
@@ -238,13 +236,16 @@ namespace syncd
         private: // update supported counters
 
             sai_status_t querySupportedPortCounters(
-                    _In_ sai_object_id_t portRid);
+                    _In_ sai_object_id_t portRid,
+                    PortCountersSet &supportedPortCounters);
 
             void getSupportedPortCounters(
-                    _In_ sai_object_id_t portRid);
+                    _In_ sai_object_id_t portRid,
+                    PortCountersSet &supportedPortCounters);
 
             void updateSupportedPortCounters(
-                    _In_ sai_object_id_t portRid);
+                    _In_ sai_object_id_t portRid,
+                    PortCountersSet &supportedPortCounters);
 
             std::vector<sai_port_stat_t> saiCheckSupportedPortDebugCounters(
                     _In_ sai_object_id_t portRid,
@@ -545,7 +546,6 @@ namespace syncd
 
         private: // supported counters
 
-            std::set<sai_port_stat_t> m_supportedPortCounters;
             std::set<sai_ingress_priority_group_stat_t> m_supportedPriorityGroupCounters;
             std::set<sai_queue_stat_t> m_supportedQueueCounters;
             std::set<sai_router_interface_stat_t> m_supportedRifCounters;

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -20,7 +20,6 @@ namespace syncd
     {
         private:
 
-            typedef std::set<sai_port_stat_t> PortCountersSet;
             FlexCounter(const FlexCounter&) = delete;
 
         public:
@@ -235,17 +234,18 @@ namespace syncd
 
         private: // update supported counters
 
+            typedef std::set<sai_port_stat_t> PortCountersSet;
             sai_status_t querySupportedPortCounters(
                     _In_ sai_object_id_t portRid,
-                    PortCountersSet &supportedPortCounters);
+                    _Out_ PortCountersSet &supportedPortCounters);
 
             void getSupportedPortCounters(
                     _In_ sai_object_id_t portRid,
-                    PortCountersSet &supportedPortCounters);
+                    _Out_ PortCountersSet &supportedPortCounters);
 
             void updateSupportedPortCounters(
                     _In_ sai_object_id_t portRid,
-                    PortCountersSet &supportedPortCounters);
+                    _Out_ PortCountersSet &supportedPortCounters);
 
             std::vector<sai_port_stat_t> saiCheckSupportedPortDebugCounters(
                     _In_ sai_object_id_t portRid,

--- a/unittest/syncd/MockableSaiInterface.cpp
+++ b/unittest/syncd/MockableSaiInterface.cpp
@@ -165,7 +165,7 @@ sai_status_t MockableSaiInterface::queryStatsCapability(
         return mock_queryStatsCapability(switch_id, object_type, stats_capability);
     }
 
-    return SAI_STATUS_SUCCESS;
+    return SAI_STATUS_NOT_SUPPORTED;
 }
 
 sai_status_t MockableSaiInterface::getStatsExt(

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -186,3 +186,82 @@ TEST(FlexCounter, addRemoveCounterForMACsecSA)
 
 }
 
+TEST(FlexCounter, addRemoveCounterForPort)
+{
+    std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
+    FlexCounter fc("test", sai, "COUNTERS_DB");
+
+    sai_object_id_t counterVid{100};
+    sai_object_id_t counterRid{100};
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(PORT_COUNTER_ID_LIST, "SAI_PORT_STAT_IF_IN_OCTETS,SAI_PORT_STAT_IF_IN_ERRORS");
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
+    sai->mock_getStats = [](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+        for (uint32_t i = 0; i < number_of_counters; i++)
+        {
+            counters[i] = (i + 1) * 100;
+        }
+        return SAI_STATUS_SUCCESS;
+    };
+
+    fc.addCounter(counterVid, counterRid, values);
+    EXPECT_EQ(fc.isEmpty(), false);
+
+    values.clear();
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    fc.addCounterPlugin(values);
+
+    usleep(1000*1000);
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::RedisPipeline pipeline(&db);
+    swss::Table countersTable(&pipeline, COUNTERS_TABLE, false);
+
+    std::vector<std::string> keys;
+    countersTable.getKeys(keys);
+    EXPECT_EQ(keys.size(), size_t(1));
+    EXPECT_EQ(keys[0], "oid:0x64");
+
+    std::string value;
+    countersTable.hget("oid:0x64", "SAI_PORT_STAT_IF_IN_OCTETS", value);
+    EXPECT_EQ(value, "100");
+    countersTable.hget("oid:0x64", "SAI_PORT_STAT_IF_IN_ERRORS", value);
+    EXPECT_EQ(value, "200");
+
+    fc.removeCounter(counterVid);
+    EXPECT_EQ(fc.isEmpty(), true);
+    countersTable.del("oid:0x64");
+    countersTable.getKeys(keys);
+    ASSERT_TRUE(keys.empty());
+
+    // Test again with queryStatsCapability support
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *capability) {
+        if (capability->count < 2)
+        {
+            capability->count = 2;
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
+        capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_ERRORS;
+        return SAI_STATUS_SUCCESS;
+    };
+
+    values.clear();
+    values.emplace_back(PORT_COUNTER_ID_LIST, "SAI_PORT_STAT_IF_IN_OCTETS,SAI_PORT_STAT_IF_IN_ERRORS");
+    fc.addCounter(counterVid, counterRid, values);
+    EXPECT_EQ(fc.isEmpty(), false);
+
+    usleep(1000*1000);
+    countersTable.hget("oid:0x64", "SAI_PORT_STAT_IF_IN_OCTETS", value);
+    EXPECT_EQ(value, "100");
+    countersTable.hget("oid:0x64", "SAI_PORT_STAT_IF_IN_ERRORS", value);
+    EXPECT_EQ(value, "200");
+
+    fc.removeCounter(counterVid);
+    EXPECT_EQ(fc.isEmpty(), true);
+    countersTable.del("oid:0x64");
+    countersTable.getKeys(keys);
+    ASSERT_TRUE(keys.empty());
+}

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -197,10 +197,21 @@ TEST(FlexCounter, addRemoveCounterForPort)
     values.emplace_back(PORT_COUNTER_ID_LIST, "SAI_PORT_STAT_IF_IN_OCTETS,SAI_PORT_STAT_IF_IN_ERRORS");
 
     test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
-    sai->mock_getStats = [](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+    sai->mock_getStats = [](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *ids, uint64_t *counters) {
         for (uint32_t i = 0; i < number_of_counters; i++)
         {
-            counters[i] = (i + 1) * 100;
+            if (ids[i] == SAI_PORT_STAT_IF_IN_OCTETS)
+            {
+                counters[i] = 100;
+            }
+            else if (ids[i] == SAI_PORT_STAT_IF_IN_ERRORS)
+            {
+                counters[i] = 200;
+            }
+            else
+            {
+                return SAI_STATUS_FAILURE;
+            }
         }
         return SAI_STATUS_SUCCESS;
     };


### PR DESCRIPTION
Fix https://github.com/Azure/sonic-buildimage/issues/10850.

A fact is there might be different port types on asic, then different port stats capabilities. Instead of using a cached supported port counter ID list for all ports, it gets supported port counter list per port.