### PR TITLE
[pipeline] Set CAP_SYS_TIME for settimeofday ok in syncd test

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -56,6 +56,7 @@ jobs:
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
+    options:  "--privileged"
 
   steps:
   - checkout: self

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -135,6 +135,8 @@ jobs:
       displayName: "Install gcovr 5.0 with recursive fix"
     - script: |
         set -ex
+        # Add SYS_TIME capability for settimeofday ok in syncd test
+        sudo setcap "cap_sys_time=eip" syncd/.libs/tests
         make check
         gcovr --version
         find SAI/meta -name "*.gc*" | xargs rm -vf

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -86,6 +86,7 @@ syncd_request_shutdown_LDADD = libSyncdRequestShutdown.a $(top_srcdir)/lib/libSa
 
 tests_SOURCES = tests.cpp
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
+tests_LDFLAGS = -Wl,-rpath,$(top_srcdir)/lib/.libs -Wl,-rpath,$(top_srcdir)/meta/.libs
 tests_LDADD = libSyncd.a -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/lib/.libs -lsairedis \
 			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
 

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -820,12 +820,6 @@ void test_watchdog_timer_clock_rollback()
 {
     SWSS_LOG_ENTER();
 
-    if (getuid() != 0)
-    {
-        SWSS_LOG_WARN("this test requires root for set time");
-        return;
-    }
-
     const int64_t WARN_TIMESPAN_USEC = 30 * 1000000;
     const uint8_t ROLLBACK_TIME_SEC = 5;
     const uint8_t LONG_RUNNING_API_TIME_SEC = 3;


### PR DESCRIPTION
The fix https://github.com/Azure/sonic-sairedis/pull/1067 is not enough. If docker user is non-root, set capability CAP_SYS_TIME for settimeofday success in syncd test, then `test_watchdog_timer_clock_rollback` can be run.