### PR TITLE
[pipeline] Add option --privileged for running slave docker

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -56,6 +56,7 @@ jobs:
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
+    options:  "--privileged"
 
   steps:
   - checkout: self


### PR DESCRIPTION
In azp run, the following failure always happens at the stage of `make check` of building syncd. 

```
Making check in syncd
make[2]: Entering directory '/__w/1/s/syncd'
make check-TESTS
make[3]: Entering directory '/__w/1/s/syncd'
tests: tests.cpp:843: void test_watchdog_timer_clock_rollback(): Assertion `settimeofday(&currentTime, NULL) == 0' failed.
/bin/bash: line 5: 13004 Aborted (core dumped) ${dir}$tst
FAIL: tests
```
The execution of `settimeofday(&currentTime, NULL)` fails in slave docker with errno **EPERM**, because CAP_SYS_TIME capability is dropped in docker. Using option `--privileged` gives docker extended privileges for its success.

This failure has existed for a long time in azp build and is not exposed till https://github.com/Azure/sonic-sairedis/pull/1050.


