### PR TITLE
[syncd] Use hash as queue for fdb notifications

### DIFF
--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -27,6 +27,7 @@ libSyncd_a_SOURCES = \
 				NotificationHandler.cpp \
 				NotificationProcessor.cpp \
 				NotificationQueue.cpp \
+				NotificationQueueHash.cpp \
 				PortMap.cpp \
 				PortMapParser.cpp \
 				RedisClient.cpp \

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -5,6 +5,7 @@ extern "C"{
 }
 
 #include "NotificationQueue.h"
+#include "NotificationQueueHash.h"
 #include "NotificationProcessor.h"
 
 #include "swss/table.h"
@@ -71,11 +72,18 @@ namespace syncd
                     _In_ const std::string& op,
                     _In_ const std::string& data);
 
+            void enqueueNotificationHash(
+                    _In_ const std::string& key,
+                    _In_ const std::string& op,
+                    _In_ const std::string& data);
+
         private:
 
             sai_switch_notifications_t m_switchNotifications;
 
             std::shared_ptr<NotificationQueue> m_notificationQueue;
+
+            std::shared_ptr<NotificationQueueHash> m_notificationQueueHash;
 
             std::shared_ptr<NotificationProcessor> m_processor;
     };

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -27,6 +27,8 @@ NotificationProcessor::NotificationProcessor(
     m_runThread = false;
 
     m_notificationQueue = std::make_shared<NotificationQueue>();
+
+    m_notificationQueueHash = std::make_shared<NotificationQueueHash>();
 }
 
 NotificationProcessor::~NotificationProcessor()
@@ -620,6 +622,11 @@ void NotificationProcessor::ntf_process_function()
         {
             processNotification(item);
         }
+
+        while (m_notificationQueueHash->tryDequeue(item))
+        {
+            processNotification(item);
+        }
     }
 }
 
@@ -660,4 +667,11 @@ std::shared_ptr<NotificationQueue> NotificationProcessor::getQueue() const
     SWSS_LOG_ENTER();
 
     return m_notificationQueue;
+}
+
+std::shared_ptr<NotificationQueueHash> NotificationProcessor::getQueueHash() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_notificationQueueHash;
 }

--- a/syncd/NotificationProcessor.h
+++ b/syncd/NotificationProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "NotificationQueue.h"
+#include "NotificationQueueHash.h"
 #include "VirtualOidTranslator.h"
 #include "RedisClient.h"
 #include "NotificationProducerBase.h"
@@ -28,6 +29,8 @@ namespace syncd
         public:
 
             std::shared_ptr<NotificationQueue> getQueue() const;
+
+            std::shared_ptr<NotificationQueueHash> getQueueHash() const;
 
             void signal();
 
@@ -123,6 +126,8 @@ namespace syncd
         private:
 
             std::shared_ptr<NotificationQueue> m_notificationQueue;
+
+            std::shared_ptr<NotificationQueueHash> m_notificationQueueHash;
 
             std::shared_ptr<std::thread> m_ntf_process_thread;
 

--- a/syncd/NotificationQueueHash.cpp
+++ b/syncd/NotificationQueueHash.cpp
@@ -1,0 +1,78 @@
+#include "NotificationQueueHash.h"
+#include "sairediscommon.h"
+
+using namespace syncd;
+
+#define NOTIFICATION_QUEUE_DROP_COUNT_INDICATOR (1000)
+#define MUTEX std::lock_guard<std::mutex> _lock(m_mutex);
+
+NotificationQueueHash::NotificationQueueHash():
+    m_dropCount(0)
+{
+    SWSS_LOG_ENTER();
+
+    // empty;
+}
+
+NotificationQueueHash::~NotificationQueueHash()
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+bool NotificationQueueHash::enqueue(
+        _In_ const std::string& key,
+        _In_ const swss::KeyOpFieldsValuesTuple& item)
+{
+    MUTEX;
+
+    SWSS_LOG_ENTER();
+
+    // if key is already in the hash, then we will override it previous content
+    // which means we are dropping that item
+
+    if (m_queueHash.find(key) != m_queueHash.end())
+    {
+        m_dropCount++;
+
+        if (!(m_dropCount % NOTIFICATION_QUEUE_DROP_COUNT_INDICATOR))
+        {
+            SWSS_LOG_NOTICE("Dropped total of %zu notifications", m_dropCount);
+        }
+    }
+
+    m_queueHash[key] = item;
+
+    return true;
+}
+
+bool NotificationQueueHash::tryDequeue(
+        _Out_ swss::KeyOpFieldsValuesTuple& item)
+{
+    MUTEX;
+
+    SWSS_LOG_ENTER();
+
+    if (m_queueHash.empty())
+    {
+        return false;
+    }
+
+    auto it = m_queueHash.begin();
+
+    item = it->second;
+
+    m_queueHash.erase(it);
+
+    return true;
+}
+
+size_t NotificationQueueHash::getQueueSize()
+{
+    MUTEX;
+
+    SWSS_LOG_ENTER();
+
+    return m_queueHash.size();
+}

--- a/syncd/NotificationQueueHash.h
+++ b/syncd/NotificationQueueHash.h
@@ -1,0 +1,41 @@
+#pragma once
+
+extern "C" {
+#include <saimetadata.h>
+}
+
+#include "swss/table.h"
+
+#include <mutex>
+#include <unordered_map>
+
+namespace syncd
+{
+    class NotificationQueueHash
+    {
+        public:
+
+            NotificationQueueHash();
+
+            virtual ~NotificationQueueHash();
+
+        public:
+
+            bool enqueue(
+                    _In_ const std::string& key,
+                    _In_ const swss::KeyOpFieldsValuesTuple& msg);
+
+            bool tryDequeue(
+                    _Out_ swss::KeyOpFieldsValuesTuple& msg);
+
+            size_t getQueueSize();
+
+        private:
+
+            std::mutex m_mutex;
+
+            std::unordered_map<std::string, swss::KeyOpFieldsValuesTuple> m_queueHash;
+
+            size_t m_dropCount;
+    };
+}

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -10,6 +10,8 @@ tests_SOURCES = main.cpp \
                 MockHelper.cpp \
 				TestCommandLineOptions.cpp \
 				TestFlexCounter.cpp \
+				TestNotificationHandler.cpp \
+				TestNotificationQueueHash.cpp
 				TestNotificationQueue.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)

--- a/unittest/syncd/MockHelper.cpp
+++ b/unittest/syncd/MockHelper.cpp
@@ -10,11 +10,3 @@ namespace test_syncd {
         mock_objectTypeQuery_result = mock_result;
     }
 }
-
-namespace syncd {
-    sai_object_type_t VidManager::objectTypeQuery(_In_ sai_object_id_t objectId)
-    {
-        SWSS_LOG_ENTER();
-        return test_syncd::mock_objectTypeQuery_result;
-    }
-}

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -13,8 +13,8 @@ TEST(FlexCounter, addRemoveCounterForFlowCounter)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t counterVid{100};
-    sai_object_id_t counterRid{100};
+    sai_object_id_t counterVid{0x54000000000000};
+    sai_object_id_t counterRid{0x54000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
 
@@ -46,12 +46,12 @@ TEST(FlexCounter, addRemoveCounterForFlowCounter)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x64");
+    EXPECT_EQ(keys[0], "oid:0x54000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x64", "SAI_COUNTER_STAT_PACKETS", value);
+    countersTable.hget("oid:0x54000000000000", "SAI_COUNTER_STAT_PACKETS", value);
     EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x64", "SAI_COUNTER_STAT_BYTES", value);
+    countersTable.hget("oid:0x54000000000000", "SAI_COUNTER_STAT_BYTES", value);
     EXPECT_EQ(value, "200");
 
     fc.removeCounter(counterVid);
@@ -81,8 +81,8 @@ TEST(FlexCounter, addRemoveCounterForMACsecFlow)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t macsecFlowVid{101};
-    sai_object_id_t macsecFlowRid{101};
+    sai_object_id_t macsecFlowVid{0x5a000000000000};
+    sai_object_id_t macsecFlowRid{0x5a000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(MACSEC_FLOW_COUNTER_ID_LIST, "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS,SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED");
 
@@ -114,17 +114,17 @@ TEST(FlexCounter, addRemoveCounterForMACsecFlow)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x65");
+    EXPECT_EQ(keys[0], "oid:0x5a000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x65", "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", value);
+    countersTable.hget("oid:0x5a000000000000", "SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", value);
     //EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x65", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED", value);
+    countersTable.hget("oid:0x5a000000000000", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED", value);
     //EXPECT_EQ(value, "200");
 
     fc.removeCounter(macsecFlowVid);
     EXPECT_EQ(fc.isEmpty(), true);
-    countersTable.del("oid:0x65");
+    countersTable.del("oid:0x5a000000000000");
     countersTable.getKeys(keys);
 
     ASSERT_TRUE(keys.empty());
@@ -136,8 +136,8 @@ TEST(FlexCounter, addRemoveCounterForMACsecSA)
     std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
-    sai_object_id_t macsecSAVid{102};
-    sai_object_id_t macsecSARid{102};
+    sai_object_id_t macsecSAVid{0x5c000000000000};
+    sai_object_id_t macsecSARid{0x5c000000000000};
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(MACSEC_SA_COUNTER_ID_LIST, "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED,SAI_MACSEC_SA_STAT_OCTETS_PROTECTED");
 
@@ -169,17 +169,17 @@ TEST(FlexCounter, addRemoveCounterForMACsecSA)
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
     EXPECT_EQ(keys.size(), size_t(1));
-    EXPECT_EQ(keys[0], "oid:0x66");
+    EXPECT_EQ(keys[0], "oid:0x5c000000000000");
 
     std::string value;
-    countersTable.hget("oid:0x66", "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", value);
+    countersTable.hget("oid:0x5c000000000000", "SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", value);
     //EXPECT_EQ(value, "100");
-    countersTable.hget("oid:0x66", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED", value);
+    countersTable.hget("oid:0x5c000000000000", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED", value);
     //EXPECT_EQ(value, "200");
 
     fc.removeCounter(macsecSAVid);
     EXPECT_EQ(fc.isEmpty(), true);
-    countersTable.del("oid:0x66");
+    countersTable.del("oid:0x5c000000000000");
     countersTable.getKeys(keys);
 
     ASSERT_TRUE(keys.empty());

--- a/unittest/syncd/TestNotificationHandler.cpp
+++ b/unittest/syncd/TestNotificationHandler.cpp
@@ -1,0 +1,63 @@
+#include "NotificationHandler.h"
+#include "SwitchNotifications.h"
+#include "RedisNotificationProducer.h"
+#include "RedisClient.h"
+
+#include "swss/dbconnector.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace syncd;
+using namespace std::placeholders;
+
+static std::shared_ptr<NotificationProcessor> g_processor;
+
+static void syncProcessNotification(
+        _In_ const swss::KeyOpFieldsValuesTuple& item)
+{
+    SWSS_LOG_ENTER();
+
+    g_processor->syncProcessNotification(item);
+}
+
+TEST(NotificationHandler, onFdbEvent)
+{
+    sai_fdb_event_notification_data_t data;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+    attr.value.oid = 0x3a00000001;
+
+    data.fdb_entry.switch_id = 0x2100000000;
+    data.fdb_entry.bv_id = 0x2600000000;
+    data.fdb_entry.mac_address[0] = 0x00;
+    data.fdb_entry.mac_address[1] = 0x22;
+    data.fdb_entry.mac_address[2] = 0x48;
+    data.fdb_entry.mac_address[3] = 0x58;
+    data.fdb_entry.mac_address[4] = 0xD1;
+    data.fdb_entry.mac_address[5] = 0x29;
+
+    data.event_type = SAI_FDB_EVENT_LEARNED;
+
+    data.attr_count = 1;
+    data.attr = &attr;
+
+    auto dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    auto client = std::make_shared<RedisClient>(dbAsic);
+    auto notifications = std::make_shared<RedisNotificationProducer>("ASIC_DB");
+    g_processor = std::make_shared<NotificationProcessor>(notifications, client, std::bind(syncProcessNotification, _1));
+    auto handler = std::make_shared<NotificationHandler>(g_processor);
+
+    SwitchNotifications sn;
+
+    sn.onFdbEvent = std::bind(&NotificationHandler::onFdbEvent, handler.get(), _1, _2);
+
+    handler->setSwitchNotifications(sn.getSwitchNotifications());
+
+    handler->onFdbEvent(1, &data);
+
+    sleep(1);
+}

--- a/unittest/syncd/TestNotificationQueueHash.cpp
+++ b/unittest/syncd/TestNotificationQueueHash.cpp
@@ -1,0 +1,35 @@
+#include "NotificationQueueHash.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace syncd;
+
+TEST(NotificationQueueHash, enqueue)
+{
+    NotificationQueueHash hash;
+
+    swss::KeyOpFieldsValuesTuple kco;
+
+    EXPECT_EQ(hash.enqueue("foo", kco), true);
+    EXPECT_EQ(hash.enqueue("foo", kco), true);
+
+    for (int i = 0; i < 2000; i++)
+    {
+        EXPECT_EQ(hash.enqueue("foo", kco), true);
+    }
+}
+
+TEST(NotificationQueueHash, tryDequeue)
+{
+    NotificationQueueHash hash;
+
+    swss::KeyOpFieldsValuesTuple kco;
+
+    EXPECT_EQ(hash.tryDequeue(kco), false);
+
+    EXPECT_EQ(hash.enqueue("foo", kco), true);
+
+    EXPECT_EQ(hash.tryDequeue(kco), true);
+}


### PR DESCRIPTION
This will drop multiple fdb notifications in case of flood but will
preserve last one