### PR TITLE
[syncd] Support ACL action data object in remove dep tree

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -2089,7 +2089,8 @@ void ComparisonLogic::removeCurrentObjectDependencyTree(
                     continue;
                 }
 
-                if (revgraph->attrmetadata->attrvaluetype != SAI_ATTR_VALUE_TYPE_OBJECT_ID)
+                if (revgraph->attrmetadata->attrvaluetype != SAI_ATTR_VALUE_TYPE_OBJECT_ID &&
+                        revgraph->attrmetadata->attrvaluetype != SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID)
                 {
                     // currently we only support reference on OID, not list
                     SWSS_LOG_THROW("attr value type %d, not supported yet, FIXME",


### PR DESCRIPTION
This is required if some of the attributes on ACL action data
object are OID's and we need to catch their refrence when
removing object and it's dependency tree.