### PR TITLE
[sairedis] Perform log rotate on request

### DIFF
--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -179,27 +179,20 @@ void Recorder::recordLine(
     {
         m_ofstream << getTimestamp() << "|" << line << std::endl;
     }
-
-    if (m_performLogRotate)
-    {
-        m_performLogRotate = false;
-
-        recordingFileReopen();
-
-        /* double check since reopen could fail */
-
-        if (m_ofstream.is_open())
-        {
-            m_ofstream << getTimestamp() << "|" << "#|logrotate on: " << m_recordingFile << std::endl;
-        }
-    }
 }
 
 void Recorder::requestLogRotate()
 {
     SWSS_LOG_ENTER();
 
-    m_performLogRotate = true;
+    recordingFileReopen();
+
+    /* double check since reopen could fail */
+
+    if (m_ofstream.is_open())
+    {
+        m_ofstream << getTimestamp() << "|" << "#|logrotate on: " << m_recordingFile << std::endl;
+    }
 }
 
 void Recorder::recordingFileReopen()

--- a/unittest/lib/Makefile.am
+++ b/unittest/lib/Makefile.am
@@ -21,6 +21,7 @@ tests_SOURCES = \
 				TestSkipRecordAttrContainer.cpp \
 				TestServerConfig.cpp \
 				TestRedisVidIndexGenerator.cpp \
+				TestRecorder.cpp \
 				TestRedisChannel.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)

--- a/unittest/lib/TestRecorder.cpp
+++ b/unittest/lib/TestRecorder.cpp
@@ -1,0 +1,28 @@
+#include "Recorder.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace sairedis;
+
+TEST(Recorder, requestLogRotate)
+{
+    Recorder rec;
+
+    rec.enableRecording(true);
+
+    rec.recordComment("foo");
+
+    int code = rename("sairedis.rec", "sairedis.rec.1");
+
+    EXPECT_EQ(code, 0);
+
+    EXPECT_NE(access("sairedis.rec", F_OK),0);
+
+    rec.requestLogRotate();
+
+    EXPECT_EQ(access("sairedis.rec", F_OK),0);
+
+    rec.recordComment("bar");
+}


### PR DESCRIPTION
Previously log rotate was performed after request and on first log line
that was recorded which caused delay and issues with syslog logrotate
when sending HUP signal, actual log rotate was not performed and handle
to a sairedis.rec was sill open preventing logrotate from happening.

Because of this change, perform log rotate CAN'T be done in signal handler, it needs to be postponed to main thread.