### PR TITLE
Fix: missing sonic-db-cli in docker-sonic-vs image

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -9,6 +9,7 @@ RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python3-swsscommon_1.0.0_amd64.deb
+RUN dpkg -i /debs/sonic-db-cli_1.0.0_amd64.deb
 
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb


### PR DESCRIPTION
What I did
Fix: missing sonic-db-cli in docker-sonic-vs image

Why I did it

How I verified it

Details if related