### PR TITLE
No sai api version check if vendor sai does not support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,7 @@ AM_COND_IF([SYNCD], [
 AM_COND_IF([SAIVS], [], [
 SAVED_FLAGS="$CXXFLAGS"
 CXXFLAGS="-lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
+AC_CHECK_FUNC(sai_query_api_version, [
 AC_MSG_CHECKING([SAI headers API version and library version check])
 AC_TRY_RUN([
 extern "C" {
@@ -201,7 +202,7 @@ int main() {
 }],
 [AC_MSG_RESULT(ok)],
 [AC_MSG_RESULT(failed)
-AC_MSG_ERROR("SAI headers API version and library version mismatch")])
+AC_MSG_ERROR("SAI headers API version and library version mismatch")])])
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 


### PR DESCRIPTION
Fix #1062 

Test log:

    dpkg --list | grep libsaibcm
    ii  libsaibcm                              7.1.0.0-1                               amd64        Switch Abstraction Interface sdk based on Broadcom SAI
    ii  libsaibcm-dev                          7.1.0.0-1                               amd64        development files for Switch Abstraction Interface sdk

    checking for main in -lsai... yes
    configure: libsai found
    checking for swig3.0... /usr/bin/swig3.0
    checking whether CXX supports -Wcast-align=strict... yes
    checking whether CXX supports -Wno-cast-function-type... yes
    checking for sai_query_api_version... no

Signed-off-by: Guohan Lu <lguohan@gmail.com>