### PR TITLE
[vslib]: Fixbug in cleanup MACsec device

### DIFF
--- a/unittest/vslib/TestMACsecManager.cpp
+++ b/unittest/vslib/TestMACsecManager.cpp
@@ -1,9 +1,11 @@
 #include "MACsecAttr.h"
 #include "MACsecManager.h"
 
+#include <swss/logger.h>
+
 #include <gtest/gtest.h>
 
-#include <vector>
+#include <set>
 
 using namespace saivs;
 
@@ -47,4 +49,51 @@ TEST(MACsecManager, update_macsec_sa_pn)
     attr.m_authKey = "";
     attr.m_sak = "";
     manager.update_macsec_sa_pn(attr, 2);
+}
+
+class MockMACsecManager_CleanupMACsecDevice : public MACsecManager
+{
+public:
+    mutable std::set<std::string> m_rest_devices;
+protected:
+    virtual bool exec(
+        _In_ const std::string &command,
+        _Out_ std::string &output) const
+    {
+        SWSS_LOG_ENTER();
+
+        if (command == "/sbin/ip macsec show")
+        {
+            output = "\
+2774: macsec0: protect on validate strict sc off sa off encrypt on send_sci on end_station off scb off replay on window 0\n\
+    cipher suite: GCM-AES-128, using ICV length 16\n\
+    TXSC: fe5400409b920001 on SA 0\n\
+2775: macsec1: protect on validate strict sc off sa off encrypt on send_sci on end_station off scb off replay on window 0\n\
+    cipher suite: GCM-AES-128, using ICV length 16\n\
+    TXSC: fe5400409b920001 on SA 0\n\
+2776: macsec2: protect on validate strict sc off sa off encrypt on send_sci on end_station off scb off replay on window 0\n\
+    cipher suite: GCM-AES-128, using ICV length 16\n\
+    TXSC: fe5400409b920001 on SA 0";
+            m_rest_devices.insert("macsec0");
+            m_rest_devices.insert("macsec1");
+            m_rest_devices.insert("macsec2");
+            return true;
+        }
+        else if (command.rfind("/sbin/ip link del ") == 0)
+        {
+            std::string name = command.substr(strlen("/sbin/ip link del "));
+            m_rest_devices.erase(name);
+            return true;
+        }
+        return MACsecManager::exec(command, output);
+    }
+};
+
+TEST(MACsecManager, cleanup_macsec_device)
+{
+    MockMACsecManager_CleanupMACsecDevice manager;
+
+    manager.cleanup_macsec_device();
+
+    EXPECT_EQ(manager.m_rest_devices.size(), 0);
 }

--- a/vslib/MACsecManager.cpp
+++ b/vslib/MACsecManager.cpp
@@ -895,7 +895,7 @@ void MACsecManager::cleanup_macsec_device() const
     //     cipher suite: GCM-AES-128, using ICV length 16
     //     TXSC: fe5400409b920001 on SA 0
     // Use pattern : '^\d+:\s*(\w+):' to extract all MACsec interface names
-    const std::regex pattern("^\\d+:\\s*(\\w+):");
+    const std::regex pattern("\\d+:\\s*(\\w+):");
     std::smatch matches;
     std::string::const_iterator searchPos(macsecInfos.cbegin());
 

--- a/vslib/MACsecManager.cpp
+++ b/vslib/MACsecManager.cpp
@@ -21,14 +21,14 @@ MACsecManager::MACsecManager()
 {
     SWSS_LOG_ENTER();
 
-    cleanup_macsec_device();
+    // empty
 }
 
 MACsecManager::~MACsecManager()
 {
     SWSS_LOG_ENTER();
 
-    cleanup_macsec_device();
+    // empty
 }
 
 bool MACsecManager::create_macsec_port(

--- a/vslib/MACsecManager.h
+++ b/vslib/MACsecManager.h
@@ -44,6 +44,8 @@ namespace saivs
                     _In_ const MACsecAttr &attr,
                     _Out_ sai_uint64_t &pn) const;
 
+            void cleanup_macsec_device() const;
+
         protected:
 
             bool create_macsec_egress_sc(
@@ -121,8 +123,6 @@ namespace saivs
                     _In_ const std::string &macsecDevice,
                     _In_ sai_int32_t direction,
                     _In_ const std::string &sci) const;
-
-            void cleanup_macsec_device() const;
 
             std::string shellquote(
                     _In_ const std::string &str) const;

--- a/vslib/MACsecManager.h
+++ b/vslib/MACsecManager.h
@@ -44,7 +44,7 @@ namespace saivs
                     _In_ const MACsecAttr &attr,
                     _Out_ sai_uint64_t &pn) const;
 
-        private:
+        protected:
 
             bool create_macsec_egress_sc(
                     _In_ const MACsecAttr &attr);
@@ -127,7 +127,7 @@ namespace saivs
             std::string shellquote(
                     _In_ const std::string &str) const;
 
-            bool exec(
+            virtual bool exec(
                     _In_ const std::string &command,
                     _Out_ std::string &output) const;
 

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -21,7 +21,7 @@ SwitchStateBase::SwitchStateBase(
 {
     SWSS_LOG_ENTER();
 
-    // empty
+    m_macsecManager.cleanup_macsec_device();
 }
 
 SwitchStateBase::SwitchStateBase(
@@ -33,6 +33,8 @@ SwitchStateBase::SwitchStateBase(
     m_realObjectIdManager(manager)
 {
     SWSS_LOG_ENTER();
+
+    m_macsecManager.cleanup_macsec_device();
 
     if (warmBootState)
     {
@@ -57,7 +59,7 @@ SwitchStateBase::~SwitchStateBase()
 {
     SWSS_LOG_ENTER();
 
-    // empty
+    m_macsecManager.cleanup_macsec_device();
 }
 
 sai_status_t SwitchStateBase::create(


### PR DESCRIPTION
The previous regex can only match one device so that the original MACsec devices cannot been cleanup by config reload.