### PR TITLE
[BFN] Provide unified approach to select P4 profile based on chip family

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -247,12 +247,24 @@ config_syncd_barefoot()
         echo "SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin" >> $PROFILE_FILE
     fi
     CMD_ARGS+=" -l -p $PROFILE_FILE"
-
-    # Check and load SDE profile
+    # Check if SDE profile configured
     P4_PROFILE=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["p4_profile"]')
     if [[ -n "$P4_PROFILE" ]]; then
         if [[ ( -d /opt/bfn/install_${P4_PROFILE} ) && ( -L /opt/bfn/install || ! -e /opt/bfn/install ) ]]; then
             ln -srfn /opt/bfn/install_${P4_PROFILE} /opt/bfn/install
+        fi
+    else
+        CHIP_FAMILY_INFO="$(cat $HWSKU_DIR/switch-tna-sai.conf | grep chip_family | awk -F : '{print $2}' | cut -d '"'  -f 2)"
+        CHIP_FAMILY=${CHIP_FAMILY_INFO,,}
+        [[ "$CHIP_FAMILY" == "tofino" ]] && P4_PTYPE="x" || P4_PTYPE="y"
+        # Check if the current profile fits the ASIC family
+        PROFILE_DEFAULT=$(readlink /opt/bfn/install)
+        if [[ "$PROFILE_DEFAULT" != "install_$P4_PTYPE"*"_profile" &&  $PROFILE_DEFAULT != *"_$CHIP_FAMILY"  ]]; then
+            # Find suitable profile
+            PROFILE=$(ls -d /opt/bfn/install_$P4_PTYPE*_profile -d  /opt/bfn/install_*_$CHIP_FAMILY 2> /dev/null | head -1)
+            if [[ ! -z $PROFILE  ]]; then
+                ln -srfn $PROFILE /opt/bfn/install
+            fi
         fi
     fi
     export PYTHONHOME=/opt/bfn/install/

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -247,7 +247,7 @@ config_syncd_barefoot()
         echo "SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin" >> $PROFILE_FILE
     fi
     CMD_ARGS+=" -l -p $PROFILE_FILE"
-    # Check if SDE profile configured
+    # Check if SDE profile is configured
     P4_PROFILE=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["p4_profile"]')
     if [[ -n "$P4_PROFILE" ]]; then
         if [[ ( -d /opt/bfn/install_${P4_PROFILE} ) && ( -L /opt/bfn/install || ! -e /opt/bfn/install ) ]]; then
@@ -259,7 +259,7 @@ config_syncd_barefoot()
         [[ "$CHIP_FAMILY" == "tofino" ]] && P4_PTYPE="x" || P4_PTYPE="y"
         # Check if the current profile fits the ASIC family
         PROFILE_DEFAULT=$(readlink /opt/bfn/install)
-        if [[ "$PROFILE_DEFAULT" != "install_$P4_PTYPE"*"_profile" &&  $PROFILE_DEFAULT != *"_$CHIP_FAMILY"  ]]; then
+        if [[ "$PROFILE_DEFAULT" != "install_$P4_PTYPE"*"_profile" && "$PROFILE_DEFAULT" != *"_$CHIP_FAMILY"  ]]; then
             # Find suitable profile
             PROFILE=$(ls -d /opt/bfn/install_$P4_PTYPE*_profile -d  /opt/bfn/install_*_$CHIP_FAMILY 2> /dev/null | head -1)
             if [[ ! -z $PROFILE  ]]; then


### PR DESCRIPTION
Currently, we do not have an option to select a default profile for each chip. One default profile per package only.
We cannot select a chip suitable profile on SDK package installation because we must detect the chip type first.

However, we have a logic in SONiC which selects suitable profile on system boot, if not selected by the user:
https://github.com/Azure/sonic-buildimage/blob/master/device/barefoot/x86_64-accton_as9516_32d-r0/syncd.conf

This is SONiC generic way to do some platform specific hooks on syncd start:
https://github.com/Azure/sonic-sairedis/blob/bc7ccc2d5c2ddad53ebd696f81ff3d45aacbf438/syncd/scripts/syncd_init_common.sh#L328

Probably it's better to move this logic here https://github.com/Azure/sonic-sairedis/blob/26094f8a614db7ac97b91516a6946402c8a81370/syncd/scripts/syncd_init_common.sh#L240

and use “chip_family” from switch-tna-sai.conf to do default p4 profile selection from one place – syncd_init_common.sh

https://github.com/Azure/sonic-buildimage/blob/e4e3adcbc2b47174e2ccfb307f6258ba3cd26b04/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/switch-tna-sai.conf#L4
