### PR TITLE
Debug test_watchdog_timer_clock_rollback failure

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -135,6 +135,7 @@ jobs:
       displayName: "Install gcovr 5.0 with recursive fix"
     - script: |
         set -ex
+        sudo setcap "cap_sys_time=eip" syncd/.libs/tests
         make check
         gcovr --version
         find SAI/meta -name "*.gc*" | xargs rm -vf

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -86,6 +86,7 @@ syncd_request_shutdown_LDADD = libSyncdRequestShutdown.a $(top_srcdir)/lib/libSa
 
 tests_SOURCES = tests.cpp
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
+tests_LDFLAGS = -Wl,-rpath,$(top_srcdir)/lib/.libs -Wl,-rpath,$(top_srcdir)/meta/.libs
 tests_LDADD = libSyncd.a -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/lib/.libs -lsairedis \
 			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
 

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -820,12 +820,6 @@ void test_watchdog_timer_clock_rollback()
 {
     SWSS_LOG_ENTER();
 
-    if (getuid() != 0)
-    {
-        SWSS_LOG_WARN("this test requires root for set time");
-        return;
-    }
-
     const int64_t WARN_TIMESPAN_USEC = 30 * 1000000;
     const uint8_t ROLLBACK_TIME_SEC = 5;
     const uint8_t LONG_RUNNING_API_TIME_SEC = 3;


### PR DESCRIPTION
https://dev.azure.com/mssonic/build/_build/results?buildId=110429&view=logs&j=61b7eb0d-78fa-5af5-6df0-b6f82d3891a8&t=6a34388b-e109-5be6-7b42-af0762c91bba

Making check in syncd
make[2]: Entering directory '/__w/1/s/syncd'
make  check-TESTS
make[3]: Entering directory '/__w/1/s/syncd'
tests: tests.cpp:843: void test_watchdog_timer_clock_rollback(): Assertion `settimeofday(&currentTime, NULL) == 0' failed.
/bin/bash: line 5: 13004 Aborted                 (core dumped) ${dir}$tst
FAIL: tests
