### PR TITLE
Add SAI_OBJECT_TYPE_TUNNEL object to break-before-make list

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -175,6 +175,8 @@ config_syncd_bcm()
     fi
 
     echo "SAI_OBJECT_TYPE_ACL_TABLE" >> /tmp/break_before_make_objects
+    echo "SAI_OBJECT_TYPE_TUNNEL" >> /tmp/break_before_make_objects
+    echo "SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY" >> /tmp/break_before_make_objects
     CMD_ARGS+=" -b /tmp/break_before_make_objects"
 
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -176,7 +176,6 @@ config_syncd_bcm()
 
     echo "SAI_OBJECT_TYPE_ACL_TABLE" >> /tmp/break_before_make_objects
     echo "SAI_OBJECT_TYPE_TUNNEL" >> /tmp/break_before_make_objects
-    echo "SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY" >> /tmp/break_before_make_objects
     CMD_ARGS+=" -b /tmp/break_before_make_objects"
 
     [ -e /dev/linux-bcm-knet ] || mknod /dev/linux-bcm-knet c 122 0


### PR DESCRIPTION
`SAI_OBJECT_TYPE_TUNNEL` has fewer attributes in 201811 than in 202012. These new attributes are CREATE only, and can't be added using just SET oper. Hence old object needs to be removed, and new object needs to be added.

Adding `SAI_OBJECT_TYPE_TUNNEL` to break before make to avoid creating a new object before removing existing ones.
Moreover existing sequence (make before break) causes SAI errors in removing VXLAN tunnel (as part of CPA teardown).

In 201811:
```
SAI_OBJECT_TYPE_TUNNEL oid:0x2a000000001781 
    SAI_TUNNEL_ATTR_DECAP_MAPPERS      : 1:oid:0x29000000001780
    SAI_TUNNEL_ATTR_TYPE               : SAI_TUNNEL_TYPE_VXLAN
    SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE : oid:0x600000000144e
```

In 202012:
```
SAI_OBJECT_TYPE_TUNNEL oid:0x2a000000001773 
    SAI_TUNNEL_ATTR_DECAP_MAPPERS      : 2:oid:0x2900000000176f,oid:0x29000000001771
    SAI_TUNNEL_ATTR_ENCAP_MAPPERS      : 2:oid:0x29000000001770,oid:0x29000000001772
    SAI_TUNNEL_ATTR_ENCAP_SRC_IP       : 10.1.0.32
    SAI_TUNNEL_ATTR_PEER_MODE          : SAI_TUNNEL_PEER_MODE_P2MP
    SAI_TUNNEL_ATTR_TYPE               : SAI_TUNNEL_TYPE_VXLAN
    SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE : oid:0x60000000014cb
```


Fixed issue being hit in CPA teardown without break before make:
```
Jun 29 18:17:39.183398 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Tearing down control plane assistant ...
Jun 29 18:17:39.339744 str-7260cx3-acs-1 NOTICE swss#orchagent: :- remove: Successfully deleted ACL rule rule_arp in table EVERFLOW
Jun 29 18:17:39.341511 str-7260cx3-acs-1 WARNING kernel: [  150.748434] linux-bcm-knet (2656): Unsupported command (type=1, opcode=52)
Jun 29 18:17:39.341658 str-7260cx3-acs-1 NOTICE swss#orchagent: :- remove: Successfully deleted ACL rule rule_nd in table EVERFLOW
Jun 29 18:17:42.338497 str-7260cx3-acs-1 NOTICE swss#orchagent: :- detach: Detached next hop observer for destination IP 192.168.8.1
Jun 29 18:17:42.340974 str-7260cx3-acs-1 NOTICE swss#orchagent: :- deactivateSession: Deactivated mirror session neighbor_advertiser
Jun 29 18:17:42.341508 str-7260cx3-acs-1 NOTICE swss#orchagent: :- deleteEntry: Removed mirror session neighbor_advertiser
Jun 29 18:17:42.345193 str-7260cx3-acs-1 ERR syncd#syncd: [none] SAI_API_TUNNEL:_brcm_sai_vxlan_disable:1231 tunnel_idx not valid in tunnel map entry, delete tunnel after deleting tunnel map entry (tunnel map index = 1)
Jun 29 18:17:42.346170 str-7260cx3-acs-1 ERR swss#orchagent: :- remove: remove status: SAI_STATUS_FAILURE
Jun 29 18:17:42.347417 str-7260cx3-acs-1 ERR swss#orchagent: :- delOperation: Error removing tunnel map neighbor_advertiser:map_1: Can't delete a tunnel map entry object
Jun 29 18:17:42.348605 str-7260cx3-acs-1 ERR swss#orchagent: :- remove: remove status: SAI_STATUS_FAILURE
Jun 29 18:17:42.348605 str-7260cx3-acs-1 ERR swss#orchagent: :- delOperation: Error removing tunnel map neighbor_advertiser:map_1: Can't delete a tunnel map entry object
Jun 29 18:17:42.349575 str-7260cx3-acs-1 ERR syncd#syncd: [none] SAI_API_TUNNEL:brcm_sai_remove_tunnel_map_entry:2773 Can't delete brcm vxlan tunnel
```